### PR TITLE
Add request typings and change JWT extraction

### DIFF
--- a/apps/client/src/features/auth/hooks/use-auth.ts
+++ b/apps/client/src/features/auth/hooks/use-auth.ts
@@ -2,18 +2,11 @@ import { useState } from "react";
 import { login, setupWorkspace } from "@/features/auth/services/auth-service";
 import { useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
-import { authTokensAtom } from "@/features/auth/atoms/auth-tokens-atom";
 import { currentUserAtom } from "@/features/user/atoms/current-user-atom";
-import {
-  ILogin,
-  IRegister,
-  ISetupWorkspace,
-} from "@/features/auth/types/auth.types";
+import { ILogin, ISetupWorkspace } from "@/features/auth/types/auth.types";
 import { notifications } from "@mantine/notifications";
 import { IAcceptInvite } from "@/features/workspace/types/workspace.types.ts";
 import { acceptInvitation } from "@/features/workspace/services/workspace-service.ts";
-import Cookies from "js-cookie";
-import { jwtDecode } from "jwt-decode";
 import APP_ROUTE from "@/lib/app-route.ts";
 import api from "@/lib/api-client";
 

--- a/apps/client/src/features/auth/hooks/use-auth.ts
+++ b/apps/client/src/features/auth/hooks/use-auth.ts
@@ -14,8 +14,6 @@ export default function useAuth() {
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
-  const [, setCurrentUser] = useAtom(currentUserAtom);
-
   const handleSignIn = async (data: ILogin) => {
     setIsLoading(true);
 
@@ -70,7 +68,7 @@ export default function useAuth() {
 
   const handleIsAuthenticated = async () => {
     try {
-      await api.get(`/api/users/me`);
+      await api.get(`/users/me`);
       return true;
     } catch {
       return false;
@@ -78,7 +76,7 @@ export default function useAuth() {
   };
 
   const handleLogout = async () => {
-    await api.post(`/api/auth/logout`);
+    await api.post(`/auth/logout`);
     navigate(APP_ROUTE.AUTH.LOGIN);
   };
 

--- a/apps/client/src/features/auth/hooks/use-auth.ts
+++ b/apps/client/src/features/auth/hooks/use-auth.ts
@@ -21,16 +21,14 @@ export default function useAuth() {
   const navigate = useNavigate();
 
   const [, setCurrentUser] = useAtom(currentUserAtom);
-  const [authToken, setAuthToken] = useAtom(authTokensAtom);
 
   const handleSignIn = async (data: ILogin) => {
     setIsLoading(true);
 
     try {
-      const res = await login(data);
-      setIsLoading(false);
-      setAuthToken(res.tokens);
+      await login(data);
 
+      setIsLoading(false);
       navigate(APP_ROUTE.HOME);
     } catch (err) {
       console.log(err);
@@ -82,13 +80,8 @@ export default function useAuth() {
   };
 
   const handleIsAuthenticated = async () => {
-    if (!authToken) {
-      return false;
-    }
-
     try {
-      const accessToken = authToken.accessToken;
-      const payload = jwtDecode(accessToken);
+      await 
 
       // true if jwt is active
       const now = Date.now().valueOf() / 1000;
@@ -99,14 +92,8 @@ export default function useAuth() {
     }
   };
 
-  const hasTokens = (): boolean => {
-    return !!authToken;
-  };
-
   const handleLogout = async () => {
-    setAuthToken(null);
     setCurrentUser(null);
-    Cookies.remove("authTokens");
     navigate(APP_ROUTE.AUTH.LOGIN);
   };
 
@@ -116,7 +103,6 @@ export default function useAuth() {
     setupWorkspace: handleSetupWorkspace,
     isAuthenticated: handleIsAuthenticated,
     logout: handleLogout,
-    hasTokens,
     isLoading,
   };
 }

--- a/apps/client/src/features/auth/hooks/use-auth.ts
+++ b/apps/client/src/features/auth/hooks/use-auth.ts
@@ -15,6 +15,7 @@ import { acceptInvitation } from "@/features/workspace/services/workspace-servic
 import Cookies from "js-cookie";
 import { jwtDecode } from "jwt-decode";
 import APP_ROUTE from "@/lib/app-route.ts";
+import api from "@/lib/api-client";
 
 export default function useAuth() {
   const [isLoading, setIsLoading] = useState(false);
@@ -44,12 +45,9 @@ export default function useAuth() {
     setIsLoading(true);
 
     try {
-      const res = await acceptInvitation(data);
+      await acceptInvitation(data);
+
       setIsLoading(false);
-
-      console.log(res);
-      setAuthToken(res.tokens);
-
       navigate(APP_ROUTE.HOME);
     } catch (err) {
       setIsLoading(false);
@@ -64,11 +62,9 @@ export default function useAuth() {
     setIsLoading(true);
 
     try {
-      const res = await setupWorkspace(data);
+      await setupWorkspace(data);
+
       setIsLoading(false);
-
-      setAuthToken(res.tokens);
-
       navigate(APP_ROUTE.HOME);
     } catch (err) {
       setIsLoading(false);
@@ -81,19 +77,15 @@ export default function useAuth() {
 
   const handleIsAuthenticated = async () => {
     try {
-      await 
-
-      // true if jwt is active
-      const now = Date.now().valueOf() / 1000;
-      return payload.exp >= now;
-    } catch (err) {
-      console.log("invalid jwt token", err);
+      await api.get(`/api/users/me`);
+      return true;
+    } catch {
       return false;
     }
   };
 
   const handleLogout = async () => {
-    setCurrentUser(null);
+    await api.post(`/api/auth/logout`);
     navigate(APP_ROUTE.AUTH.LOGIN);
   };
 

--- a/apps/client/src/features/user/services/user-service.ts
+++ b/apps/client/src/features/user/services/user-service.ts
@@ -2,7 +2,7 @@ import api from "@/lib/api-client";
 import { ICurrentUser, IUser } from "@/features/user/types/user.types";
 
 export async function getMyInfo(): Promise<ICurrentUser> {
-  const req = await api.post<ICurrentUser>("/users/me");
+  const req = await api.get<ICurrentUser>("/users/me");
   return req.data as ICurrentUser;
 }
 

--- a/apps/server/src/common/decorators/auth-user.decorator.ts
+++ b/apps/server/src/common/decorators/auth-user.decorator.ts
@@ -3,14 +3,16 @@ import {
   createParamDecorator,
   ExecutionContext,
 } from '@nestjs/common';
+import { AppRequest } from '../helpers/types/request';
 
 export const AuthUser = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
-    const request = ctx.switchToHttp().getRequest();
-    if (!request?.user?.user) {
+    const request = ctx.switchToHttp().getRequest<AppRequest>();
+
+    if (!request.user) {
       throw new BadRequestException('Invalid User');
     }
 
-    return request.user.user;
+    return request.user;
   },
 );

--- a/apps/server/src/common/decorators/auth-workspace.decorator.ts
+++ b/apps/server/src/common/decorators/auth-workspace.decorator.ts
@@ -3,11 +3,13 @@ import {
   createParamDecorator,
   ExecutionContext,
 } from '@nestjs/common';
+import { AppRequest } from '../helpers/types/request';
 
 export const AuthWorkspace = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
-    const request = ctx.switchToHttp().getRequest();
-    const workspace = request.raw?.workspace ?? request?.user?.workspace;
+    const request = ctx.switchToHttp().getRequest<AppRequest>();
+
+    const workspace = request.raw.workspace;
 
     if (!workspace) {
       throw new BadRequestException('Invalid workspace');

--- a/apps/server/src/common/helpers/types/request.ts
+++ b/apps/server/src/common/helpers/types/request.ts
@@ -1,0 +1,10 @@
+import { User, Workspace } from '@docmost/db/types/entity.types';
+import { FastifyRequest } from 'fastify';
+
+export interface AppRequest extends FastifyRequest {
+  user: User;
+  raw: FastifyRequest['raw'] & {
+    workspaceId: string;
+    workspace: Workspace;
+  };
+}

--- a/apps/server/src/common/middlewares/domain.middleware.ts
+++ b/apps/server/src/common/middlewares/domain.middleware.ts
@@ -1,7 +1,8 @@
 import { Injectable, NestMiddleware, NotFoundException } from '@nestjs/common';
-import { FastifyRequest, FastifyReply } from 'fastify';
+import { FastifyReply } from 'fastify';
 import { EnvironmentService } from '../../integrations/environment/environment.service';
 import { WorkspaceRepo } from '@docmost/db/repos/workspace/workspace.repo';
+import { AppRequest } from '../helpers/types/request';
 
 @Injectable()
 export class DomainMiddleware implements NestMiddleware {
@@ -10,21 +11,19 @@ export class DomainMiddleware implements NestMiddleware {
     private environmentService: EnvironmentService,
   ) {}
   async use(
-    req: FastifyRequest['raw'],
-    res: FastifyReply['raw'],
+    req: AppRequest['raw'],
+    _res: FastifyReply['raw'],
     next: () => void,
   ) {
     if (this.environmentService.isSelfHosted()) {
       const workspace = await this.workspaceRepo.findFirst();
+
       if (!workspace) {
-        //throw new NotFoundException('Workspace not found');
-        (req as any).workspaceId = null;
-        return next();
+        throw new NotFoundException('Workspace not found');
       }
 
-      // TODO: unify
-      (req as any).workspaceId = workspace.id;
-      (req as any).workspace = workspace;
+      req.workspaceId = workspace.id;
+      req.workspace = workspace;
     } else if (this.environmentService.isCloud()) {
       const header = req.headers.host;
       const subdomain = header.split('.')[0];
@@ -35,8 +34,8 @@ export class DomainMiddleware implements NestMiddleware {
         throw new NotFoundException('Workspace not found');
       }
 
-      (req as any).workspaceId = workspace.id;
-      (req as any).workspace = workspace;
+      req.workspaceId = workspace.id;
+      req.workspace = workspace;
     }
 
     next();

--- a/apps/server/src/core/auth/auth.controller.ts
+++ b/apps/server/src/core/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
   Post,
   Req,
+  Res,
   UseGuards,
 } from '@nestjs/common';
 import { LoginDto } from './dto/login.dto';
@@ -19,6 +20,8 @@ import { AuthUser } from '../../common/decorators/auth-user.decorator';
 import { User, Workspace } from '@docmost/db/types/entity.types';
 import { AuthWorkspace } from '../../common/decorators/auth-workspace.decorator';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { FastifyReply } from 'fastify';
+import { AppRequest } from 'src/common/helpers/types/request';
 
 @Controller('auth')
 export class AuthController {
@@ -29,8 +32,16 @@ export class AuthController {
 
   @HttpCode(HttpStatus.OK)
   @Post('login')
-  async login(@Req() req, @Body() loginInput: LoginDto) {
-    return this.authService.login(loginInput, req.raw.workspaceId);
+  async login(
+    @Req() req: AppRequest,
+    @Res() reply: FastifyReply,
+    @Body() loginInput: LoginDto,
+  ) {
+    const token = await this.authService.login(loginInput, req.raw.workspaceId);
+
+    this.setCookie(reply, token);
+
+    return reply.send();
   }
 
   /* @HttpCode(HttpStatus.OK)
@@ -60,5 +71,13 @@ export class AuthController {
     @AuthWorkspace() workspace: Workspace,
   ) {
     return this.authService.changePassword(dto, user.id, workspace.id);
+  }
+
+  private setCookie(reply: FastifyReply, token: string): void {
+    reply.setCookie('token', token, {
+      path: '/',
+      httpOnly: true,
+      secure: this.environmentService.getNodeEnv() === 'production',
+    });
   }
 }

--- a/apps/server/src/core/auth/auth.controller.ts
+++ b/apps/server/src/core/auth/auth.controller.ts
@@ -44,6 +44,13 @@ export class AuthController {
     return reply.send();
   }
 
+  @HttpCode(HttpStatus.OK)
+  @Post('logout')
+  async logout(@Res() reply: FastifyReply) {
+    reply.clearCookie('token');
+    return reply.send();
+  }
+
   /* @HttpCode(HttpStatus.OK)
   @Post('register')
   async register(@Req() req, @Body() createUserDto: CreateUserDto) {

--- a/apps/server/src/core/auth/services/auth.service.ts
+++ b/apps/server/src/core/auth/services/auth.service.ts
@@ -25,7 +25,7 @@ export class AuthService {
     private mailService: MailService,
   ) {}
 
-  async login(loginDto: LoginDto, workspaceId: string) {
+  async login(loginDto: LoginDto, workspaceId: string): Promise<string> {
     const user = await this.userRepo.findByEmail(
       loginDto.email,
       workspaceId,
@@ -42,8 +42,7 @@ export class AuthService {
     user.lastLoginAt = new Date();
     await this.userRepo.updateLastLogin(user.id, workspaceId);
 
-    const tokens: TokensDto = await this.tokenService.generateTokens(user);
-    return { tokens };
+    return this.tokenService.generateAccessToken(user);
   }
 
   async register(createUserDto: CreateUserDto, workspaceId: string) {

--- a/apps/server/src/core/auth/strategies/jwt.strategy.ts
+++ b/apps/server/src/core/auth/strategies/jwt.strategy.ts
@@ -4,12 +4,13 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import { Strategy } from 'passport-jwt';
+import { ExtractJwt, Strategy } from 'passport-jwt';
 import { EnvironmentService } from '../../../integrations/environment/environment.service';
 import { JwtPayload, JwtType } from '../dto/jwt-payload';
 import { WorkspaceRepo } from '@docmost/db/repos/workspace/workspace.repo';
 import { UserRepo } from '@docmost/db/repos/user/user.repo';
 import { FastifyRequest } from 'fastify';
+import { AppRequest } from 'src/common/helpers/types/request';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
@@ -18,23 +19,29 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     private workspaceRepo: WorkspaceRepo,
     private readonly environmentService: EnvironmentService,
   ) {
+    function extractFromCookie(req: FastifyRequest) {
+      return req.cookies['authTokens']['accessToken'];
+    }
+
+    function extractTokenFromHeader(
+      request: FastifyRequest,
+    ): string | undefined {
+      const [type, token] = request.headers.authorization?.split(' ') ?? [];
+      return type === 'Bearer' ? token : undefined;
+    }
+
     super({
-      jwtFromRequest: (req: FastifyRequest) => {
-        let accessToken = null;
-
-        try {
-          accessToken = JSON.parse(req.cookies?.authTokens)?.accessToken;
-        } catch {}
-
-        return accessToken || this.extractTokenFromHeader(req);
-      },
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        extractFromCookie,
+        extractTokenFromHeader,
+      ]),
       ignoreExpiration: false,
       secretOrKey: environmentService.getAppSecret(),
       passReqToCallback: true,
     });
   }
 
-  async validate(req: any, payload: JwtPayload) {
+  async validate(req: AppRequest, payload: JwtPayload) {
     if (!payload.workspaceId || payload.type !== JwtType.ACCESS) {
       throw new UnauthorizedException();
     }
@@ -57,11 +64,12 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
       throw new UnauthorizedException();
     }
 
-    return { user, workspace };
-  }
+    // If the workspace being accessed does not match the user that was
+    // authenticated, then the user is not authorized
+    if (req.raw.workspaceId !== payload.workspaceId) {
+      throw new UnauthorizedException();
+    }
 
-  private extractTokenFromHeader(request: FastifyRequest): string | undefined {
-    const [type, token] = request.headers.authorization?.split(' ') ?? [];
-    return type === 'Bearer' ? token : undefined;
+    return user;
   }
 }

--- a/apps/server/src/core/auth/strategies/jwt.strategy.ts
+++ b/apps/server/src/core/auth/strategies/jwt.strategy.ts
@@ -22,18 +22,10 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     function extractFromCookie(req: FastifyRequest) {
       return req.cookies['authTokens']['accessToken'];
     }
-
-    function extractTokenFromHeader(
-      request: FastifyRequest,
-    ): string | undefined {
-      const [type, token] = request.headers.authorization?.split(' ') ?? [];
-      return type === 'Bearer' ? token : undefined;
-    }
-
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         extractFromCookie,
-        extractTokenFromHeader,
+        ExtractJwt.fromAuthHeaderAsBearerToken,
       ]),
       ignoreExpiration: false,
       secretOrKey: environmentService.getAppSecret(),

--- a/apps/server/src/core/auth/strategies/jwt.strategy.ts
+++ b/apps/server/src/core/auth/strategies/jwt.strategy.ts
@@ -19,13 +19,14 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     private workspaceRepo: WorkspaceRepo,
     private readonly environmentService: EnvironmentService,
   ) {
-    function extractFromCookie(req: FastifyRequest) {
-      return req.cookies['authTokens']['accessToken'];
+    function extractFromCookie(req: FastifyRequest): string | undefined {
+      return req.cookies['token'];
     }
+
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         extractFromCookie,
-        ExtractJwt.fromAuthHeaderAsBearerToken,
+        ExtractJwt.fromAuthHeaderAsBearerToken(),
       ]),
       ignoreExpiration: false,
       secretOrKey: environmentService.getAppSecret(),

--- a/apps/server/src/core/user/user.controller.ts
+++ b/apps/server/src/core/user/user.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
   Post,
@@ -19,7 +20,7 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @HttpCode(HttpStatus.OK)
-  @Post('me')
+  @Get('me')
   async getUserIno(
     @AuthUser() authUser: User,
     @AuthWorkspace() workspace: Workspace,


### PR DESCRIPTION
This PR does a small bit of housekeeping to make it easier to potentially add OIDC in the future, and generally improves developer experience. 

- Adds a new `AppRequest` type which contains the correct typing for `user`, `workspace` and `workspaceId` and uses that new type where appropriate
- Uses the provided extractor functions option from the JWT Module