### PR TITLE
client: fix APP_URL usage

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "client",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/apps/client/src/features/page/components/header/page-header-menu.tsx
+++ b/apps/client/src/features/page/components/header/page-header-menu.tsx
@@ -19,7 +19,6 @@ import { getAppUrl } from "@/lib/config.ts";
 import { extractPageSlugId } from "@/lib";
 import { treeApiAtom } from "@/features/page/tree/atoms/tree-api-atom.ts";
 import { useDeletePageModal } from "@/features/page/hooks/use-delete-page-modal.tsx";
-import { boolean } from "zod";
 
 interface PageHeaderMenuProps {
   readOnly?: boolean;

--- a/apps/client/src/lib/config.ts
+++ b/apps/client/src/lib/config.ts
@@ -7,13 +7,11 @@ declare global {
 export function getAppUrl(): string {
   let appUrl = window.CONFIG?.APP_URL || process.env.APP_URL;
 
-  if (!appUrl) {
-    appUrl = import.meta.env.DEV
-      ? "http://localhost:3000"
-      : window.location.protocol + "//" + window.location.host;
+  if (import.meta.env.DEV) {
+    return appUrl || "http://localhost:3000";
   }
 
-  return appUrl;
+  return `${window.location.protocol}//${window.location.host}`;
 }
 
 export function getBackendUrl(): string {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "author": "",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docmost",
   "homepage": "https://docmost.com",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "build": "nx run-many -t build",


### PR DESCRIPTION
This PR fixes the `APP_URL` usage on the frontend. The `APP_URL` is useful for building email links.
With this update, the frontend now relies on `window.location.host` when not in VITE dev mode. 

Fixes https://github.com/docmost/docmost/issues/28 and the issue mentioned on [HN](https://news.ycombinator.com/item?id=40834594).
