### PR TITLE
add STMP_SECURE and changed auth config

### DIFF
--- a/apps/server/src/integrations/environment/environment.service.ts
+++ b/apps/server/src/integrations/environment/environment.service.ts
@@ -87,17 +87,6 @@ export class EnvironmentService {
     return parseInt(this.configService.get<string>('SMTP_PORT'));
   }
 
-  getSmtpAuth(): object {
-    let auth = undefined;
-    if (this.getSmtpUsername() && this.getSmtpPassword()) {
-      auth = {
-          user: this.getSmtpUsername(),
-          pass: this.getSmtpPassword(),
-        };
-    }
-    return auth;
-  }
-
   getSmtpSecure(): boolean {
     const secure = this.configService
       .get<string>('SMTP_SECURE', 'false')

--- a/apps/server/src/integrations/environment/environment.service.ts
+++ b/apps/server/src/integrations/environment/environment.service.ts
@@ -87,6 +87,24 @@ export class EnvironmentService {
     return parseInt(this.configService.get<string>('SMTP_PORT'));
   }
 
+  getSmtpAuth(): object {
+    let auth = undefined;
+    if (this.getSmtpUsername() && this.getSmtpPassword()) {
+      auth = {
+          user: this.getSmtpUsername(),
+          pass: this.getSmtpPassword(),
+        };
+    }
+    return auth;
+  }
+
+  getSmtpSecure(): boolean {
+    const secure = this.configService
+      .get<string>('SMTP_SECURE', 'false')
+      .toLowerCase();
+    return secure === 'true';
+  }
+
   getSmtpUsername(): string {
     return this.configService.get<string>('SMTP_USERNAME');
   }

--- a/apps/server/src/integrations/mail/providers/mail.provider.ts
+++ b/apps/server/src/integrations/mail/providers/mail.provider.ts
@@ -26,13 +26,20 @@ export const mailDriverConfigProvider = {
 
     switch (driver) {
       case MailOption.SMTP:
+        let auth = undefined;
+        if (environmentService.getSmtpUsername() && environmentService.getSmtpPassword()) {
+          auth = {
+              user: environmentService.getSmtpUsername(),
+              pass: environmentService.getSmtpPassword(),
+            };
+        }
         return {
           driver,
           config: {
             host: environmentService.getSmtpHost(),
             port: environmentService.getSmtpPort(),
             connectionTimeout: 30 * 1000, // 30 seconds
-            auth: environmentService.getSmtpAuth(),
+            auth,
             secure: environmentService.getSmtpSecure(),
           } as SMTPTransport.Options,
         };

--- a/apps/server/src/integrations/mail/providers/mail.provider.ts
+++ b/apps/server/src/integrations/mail/providers/mail.provider.ts
@@ -32,10 +32,8 @@ export const mailDriverConfigProvider = {
             host: environmentService.getSmtpHost(),
             port: environmentService.getSmtpPort(),
             connectionTimeout: 30 * 1000, // 30 seconds
-            auth: {
-              user: environmentService.getSmtpUsername(),
-              pass: environmentService.getSmtpPassword(),
-            },
+            auth: environmentService.getSmtpAuth(),
+            secure: environmentService.getSmtpSecure(),
           } as SMTPTransport.Options,
         };
 


### PR DESCRIPTION
Only configure auth object in smtp config if user and password are provided. If no auth object is defined, [nodemailer assumes the connection is already authenticated](https://nodemailer.com/smtp/#authentication).

Also exposed the secure config option.