### PR TITLE
fix: disconnect Redis health checker

### DIFF
--- a/apps/server/src/integrations/health/redis.health.ts
+++ b/apps/server/src/integrations/health/redis.health.ts
@@ -22,6 +22,7 @@ export class RedisHealthIndicator extends HealthIndicator {
       });
 
       await redis.ping();
+      redis.disconnect();
       return this.getStatus(key, true);
     } catch (e) {
       this.logger.error(e);


### PR DESCRIPTION
I have both Docker and Uptime Kuma pinging the `/health` endpoint and after a few days my tiny VPS explodes with errors like:
```
docmost-1  | [ioredis] Unhandled error event: ReplyError: ERR max number of clients reached
docmost-1  |     at parseError (/app/node_modules/.pnpm/redis-parser@3.0.0/node_modules/redis-parser/lib/parser.js:179:12)
docmost-1  |     at parseType (/app/node_modules/.pnpm/redis-parser@3.0.0/node_modules/redis-parser/lib/parser.js:302:14)
```

Turns out that, if we don't disconnect the Redis client, they keep accumulating and don't timeout by default. To verify this in practice:
```
$ curl http://localhost:3000/api/health
{"status":"ok","info":{"database":{"status":"up"},"redis":{"status":"up"}},"error":{},"details":{"database":{"status":"up"},"redis":{"status":"up"}}}

$ docker exec -it docmost-redis-1 redis-cli CLIENT LIST | wc -l                                                                                                                        
10

$ curl http://localhost:3000/api/health
{"status":"ok","info":{"database":{"status":"up"},"redis":{"status":"up"}},"error":{},"details":{"database":{"status":"up"},"redis":{"status":"up"}}}

$ docker exec -it docmost-redis-1 redis-cli CLIENT LIST | wc -l                                                                                                                        
11
...
```
Here we see that after each call to the `/health` endpoint, the number of clients connected to Redis increases.

In this diff, we disconnect the Redis client after the `ping`, and the problem now goes away:
```
$ curl http://localhost:3000/api/health
{"status":"ok","info":{"database":{"status":"up"},"redis":{"status":"up"}},"error":{},"details":{"database":{"status":"up"},"redis":{"status":"up"}}}

$ docker exec -it docmost-redis-1 redis-cli CLIENT LIST | wc -l                                                                                                                        
8

$ curl http://localhost:3000/api/health
{"status":"ok","info":{"database":{"status":"up"},"redis":{"status":"up"}},"error":{},"details":{"database":{"status":"up"},"redis":{"status":"up"}}}

$ docker exec -it docmost-redis-1 redis-cli CLIENT LIST | wc -l                                                                                                                        
8

$ curl http://localhost:3000/api/health
{"status":"ok","info":{"database":{"status":"up"},"redis":{"status":"up"}},"error":{},"details":{"database":{"status":"up"},"redis":{"status":"up"}}}

$ docker exec -it docmost-redis-1 redis-cli CLIENT LIST | wc -l                                                                                                                        
8
...
```