### PR TITLE
Remove explicit credentials configuration for S3 client

### DIFF
--- a/apps/server/src/integrations/environment/environment.service.ts
+++ b/apps/server/src/integrations/environment/environment.service.ts
@@ -43,14 +43,6 @@ export class EnvironmentService {
     return this.configService.get<string>('STORAGE_DRIVER', 'local');
   }
 
-  getAwsS3AccessKeyId(): string {
-    return this.configService.get<string>('AWS_S3_ACCESS_KEY_ID');
-  }
-
-  getAwsS3SecretAccessKey(): string {
-    return this.configService.get<string>('AWS_S3_SECRET_ACCESS_KEY');
-  }
-
   getAwsS3Region(): string {
     return this.configService.get<string>('AWS_S3_REGION');
   }

--- a/apps/server/src/integrations/storage/providers/storage.provider.ts
+++ b/apps/server/src/integrations/storage/providers/storage.provider.ts
@@ -48,10 +48,6 @@ export const storageDriverConfigProvider = {
             endpoint: environmentService.getAwsS3Endpoint(),
             bucket: environmentService.getAwsS3Bucket(),
             baseUrl: environmentService.getAwsS3Url(),
-            credentials: {
-              accessKeyId: environmentService.getAwsS3AccessKeyId(),
-              secretAccessKey: environmentService.getAwsS3SecretAccessKey(),
-            },
           },
         };
 


### PR DESCRIPTION
By explicitly providing the credentials configuration block, we were overwriting the AWS Node SDK's built in environment variable parsing. This meant that when using short lived tokens, which uses `AWS_SESSION_TOKEN` as well as `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` that it was failing, as it would see the access key and the access key ID, but not a valid session. 

By removing it, we let the Node SDK natively get the credentials. This works with both the legacy (and not recommended) long-term credentials, providing both the access key and ID, but also with the more secure recommended credentials that utilise a session token. 

The docs will need to be updated to reference `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` rather than `AWS_S3_SECRET_ACCESS_KEY` and `AWS_S3_SECRET_ACCESS_KEY`

Closes #50