### PR TITLE
feat(backend): forgot password

### DIFF
--- a/apps/server/src/core/auth/auth.controller.ts
+++ b/apps/server/src/core/auth/auth.controller.ts
@@ -19,6 +19,7 @@ import { AuthUser } from '../../common/decorators/auth-user.decorator';
 import { User, Workspace } from '@docmost/db/types/entity.types';
 import { AuthWorkspace } from '../../common/decorators/auth-workspace.decorator';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -31,6 +32,18 @@ export class AuthController {
   @Post('login')
   async login(@Req() req, @Body() loginInput: LoginDto) {
     return this.authService.login(loginInput, req.raw.workspaceId);
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Post('forgot-password')
+  async forgotPassword(
+    @Req() req,
+    @Body() forgotPasswordDto: ForgotPasswordDto,
+  ) {
+    return this.authService.forgotPassword(
+      forgotPasswordDto,
+      req.raw.workspaceId,
+    );
   }
 
   /* @HttpCode(HttpStatus.OK)

--- a/apps/server/src/core/auth/dto/forgot-password.dto.ts
+++ b/apps/server/src/core/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,15 @@
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  @IsOptional()
+  @IsString()
+  code: string;
+
+  @IsOptional()
+  @IsString()
+  newPassword: string;
+}

--- a/apps/server/src/core/auth/services/auth.service.ts
+++ b/apps/server/src/core/auth/services/auth.service.ts
@@ -15,6 +15,10 @@ import { comparePasswordHash, hashPassword } from '../../../common/helpers';
 import { ChangePasswordDto } from '../dto/change-password.dto';
 import { MailService } from '../../../integrations/mail/mail.service';
 import ChangePasswordEmail from '@docmost/transactional/emails/change-password-email';
+import { ForgotPasswordDto } from '../dto/forgot-password.dto';
+import { TemporaryCodeRepo } from '@docmost/db/repos/temporary-code/temporary-code.repo';
+import { randomBytes } from 'crypto';
+import ForgotPasswordEmail from '@docmost/transactional/emails/forgot-password-email';
 
 @Injectable()
 export class AuthService {
@@ -22,6 +26,7 @@ export class AuthService {
     private signupService: SignupService,
     private tokenService: TokenService,
     private userRepo: UserRepo,
+    private temporaryCodeRepo: TemporaryCodeRepo,
     private mailService: MailService,
   ) {}
 
@@ -44,6 +49,95 @@ export class AuthService {
 
     const tokens: TokensDto = await this.tokenService.generateTokens(user);
     return { tokens };
+  }
+
+  async forgotPassword(
+    forgotPasswordDto: ForgotPasswordDto,
+    workspaceId: string,
+  ) {
+    const user = await this.userRepo.findByEmail(
+      forgotPasswordDto.email,
+      workspaceId,
+      true,
+    );
+    if (!user) {
+      return;
+    }
+
+    if (
+      forgotPasswordDto.code == null ||
+      forgotPasswordDto.newPassword == null
+    ) {
+      // Generate 5-character temporary code
+      const code = randomBytes(8).toString('hex').slice(0, 5).toUpperCase();
+      const hashedCode = await hashPassword(code);
+      await this.temporaryCodeRepo.insertTemporaryCode({
+        code: hashedCode,
+        user_id: user.id,
+        workspace_id: user.workspaceId,
+        expires_at: new Date(new Date().getTime() + 5 * 60 * 1000), // should expires in 5 minute
+      });
+
+      const emailTemplate = ForgotPasswordEmail({
+        username: user.name,
+        code: code,
+      });
+      await this.mailService.sendToQueue({
+        to: user.email,
+        subject: 'Reset your password',
+        template: emailTemplate,
+      });
+
+      return;
+    }
+
+    // Get all temporary codes that are not expired
+    const temporaryCodes = await this.temporaryCodeRepo.findByUserId(
+      user.id,
+      user.workspaceId,
+    );
+    // Limit to the last 3 codes, so we have a total time window of 15 minutes
+    const validTemporaryCodes = temporaryCodes
+      .filter((code) => code.expires_at > new Date() && code.used_at == null)
+      .slice(0, 3);
+
+    for (const code of validTemporaryCodes) {
+      const validated = await comparePasswordHash(
+        forgotPasswordDto.code,
+        code.code,
+      );
+      if (validated) {
+        // Update the used_at field to the current time
+        await this.temporaryCodeRepo.updateTemporaryCode(
+          {
+            used_at: new Date(),
+          },
+          code.id,
+        );
+
+        const newPasswordHash = await hashPassword(
+          forgotPasswordDto.newPassword,
+        );
+        await this.userRepo.updateUser(
+          {
+            password: newPasswordHash,
+          },
+          user.id,
+          workspaceId,
+        );
+
+        const emailTemplate = ChangePasswordEmail({ username: user.name });
+        await this.mailService.sendToQueue({
+          to: user.email,
+          subject: 'Your password has been changed',
+          template: emailTemplate,
+        });
+
+        return;
+      }
+    }
+
+    throw new BadRequestException('Incorrect code');
   }
 
   async register(createUserDto: CreateUserDto, workspaceId: string) {

--- a/apps/server/src/database/migrations/20240903T124647-temporary-code.ts
+++ b/apps/server/src/database/migrations/20240903T124647-temporary-code.ts
@@ -1,0 +1,26 @@
+import { sql, Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable('temporary_codes')
+    .addColumn('id', 'uuid', (col) =>
+      col.primaryKey().defaultTo(sql`gen_uuid_v7()`),
+    )
+    .addColumn('code', 'varchar', (col) => col.notNull())
+    .addColumn('user_id', 'uuid', (col) =>
+      col.notNull().references('users.id').onDelete('cascade'),
+    )
+    .addColumn('workspace_id', 'uuid', (col) =>
+      col.references('workspaces.id').onDelete('cascade'),
+    )
+    .addColumn('expires_at', 'timestamptz', (col) => col.notNull())
+    .addColumn('used_at', 'timestamptz', (col) => col)
+    .addColumn('created_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable('temporary_codes').execute();
+}

--- a/apps/server/src/database/repos/temporary-code/temporary-code.repo.ts
+++ b/apps/server/src/database/repos/temporary-code/temporary-code.repo.ts
@@ -1,0 +1,63 @@
+import {
+  InsertableTemporaryCode,
+  TemporaryCode,
+  UpdatableTemporaryCode,
+} from '@docmost/db/types/entity.types';
+import { KyselyDB, KyselyTransaction } from '@docmost/db/types/kysely.types';
+import { dbOrTx } from '@docmost/db/utils';
+import { Injectable } from '@nestjs/common';
+import { InjectKysely } from 'nestjs-kysely';
+import { hashPassword } from 'src/common/helpers';
+
+@Injectable()
+export class TemporaryCodeRepo {
+  constructor(@InjectKysely() private readonly db: KyselyDB) {}
+
+  async insertTemporaryCode(
+    insertableTemporaryCode: InsertableTemporaryCode,
+    trx?: KyselyTransaction,
+  ) {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .insertInto('temporaryCodes')
+      .values(insertableTemporaryCode)
+      .returningAll()
+      .executeTakeFirst();
+  }
+
+  async findByUserId(
+    userId: string,
+    workspaceId: string,
+    trx?: KyselyTransaction,
+  ) {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .selectFrom('temporaryCodes')
+      .select([
+        'id',
+        'code',
+        'user_id',
+        'workspace_id',
+        'expires_at',
+        'used_at',
+        'created_at',
+      ])
+      .where('user_id', '=', userId)
+      .where('workspace_id', '=', workspaceId)
+      .orderBy('expires_at desc')
+      .execute();
+  }
+
+  async updateTemporaryCode(
+    updatableTemporaryCode: UpdatableTemporaryCode,
+    temporaryCodeId: string,
+    trx?: KyselyTransaction,
+  ) {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .updateTable('temporaryCodes')
+      .set({ ...updatableTemporaryCode })
+      .where('id', '=', temporaryCodeId)
+      .execute();
+  }
+}

--- a/apps/server/src/database/types/db.d.ts
+++ b/apps/server/src/database/types/db.d.ts
@@ -1,10 +1,15 @@
-import type { ColumnType } from "kysely";
+import type { ColumnType } from 'kysely';
 
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>;
 
-export type Int8 = ColumnType<string, bigint | number | string, bigint | number | string>;
+export type Int8 = ColumnType<
+  string,
+  bigint | number | string,
+  bigint | number | string
+>;
 
 export type Json = JsonValue;
 
@@ -185,6 +190,16 @@ export interface Workspaces {
   updatedAt: Generated<Timestamp>;
 }
 
+export interface TemporaryCodes {
+  id: Generated<string>;
+  code: string;
+  user_id: string;
+  workspace_id: string;
+  expires_at: Timestamp;
+  used_at: Timestamp | null;
+  created_at: Generated<Timestamp>;
+}
+
 export interface DB {
   attachments: Attachments;
   comments: Comments;
@@ -197,4 +212,5 @@ export interface DB {
   users: Users;
   workspaceInvitations: WorkspaceInvitations;
   workspaces: Workspaces;
+  temporaryCodes: TemporaryCodes;
 }

--- a/apps/server/src/database/types/entity.types.ts
+++ b/apps/server/src/database/types/entity.types.ts
@@ -11,6 +11,7 @@ import {
   GroupUsers,
   SpaceMembers,
   WorkspaceInvitations,
+  TemporaryCodes,
 } from './db';
 
 // Workspace
@@ -71,3 +72,8 @@ export type UpdatableComment = Updateable<Omit<Comments, 'id'>>;
 export type Attachment = Selectable<Attachments>;
 export type InsertableAttachment = Insertable<Attachments>;
 export type UpdatableAttachment = Updateable<Omit<Attachments, 'id'>>;
+
+// Temporary Code
+export type TemporaryCode = Selectable<TemporaryCodes>;
+export type InsertableTemporaryCode = Insertable<TemporaryCodes>;
+export type UpdatableTemporaryCode = Updateable<Omit<TemporaryCodes, 'id'>>;

--- a/apps/server/src/integrations/environment/environment.service.ts
+++ b/apps/server/src/integrations/environment/environment.service.ts
@@ -62,9 +62,9 @@ export class EnvironmentService {
   getAwsS3Endpoint(): string {
     return this.configService.get<string>('AWS_S3_ENDPOINT');
   }
-  
+
   getAwsS3ForcePathStyle(): boolean {
-    return this.configService.get<boolean>('AWS_S3_FORCE_PATH_STYLE')
+    return this.configService.get<boolean>('AWS_S3_FORCE_PATH_STYLE');
   }
 
   getAwsS3Url(): string {

--- a/apps/server/src/integrations/import/import.module.ts
+++ b/apps/server/src/integrations/import/import.module.ts
@@ -4,6 +4,6 @@ import { ImportController } from './import.controller';
 
 @Module({
   providers: [ImportService],
-  controllers: [ImportController]
+  controllers: [ImportController],
 })
 export class ImportModule {}

--- a/apps/server/src/integrations/mail/providers/mail.provider.ts
+++ b/apps/server/src/integrations/mail/providers/mail.provider.ts
@@ -27,11 +27,14 @@ export const mailDriverConfigProvider = {
     switch (driver) {
       case MailOption.SMTP:
         let auth = undefined;
-        if (environmentService.getSmtpUsername() && environmentService.getSmtpPassword()) {
+        if (
+          environmentService.getSmtpUsername() &&
+          environmentService.getSmtpPassword()
+        ) {
           auth = {
-              user: environmentService.getSmtpUsername(),
-              pass: environmentService.getSmtpPassword(),
-            };
+            user: environmentService.getSmtpUsername(),
+            pass: environmentService.getSmtpPassword(),
+          };
         }
         return {
           driver,

--- a/apps/server/src/integrations/transactional/emails/forgot-password-email.tsx
+++ b/apps/server/src/integrations/transactional/emails/forgot-password-email.tsx
@@ -1,0 +1,27 @@
+import { Section, Text } from '@react-email/components';
+import * as React from 'react';
+import { content, paragraph } from '../css/styles';
+import { MailBody } from '../partials/partials';
+
+interface Props {
+    username: string;
+    code: string;
+}
+
+export const ForgotPasswordEmail = ({ username, code }: Props) => {
+    return (
+        <MailBody>
+          <Section style={content}>
+            <Text style={paragraph}>Hi {username},</Text>
+            <Text style={paragraph}>
+              The code for resetting your password is: <strong>{code}</strong>.
+            </Text>
+            <Text style={paragraph}>
+              If you did not request a password reset, please ignore this email.
+            </Text>
+          </Section>
+        </MailBody>
+      );
+}
+
+export default ForgotPasswordEmail;

--- a/apps/server/src/integrations/transactional/utils/utils.ts
+++ b/apps/server/src/integrations/transactional/utils/utils.ts
@@ -1,6 +1,6 @@
 export const formatDate = (date: Date) => {
-  new Intl.DateTimeFormat("en", {
-    dateStyle: "medium",
-    timeStyle: "medium",
+  new Intl.DateTimeFormat('en', {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
   }).format(date);
 };


### PR DESCRIPTION
Partially closes #182, still need to implement the frontend side of things.

How this works:
```http
POST http://API_URL/auth/forgot-password
Content-Type: application/json
{
  "email": "foo@example.com"
}
```

Then check user's email, a code should be provided. If their email don't exist, it will always return 200 OK response. This is intended to protect the privacy & security of the user.

Then, re-hit the endpoint.
```http
POST http://API_URL/auth/forgot-password
Content-Type: application/json

{
  "email": "foo@example.com",
  "code": "XXXXX",
  "newPassword": "very strong password"
} 
```

A security notice email will be sent if the code is correct. If not, a 400 BAD REQUEST response of "Incorrect code" will be sent.