### PR TITLE
Add support for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables

### DIFF
--- a/apps/server/src/integrations/storage/drivers/s3.driver.ts
+++ b/apps/server/src/integrations/storage/drivers/s3.driver.ts
@@ -34,9 +34,6 @@ export class S3Driver implements StorageDriver {
       });
 
       await this.s3Client.send(command);
-      // we can get the path from location
-
-      console.log(`File uploaded successfully: ${filePath}`);
     } catch (err) {
       throw new Error(`Failed to upload file: ${(err as Error).message}`);
     }

--- a/apps/server/src/integrations/storage/providers/storage.provider.ts
+++ b/apps/server/src/integrations/storage/providers/storage.provider.ts
@@ -41,19 +41,33 @@ export const storageDriverConfigProvider = {
         };
 
       case StorageOption.S3:
-        return {
+        const s3Config = {
           driver,
           config: {
             region: environmentService.getAwsS3Region(),
             endpoint: environmentService.getAwsS3Endpoint(),
             bucket: environmentService.getAwsS3Bucket(),
             baseUrl: environmentService.getAwsS3Url(),
-            credentials: {
-              accessKeyId: environmentService.getAwsS3AccessKeyId(),
-              secretAccessKey: environmentService.getAwsS3SecretAccessKey(),
-            },
+            credentials: undefined,
           },
         };
+
+        /**
+         * This makes use of AWS_S3_ACCESS_KEY_ID and AWS_S3_SECRET_ACCESS_KEY if present,
+         * If not present, it makes it lenient for the AWS SDK to use
+         * AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY if they are present in the environment
+         */
+        if (
+          environmentService.getAwsS3AccessKeyId() &&
+          environmentService.getAwsS3SecretAccessKey()
+        ) {
+          s3Config.config.credentials = {
+            accessKeyId: environmentService.getAwsS3AccessKeyId(),
+            secretAccessKey: environmentService.getAwsS3SecretAccessKey(),
+          };
+        }
+
+        return s3Config;
 
       default:
         throw new Error(`Unknown storage driver: ${driver}`);

--- a/apps/server/src/integrations/storage/providers/storage.provider.ts
+++ b/apps/server/src/integrations/storage/providers/storage.provider.ts
@@ -58,7 +58,7 @@ export const storageDriverConfigProvider = {
          * AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY if they are present in the environment
          */
         if (
-          environmentService.getAwsS3AccessKeyId() &&
+          environmentService.getAwsS3AccessKeyId() ||
           environmentService.getAwsS3SecretAccessKey()
         ) {
           s3Config.config.credentials = {

--- a/apps/server/src/integrations/storage/storage.service.ts
+++ b/apps/server/src/integrations/storage/storage.service.ts
@@ -1,15 +1,17 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { STORAGE_DRIVER_TOKEN } from './constants/storage.constants';
 import { StorageDriver } from './interfaces';
 
 @Injectable()
 export class StorageService {
+  private readonly logger = new Logger(StorageService.name);
   constructor(
     @Inject(STORAGE_DRIVER_TOKEN) private storageDriver: StorageDriver,
   ) {}
 
   async upload(filePath: string, fileContent: Buffer | any) {
     await this.storageDriver.upload(filePath, fileContent);
+    this.logger.debug(`File uploaded successfully. Path: ${filePath}`);
   }
 
   async read(filePath: string): Promise<Buffer> {


### PR DESCRIPTION
This PR makes provision to support `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.

You can decide to either use `AWS_S3_ACCESS_KEY_ID` and `AWS_S3_SECRET_ACCESS_KEY` or 
`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. 
The `AWS_S3_` prefixed one will take precedence if present.

See #56 for why we need this.
