### PR TITLE
Support RTL by auto detect direction

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -48,7 +48,6 @@
     "socket.io-client": "^4.8.1",
     "tippy.js": "^6.3.7",
     "tiptap-extension-global-drag-handle": "^0.1.16",
-    "tiptap-text-direction": "^0.3.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -48,6 +48,7 @@
     "socket.io-client": "^4.8.1",
     "tippy.js": "^6.3.7",
     "tiptap-extension-global-drag-handle": "^0.1.16",
+    "tiptap-text-direction": "^0.3.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/apps/client/src/features/comment/components/comment-editor.tsx
+++ b/apps/client/src/features/comment/components/comment-editor.tsx
@@ -8,6 +8,7 @@ import { useFocusWithin } from "@mantine/hooks";
 import clsx from "clsx";
 import { forwardRef, useEffect, useImperativeHandle } from "react";
 import { useTranslation } from "react-i18next";
+import TextDirection from "tiptap-text-direction";
 
 interface CommentEditorProps {
   defaultContent?: any;
@@ -40,6 +41,7 @@ const CommentEditor = forwardRef(
         Placeholder.configure({
           placeholder: placeholder || t("Reply..."),
         }),
+        TextDirection.configure({ types: ["paragraph"] }),
         Underline,
         Link,
       ],

--- a/apps/client/src/features/comment/components/comment-editor.tsx
+++ b/apps/client/src/features/comment/components/comment-editor.tsx
@@ -8,7 +8,7 @@ import { useFocusWithin } from "@mantine/hooks";
 import clsx from "clsx";
 import { forwardRef, useEffect, useImperativeHandle } from "react";
 import { useTranslation } from "react-i18next";
-import TextDirection from "tiptap-text-direction";
+import { TextDirection } from "@/features/editor/extensions/detect-direction";
 
 interface CommentEditorProps {
   defaultContent?: any;

--- a/apps/client/src/features/comment/components/comment-list-item.tsx
+++ b/apps/client/src/features/comment/components/comment-list-item.tsx
@@ -15,6 +15,7 @@ import {
 import { IComment } from "@/features/comment/types/comment.types";
 import { CustomAvatar } from "@/components/ui/custom-avatar.tsx";
 import { currentUserAtom } from "@/features/user/atoms/current-user-atom.ts";
+import { getTextDirection } from "tiptap-text-direction";
 
 interface CommentListItemProps {
   comment: IComment;
@@ -99,7 +100,7 @@ function CommentListItem({ comment }: CommentListItemProps) {
 
       <div>
         {!comment.parentCommentId && comment?.selection && (
-          <Box className={classes.textSelection}>
+          <Box className={classes.textSelection} dir={getTextDirection(comment?.selection || '')}>
             <Text size="sm">{comment?.selection}</Text>
           </Box>
         )}

--- a/apps/client/src/features/comment/components/comment-list-item.tsx
+++ b/apps/client/src/features/comment/components/comment-list-item.tsx
@@ -15,7 +15,7 @@ import {
 import { IComment } from "@/features/comment/types/comment.types";
 import { CustomAvatar } from "@/components/ui/custom-avatar.tsx";
 import { currentUserAtom } from "@/features/user/atoms/current-user-atom.ts";
-import { getTextDirection } from "tiptap-text-direction";
+import { getTextDirection } from "@/features/editor/extensions/detect-direction";
 
 interface CommentListItemProps {
   comment: IComment;

--- a/apps/client/src/features/comment/components/comment.module.css
+++ b/apps/client/src/features/comment/components/comment.module.css
@@ -11,6 +11,11 @@
     border-left: 2px solid var(--mantine-color-gray-6);
     padding: 8px;
     background: var(--mantine-color-gray-light);
+
+    &[dir="rtl"] {
+        border-right: 2px solid var(--mantine-color-gray-6);
+        border-left: none;
+    }
 }
 
 .commentEditor {

--- a/apps/client/src/features/editor/components/callout/callout-view.tsx
+++ b/apps/client/src/features/editor/components/callout/callout-view.tsx
@@ -11,7 +11,7 @@ import { CalloutType } from "@docmost/editor-ext";
 
 export default function CalloutView(props: NodeViewProps) {
   const { node } = props;
-  const { type } = node.attrs;
+  const { type, dir } = node.attrs;
 
   return (
     <NodeViewWrapper>
@@ -25,6 +25,7 @@ export default function CalloutView(props: NodeViewProps) {
           message: classes.message,
           icon: classes.icon,
         }}
+        dir={dir}
       >
         <NodeViewContent />
       </Alert>

--- a/apps/client/src/features/editor/extensions/detect-direction.ts
+++ b/apps/client/src/features/editor/extensions/detect-direction.ts
@@ -1,0 +1,225 @@
+// original code: https://github.com/amirhhashemi/tiptap-text-direction/blob/master/src/index.ts
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { EditorView } from "@tiptap/pm/view";
+
+const RTL = "\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC";
+const LTR =
+  "A-Za-z\u00C0-\u00D6\u00D8-\u00F6" +
+  "\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF\u200E\u2C00-\uFB1C" +
+  "\uFE00-\uFE6F\uFEFD-\uFFFF";
+
+const RTL_REGEX = new RegExp(`^[^${LTR}]*[${RTL}]`);
+const LTR_REGEX = new RegExp(`^[^${RTL}]*[${LTR}]`);
+
+export function getTextDirection(text: string): "ltr" | "rtl" | null {
+  if (!text) {
+    return null;
+  }
+  if (RTL_REGEX.test(text)) {
+    return "rtl";
+  }
+  if (LTR_REGEX.test(text)) {
+    return "ltr";
+  }
+  return null;
+}
+
+const validDirections = ["ltr", "rtl", "auto"] as const;
+type Direction = (typeof validDirections)[number];
+
+export interface TextDirectionOptions {
+  /**
+   * Node types for which you want to set the `dir` attribute
+   * (e.g. ["paragraph", "heading", "listItem"]).
+   */
+  types: string[];
+  /**
+   * If you want a default direction (e.g. "ltr" or "rtl") when
+   * no direction can be inferred from the node text.
+   */
+  defaultDirection: Direction | null;
+}
+
+/**
+ * A Tiptap extension for automatically detecting and updating
+ * the text direction (dir) on specific node types. It also
+ * exposes commands for manually setting and unsetting direction.
+ */
+export const TextDirection = Extension.create<TextDirectionOptions>({
+  name: "textDirection",
+
+  addOptions() {
+    return {
+      types: [],
+      defaultDirection: null,
+    };
+  },
+
+  /**
+   * We add a `dir` attribute to the configured node types.
+   * By default, `dir` is `null`, so it’s omitted unless we set it.
+   */
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          dir: {
+            default: null,
+            parseHTML: (element) =>
+              element.dir || this.options.defaultDirection,
+            renderHTML: (attributes) => {
+              // If it's the default direction, skip setting `dir`
+              if (attributes.dir === this.options.defaultDirection) {
+                return {};
+              }
+              return { dir: attributes.dir };
+            },
+          },
+        },
+      },
+    ];
+  },
+
+  /**
+   * Add commands to manually set/unset direction.
+   */
+  addCommands() {
+    return {
+      setTextDirection:
+        (direction: Direction) =>
+        ({ commands }) => {
+          if (!validDirections.includes(direction)) {
+            return false;
+          }
+          // Apply `dir` to all relevant node types
+          return this.options.types.every((type) =>
+            commands.updateAttributes(type, { dir: direction }),
+          );
+        },
+
+      unsetTextDirection:
+        () =>
+        ({ commands }) => {
+          return this.options.types.every((type) =>
+            commands.resetAttributes(type, "dir"),
+          );
+        },
+    };
+  },
+
+  /**
+   * Example keyboard shortcuts for quick direction switching.
+   */
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Alt-l": () => this.editor.commands.setTextDirection("ltr"),
+      "Mod-Alt-r": () => this.editor.commands.setTextDirection("rtl"),
+    };
+  },
+
+  /**
+   * The main logic is in the ProseMirror plugin: we track IME composition
+   * and update directions only when safe.
+   */
+  addProseMirrorPlugins() {
+    const { types } = this.options;
+    const pluginKey = new PluginKey("textDirectionPluginKey");
+
+    return [
+      new Plugin({
+        key: pluginKey,
+
+        // We store a small plugin state, just a flag for `isComposing`.
+        state: {
+          init() {
+            return { isComposing: false };
+          },
+          apply(tr, pluginValue) {
+            // We keep the same state unless we specifically update it ourselves
+            // in the handleDOMEvents below.
+            return { ...pluginValue };
+          },
+        },
+
+        props: {
+          // This is how ProseMirror suggests handling composition events.
+          // We do NOT rely on global `document.addEventListener(...)`.
+          handleDOMEvents: {
+            compositionstart: (view: EditorView, event: Event) => {
+              const state = pluginKey.getState(view.state);
+              state.isComposing = true;
+              return false; // allow normal handling
+            },
+            compositionend: (view: EditorView, event: Event) => {
+              const state = pluginKey.getState(view.state);
+              state.isComposing = false;
+
+              // Once composition ends, we can safely detect directions
+              // for any changed nodes.
+              const { tr } = view.state;
+              tr.setMeta("addToHistory", false);
+
+              let modified = false;
+              view.state.doc.descendants((node, pos) => {
+                if (!types.includes(node.type.name)) return;
+
+                // If there's no text, skip
+                if (!node.textContent) return;
+
+                const detected = getTextDirection(node.textContent);
+                const current = node.attrs.dir;
+                // Only update if it’s actually changed
+                if (detected !== current) {
+                  tr.setNodeAttribute(pos, "dir", detected ?? null);
+                  modified = true;
+                }
+              });
+
+              if (modified) {
+                view.dispatch(tr);
+              }
+
+              return false; // allow normal handling
+            },
+          },
+        },
+
+        // For non-IME text input (straight typing in English, etc.),
+        // we can automatically detect direction in `appendTransaction`.
+        appendTransaction: (transactions, oldState, newState) => {
+          const pluginState = pluginKey.getState(oldState);
+          // If we’re currently composing (IME in progress), skip
+          if (pluginState.isComposing) {
+            return null;
+          }
+
+          // If no actual doc change, do nothing
+          const docChanged = transactions.some((tr) => tr.docChanged);
+          if (!docChanged) {
+            return null;
+          }
+
+          const tr = newState.tr;
+          tr.setMeta("addToHistory", false);
+
+          let modified = false;
+          newState.doc.descendants((node, pos) => {
+            if (!types.includes(node.type.name)) return;
+
+            if (!node.textContent) return;
+            const detected = getTextDirection(node.textContent);
+            const current = node.attrs.dir;
+            if (detected !== current) {
+              tr.setNodeAttribute(pos, "dir", detected ?? null);
+              modified = true;
+            }
+          });
+
+          return modified ? tr : null;
+        },
+      }),
+    ];
+  },
+});

--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -16,7 +16,6 @@ import SlashCommand from "@/features/editor/extensions/slash-command";
 import { Collaboration } from "@tiptap/extension-collaboration";
 import { CollaborationCursor } from "@tiptap/extension-collaboration-cursor";
 import { HocuspocusProvider } from "@hocuspocus/provider";
-import { TextDirection } from "tiptap-text-direction";
 import {
   Comment,
   Details,
@@ -71,6 +70,7 @@ import { ReactNodeViewRenderer } from "@tiptap/react";
 import MentionView from "@/features/editor/components/mention/mention-view.tsx";
 import i18n from "@/i18n.ts";
 import { MarkdownClipboard } from "@/features/editor/extensions/markdown-clipboard.ts";
+import { TextDirection } from "./detect-direction";
 
 const lowlight = createLowlight(common);
 lowlight.register("mermaid", plaintext);

--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -16,6 +16,7 @@ import SlashCommand from "@/features/editor/extensions/slash-command";
 import { Collaboration } from "@tiptap/extension-collaboration";
 import { CollaborationCursor } from "@tiptap/extension-collaboration-cursor";
 import { HocuspocusProvider } from "@hocuspocus/provider";
+import { TextDirection } from "tiptap-text-direction";
 import {
   Comment,
   Details,
@@ -113,6 +114,12 @@ export const mainExtensions = [
     showOnlyWhenEditable: true,
   }),
   TextAlign.configure({ types: ["heading", "paragraph"] }),
+  TextDirection.configure({
+    types: [
+      "heading", "paragraph", "bulletList", "orderedList", "taskList", "blockquote",
+      "callout", "tableCell", "tableHeader",
+    ]
+  }),
   TaskList,
   TaskItem.configure({
     nested: true,

--- a/apps/client/src/features/editor/styles/core.css
+++ b/apps/client/src/features/editor/styles/core.css
@@ -21,6 +21,7 @@
   }
 
   p {
+    text-align: start;
     margin-top: 0.65em;
     margin-bottom: 0.65em;
   }
@@ -77,6 +78,11 @@
       var(--mantine-color-dark-8)
     );
     margin: 0;
+
+    &[dir="rtl"] {
+      border-right: 2px solid var(--mantine-color-gray-6);
+      border-left: none;
+    }
   }
 
   hr {

--- a/apps/client/src/features/editor/styles/table.css
+++ b/apps/client/src/features/editor/styles/table.css
@@ -42,7 +42,7 @@
               var(--mantine-color-dark-5)
       );
       font-weight: bold;
-      text-align: left;
+      text-align: start;
     }
 
     .column-resize-handle {

--- a/apps/client/src/features/editor/styles/title-editor.module.css
+++ b/apps/client/src/features/editor/styles/title-editor.module.css
@@ -1,0 +1,5 @@
+.titleEditor {
+    h1 {
+        unicode-bidi: plaintext;
+    }
+}

--- a/apps/client/src/features/editor/title-editor.tsx
+++ b/apps/client/src/features/editor/title-editor.tsx
@@ -1,4 +1,5 @@
 import "@/features/editor/styles/index.css";
+import classes from "@/features/editor/styles/title-editor.module.css";
 import React, { useEffect, useState } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { Document } from "@tiptap/extension-document";
@@ -144,5 +145,9 @@ export function TitleEditor({
     }
   }
 
-  return <EditorContent editor={titleEditor} onKeyDown={handleTitleKeyDown} />;
+  return <EditorContent 
+      className={classes.titleEditor}
+      editor={titleEditor}
+      onKeyDown={handleTitleKeyDown}
+    />;
 }

--- a/apps/client/src/features/page/tree/styles/tree.module.css
+++ b/apps/client/src/features/page/tree/styles/tree.module.css
@@ -95,6 +95,8 @@
     text-overflow: ellipsis;
     font-size: rem(14px);
     font-weight: 500;
+    unicode-bidi: plaintext;
+    text-align: left;
 }
 
 .arrow {

--- a/apps/server/src/collaboration/collaboration.util.ts
+++ b/apps/server/src/collaboration/collaboration.util.ts
@@ -40,7 +40,7 @@ import { generateHTML } from '../common/helpers/prosemirror/html';
 // see:https://github.com/ueberdosis/tiptap/issues/4089
 import { generateJSON } from '@tiptap/html';
 import { Node } from '@tiptap/pm/model';
-import TextDirection from "tiptap-text-direction";
+import { TextDirection } from './extensions/detect-direction';
 
 export const tiptapExtensions = [
   StarterKit.configure({
@@ -80,16 +80,9 @@ export const tiptapExtensions = [
   Mention,
   TextDirection.configure({
     types: [
-      'heading',
-      'paragraph',
-      'bulletList',
-      'orderedList',
-      'taskList',
-      'blockquote',
-      'callout',
-      'tableCell',
-      'tableHeader',
-    ],
+      "heading", "paragraph", "bulletList", "orderedList", "taskList", "blockquote",
+      "callout", "tableCell", "tableHeader",
+    ]
   }),
 ] as any;
 

--- a/apps/server/src/collaboration/collaboration.util.ts
+++ b/apps/server/src/collaboration/collaboration.util.ts
@@ -40,6 +40,7 @@ import { generateHTML } from '../common/helpers/prosemirror/html';
 // see:https://github.com/ueberdosis/tiptap/issues/4089
 import { generateJSON } from '@tiptap/html';
 import { Node } from '@tiptap/pm/model';
+import TextDirection from "tiptap-text-direction";
 
 export const tiptapExtensions = [
   StarterKit.configure({
@@ -76,7 +77,20 @@ export const tiptapExtensions = [
   Drawio,
   Excalidraw,
   Embed,
-  Mention
+  Mention,
+  TextDirection.configure({
+    types: [
+      'heading',
+      'paragraph',
+      'bulletList',
+      'orderedList',
+      'taskList',
+      'blockquote',
+      'callout',
+      'tableCell',
+      'tableHeader',
+    ],
+  }),
 ] as any;
 
 export function jsonToHtml(tiptapJson: any) {

--- a/apps/server/src/collaboration/extensions/detect-direction.ts
+++ b/apps/server/src/collaboration/extensions/detect-direction.ts
@@ -1,0 +1,225 @@
+// original code: https://github.com/amirhhashemi/tiptap-text-direction/blob/master/src/index.ts
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { EditorView } from "@tiptap/pm/view";
+
+const RTL = "\u0591-\u07FF\uFB1D-\uFDFD\uFE70-\uFEFC";
+const LTR =
+  "A-Za-z\u00C0-\u00D6\u00D8-\u00F6" +
+  "\u00F8-\u02B8\u0300-\u0590\u0800-\u1FFF\u200E\u2C00-\uFB1C" +
+  "\uFE00-\uFE6F\uFEFD-\uFFFF";
+
+const RTL_REGEX = new RegExp(`^[^${LTR}]*[${RTL}]`);
+const LTR_REGEX = new RegExp(`^[^${RTL}]*[${LTR}]`);
+
+export function getTextDirection(text: string): "ltr" | "rtl" | null {
+  if (!text) {
+    return null;
+  }
+  if (RTL_REGEX.test(text)) {
+    return "rtl";
+  }
+  if (LTR_REGEX.test(text)) {
+    return "ltr";
+  }
+  return null;
+}
+
+const validDirections = ["ltr", "rtl", "auto"] as const;
+type Direction = (typeof validDirections)[number];
+
+export interface TextDirectionOptions {
+  /**
+   * Node types for which you want to set the `dir` attribute
+   * (e.g. ["paragraph", "heading", "listItem"]).
+   */
+  types: string[];
+  /**
+   * If you want a default direction (e.g. "ltr" or "rtl") when
+   * no direction can be inferred from the node text.
+   */
+  defaultDirection: Direction | null;
+}
+
+/**
+ * A Tiptap extension for automatically detecting and updating
+ * the text direction (dir) on specific node types. It also
+ * exposes commands for manually setting and unsetting direction.
+ */
+export const TextDirection = Extension.create<TextDirectionOptions>({
+  name: "textDirection",
+
+  addOptions() {
+    return {
+      types: [],
+      defaultDirection: null,
+    };
+  },
+
+  /**
+   * We add a `dir` attribute to the configured node types.
+   * By default, `dir` is `null`, so it’s omitted unless we set it.
+   */
+  addGlobalAttributes() {
+    return [
+      {
+        types: this.options.types,
+        attributes: {
+          dir: {
+            default: null,
+            parseHTML: (element) =>
+              element.dir || this.options.defaultDirection,
+            renderHTML: (attributes) => {
+              // If it's the default direction, skip setting `dir`
+              if (attributes.dir === this.options.defaultDirection) {
+                return {};
+              }
+              return { dir: attributes.dir };
+            },
+          },
+        },
+      },
+    ];
+  },
+
+  /**
+   * Add commands to manually set/unset direction.
+   */
+  addCommands() {
+    return {
+      setTextDirection:
+        (direction: Direction) =>
+        ({ commands }) => {
+          if (!validDirections.includes(direction)) {
+            return false;
+          }
+          // Apply `dir` to all relevant node types
+          return this.options.types.every((type) =>
+            commands.updateAttributes(type, { dir: direction }),
+          );
+        },
+
+      unsetTextDirection:
+        () =>
+        ({ commands }) => {
+          return this.options.types.every((type) =>
+            commands.resetAttributes(type, "dir"),
+          );
+        },
+    };
+  },
+
+  /**
+   * Example keyboard shortcuts for quick direction switching.
+   */
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Alt-l": () => this.editor.commands.setTextDirection("ltr"),
+      "Mod-Alt-r": () => this.editor.commands.setTextDirection("rtl"),
+    };
+  },
+
+  /**
+   * The main logic is in the ProseMirror plugin: we track IME composition
+   * and update directions only when safe.
+   */
+  addProseMirrorPlugins() {
+    const { types } = this.options;
+    const pluginKey = new PluginKey("textDirectionPluginKey");
+
+    return [
+      new Plugin({
+        key: pluginKey,
+
+        // We store a small plugin state, just a flag for `isComposing`.
+        state: {
+          init() {
+            return { isComposing: false };
+          },
+          apply(tr, pluginValue) {
+            // We keep the same state unless we specifically update it ourselves
+            // in the handleDOMEvents below.
+            return { ...pluginValue };
+          },
+        },
+
+        props: {
+          // This is how ProseMirror suggests handling composition events.
+          // We do NOT rely on global `document.addEventListener(...)`.
+          handleDOMEvents: {
+            compositionstart: (view: EditorView, event: Event) => {
+              const state = pluginKey.getState(view.state);
+              state.isComposing = true;
+              return false; // allow normal handling
+            },
+            compositionend: (view: EditorView, event: Event) => {
+              const state = pluginKey.getState(view.state);
+              state.isComposing = false;
+
+              // Once composition ends, we can safely detect directions
+              // for any changed nodes.
+              const { tr } = view.state;
+              tr.setMeta("addToHistory", false);
+
+              let modified = false;
+              view.state.doc.descendants((node, pos) => {
+                if (!types.includes(node.type.name)) return;
+
+                // If there's no text, skip
+                if (!node.textContent) return;
+
+                const detected = getTextDirection(node.textContent);
+                const current = node.attrs.dir;
+                // Only update if it’s actually changed
+                if (detected !== current) {
+                  tr.setNodeAttribute(pos, "dir", detected ?? null);
+                  modified = true;
+                }
+              });
+
+              if (modified) {
+                view.dispatch(tr);
+              }
+
+              return false; // allow normal handling
+            },
+          },
+        },
+
+        // For non-IME text input (straight typing in English, etc.),
+        // we can automatically detect direction in `appendTransaction`.
+        appendTransaction: (transactions, oldState, newState) => {
+          const pluginState = pluginKey.getState(oldState);
+          // If we’re currently composing (IME in progress), skip
+          if (pluginState.isComposing) {
+            return null;
+          }
+
+          // If no actual doc change, do nothing
+          const docChanged = transactions.some((tr) => tr.docChanged);
+          if (!docChanged) {
+            return null;
+          }
+
+          const tr = newState.tr;
+          tr.setMeta("addToHistory", false);
+
+          let modified = false;
+          newState.doc.descendants((node, pos) => {
+            if (!types.includes(node.type.name)) return;
+
+            if (!node.textContent) return;
+            const detected = getTextDirection(node.textContent);
+            const current = node.attrs.dir;
+            if (detected !== current) {
+              tr.setNodeAttribute(pos, "dir", detected ?? null);
+              modified = true;
+            }
+          });
+
+          return modified ? tr : null;
+        },
+      }),
+    ];
+  },
+});

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "jszip": "^3.10.1",
     "linkifyjs": "^4.2.0",
     "marked": "^13.0.3",
+    "tiptap-text-direction": "^0.3.1",
     "uuid": "^11.1.0",
     "y-indexeddb": "^9.0.12",
     "yjs": "^13.6.20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       marked:
         specifier: ^13.0.3
         version: 13.0.3
+      tiptap-text-direction:
+        specifier: ^0.3.1
+        version: 0.3.1(@tiptap/core@2.10.3(@tiptap/pm@2.10.3))(@tiptap/pm@2.10.3)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -314,9 +317,6 @@ importers:
       tiptap-extension-global-drag-handle:
         specifier: ^0.1.16
         version: 0.1.18
-      tiptap-text-direction:
-        specifier: ^0.3.1
-        version: 0.3.1(@tiptap/core@2.10.3(@tiptap/pm@2.10.3))(@tiptap/pm@2.10.3)
       zod:
         specifier: ^3.23.8
         version: 3.24.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       tiptap-extension-global-drag-handle:
         specifier: ^0.1.16
         version: 0.1.18
+      tiptap-text-direction:
+        specifier: ^0.3.1
+        version: 0.3.1(@tiptap/core@2.10.3(@tiptap/pm@2.10.3))(@tiptap/pm@2.10.3)
       zod:
         specifier: ^3.23.8
         version: 3.24.2
@@ -7789,6 +7792,12 @@ packages:
 
   tiptap-extension-global-drag-handle@0.1.18:
     resolution: {integrity: sha512-jwFuy1K8DP3a4bFy76Hpc63w1Sil0B7uZ3mvhQomVvUFCU787Lg2FowNhn7NFzeyok761qY2VG+PZ/FDthWUdg==}
+
+  tiptap-text-direction@0.3.1:
+    resolution: {integrity: sha512-h3WerSUqesMDVzKcMAinMz0FaBqUiNd0KoiU/LahJaeV+jT1jkw9EQ7ixCwM+pvcIJTHfmzry/4gA5P5p0Al1A==}
+    peerDependencies:
+      '@tiptap/core': ^2.0.0
+      '@tiptap/pm': ^2.0.0
 
   tldts-core@6.1.78:
     resolution: {integrity: sha512-jS0svNsB99jR6AJBmfmEWuKIgz91Haya91Z43PATaeHJ24BkMoNRb/jlaD37VYjb0mYf6gRL/HOnvS1zEnYBiw==}
@@ -16941,6 +16950,11 @@ snapshots:
       '@popperjs/core': 2.11.8
 
   tiptap-extension-global-drag-handle@0.1.18: {}
+
+  tiptap-text-direction@0.3.1(@tiptap/core@2.10.3(@tiptap/pm@2.10.3))(@tiptap/pm@2.10.3):
+    dependencies:
+      '@tiptap/core': 2.10.3(@tiptap/pm@2.10.3)
+      '@tiptap/pm': 2.10.3
 
   tldts-core@6.1.78: {}
 


### PR DESCRIPTION
With this change, the browser detect the direction of each element of editor, so If we write in RTL language in a paragraph, the direction change automatically to RTL for that paragraph.

I test it only using inspect element and add this style.

The result is here, paragraphs with RTL text automatically aligned from right and the direction is correct for both LTR and RTL texts.

![image](https://github.com/user-attachments/assets/b89ea7fc-7370-4155-9c0c-8a772ddcbb48)
