### PR TITLE
Add health check and development script

### DIFF
--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -11,6 +11,7 @@ import { MailModule } from './integrations/mail/mail.module';
 import { QueueModule } from './integrations/queue/queue.module';
 import { StaticModule } from './integrations/static/static.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
+import { HealthModule } from './integrations/health/health.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
     WsModule,
     QueueModule,
     StaticModule,
+    HealthModule,
     StorageModule.forRootAsync({
       imports: [EnvironmentModule],
     }),

--- a/apps/server/src/integrations/health/health.controller.ts
+++ b/apps/server/src/integrations/health/health.controller.ts
@@ -1,0 +1,26 @@
+import { KyselyDB } from '@docmost/db/types/kysely.types';
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  InternalServerErrorException,
+  Post,
+} from '@nestjs/common';
+import { sql } from 'kysely';
+import { InjectKysely } from 'nestjs-kysely';
+
+@Controller()
+export class HealthController {
+  constructor(@InjectKysely() private readonly db: KyselyDB) {}
+
+  @Get('health')
+  @HttpCode(HttpStatus.OK)
+  async health() {
+    try {
+      await sql`SELECT 1=1`.execute(this.db);
+    } catch (error) {
+      throw new InternalServerErrorException('Health check failed');
+    }
+  }
+}

--- a/apps/server/src/integrations/health/health.module.ts
+++ b/apps/server/src/integrations/health/health.module.ts
@@ -1,0 +1,8 @@
+import { Global, Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+
+@Global()
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "client:dev": "nx run client:dev",
     "server:dev": "nx run server:start:dev",
     "server:start": "nx run server:start:prod",
-    "email:dev": "nx run @docmost/transactional:dev"
+    "email:dev": "nx run @docmost/transactional:dev",
+    "dev": "pnpm concurrently -n \"frontend,backend\" -c \"cyan,green\" \"pnpm run client:dev\" \"pnpm run server:dev\""
   },
   "dependencies": {
     "@docmost/editor-ext": "workspace:*",
@@ -66,6 +67,7 @@
     "@nx/js": "19.3.2",
     "@types/uuid": "^10.0.0",
     "nx": "19.3.2",
+    "concurrently": "^8.2.2",
     "tsx": "^4.15.7"
   },
   "workspaces": {


### PR DESCRIPTION
Adds a simple health check endpoint that verifies the connection to the database. 

This also contains a development server script I personally find helpful, but am happy to remove if you'd prefer. 

Closes #49 