### PR TITLE
CORS setup and Vite devServer proxy

### DIFF
--- a/apps/client/src/lib/api-client.ts
+++ b/apps/client/src/lib/api-client.ts
@@ -1,10 +1,9 @@
 import axios, { AxiosInstance } from "axios";
 import Cookies from "js-cookie";
 import Routes from "@/lib/app-route.ts";
-import { getBackendUrl } from "@/lib/config.ts";
 
 const api: AxiosInstance = axios.create({
-  baseURL: getBackendUrl(),
+  baseURL: "/api",
   withCredentials: true,
 });
 
@@ -27,7 +26,7 @@ api.interceptors.request.use(
   },
   (error) => {
     return Promise.reject(error);
-  },
+  }
 );
 
 api.interceptors.response.use(
@@ -68,7 +67,7 @@ api.interceptors.response.use(
       }
     }
     return Promise.reject(error);
-  },
+  }
 );
 
 function redirectToLogin() {

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -19,5 +19,13 @@ export default defineConfig(({ mode }) => {
         "@": "/src",
       },
     },
+    server: {
+      proxy: {
+        "/api": {
+          target: APP_URL,
+          changeOrigin: true,
+        },
+      },
+    },
   };
 });

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -59,15 +59,7 @@ async function bootstrap() {
     }),
   );
 
-  if (process.env.NODE_ENV !== 'production') {
-    // make development easy
-    app.enableCors({
-      origin: ['http://localhost:5173'],
-      credentials: true,
-    });
-  } else {
-    app.enableCors();
-  }
+  app.enableCors();
 
   app.useGlobalInterceptors(new TransformHttpResponseInterceptor());
   app.enableShutdownHooks();


### PR DESCRIPTION
We can use the devServer proxy option in Vite to avoid needing a CORS exception for development