### PR TITLE
fix: send "invitation accepted" email to inviter

### DIFF
--- a/apps/server/src/core/workspace/services/workspace-invitation.service.ts
+++ b/apps/server/src/core/workspace/services/workspace-invitation.service.ts
@@ -248,7 +248,7 @@ export class WorkspaceInvitationService {
       });
 
       await this.mailService.sendToQueue({
-        to: invitation.email,
+        to: invitedByUser.email,
         subject: `${newUser.name} has accepted your Docmost invite`,
         template: emailTemplate,
       });


### PR DESCRIPTION
The email says "${invitedUserName} has accepted your invitation ...", so it makes more sense to send it to the inviter instead of the invitee.