### PR TITLE
fix: use environment service for refresh token's expiration

### DIFF
--- a/apps/server/src/core/auth/services/token.service.ts
+++ b/apps/server/src/core/auth/services/token.service.ts
@@ -31,7 +31,7 @@ export class TokenService {
       workspaceId,
       type: JwtType.REFRESH,
     };
-    const expiresIn = '30d'; // todo: fix
+    const expiresIn = this.environmentService.getJwtTokenExpiresIn();
     return this.jwtService.sign(payload, { expiresIn });
   }
 


### PR DESCRIPTION
Use the environment service for the `JWT_TOKEN_EXPIRES_IN` value instead of `30d` hardcoded.