### PR TITLE
fix: horizontal scrollbar always shown on math block

### DIFF
--- a/apps/client/src/features/editor/components/math/math.module.css
+++ b/apps/client/src/features/editor/components/math/math.module.css
@@ -33,7 +33,7 @@
     border-radius: 4px;
     transition: background-color 0.2s;
     margin: 0 0.1rem;
-    overflow-x: scroll;
+    overflow-x: auto;
 
     .textInput {
         width: 400px;


### PR DESCRIPTION
Setting the containers overflow-x rule to auto removed the scrollbar when not needed, but allows it to popup when needed.

Change confirmed to hide scrollbar and show if equation does not fit the width on (tested with responsive design mode):
- Chromium 126.0.6478.126
- Firefox 128.0.3 (64-bit)

Aims to fix (#292)