### PR TITLE
fix: base64 encoded drawio image decoded to Latin-1 instead of UTF-8

### DIFF
--- a/apps/client/src/lib/utils.ts
+++ b/apps/client/src/lib/utils.ts
@@ -53,11 +53,21 @@ export async function svgStringToFile(
   return new File([blob], fileName, { type: "image/svg+xml" });
 }
 
+// Convert a string holding Base64 encoded UTF-8 data into a proper UTF-8 encoded string
+// as a replacement for `atob`.
+// based on: https://developer.mozilla.org/en-US/docs/Glossary/Base64
+function decodeBase64(base64: string): string {
+  // convert string to bytes
+  const bytes = Uint8Array.from(atob(base64), (m) => m.codePointAt(0));
+  // properly decode bytes to UTF-8 encoded string
+  return new TextDecoder().decode(bytes);
+}
+
 export function decodeBase64ToSvgString(base64Data: string): string {
   const base64Prefix = 'data:image/svg+xml;base64,';
   if (base64Data.startsWith(base64Prefix)) {
       base64Data = base64Data.replace(base64Prefix, '');
   }
 
-  return atob(base64Data);
+  return decodeBase64(base64Data);
 }


### PR DESCRIPTION
Drawio encodes the image data as Base64 for sending. The client decodes the Base64 to text assuming Latin-1 encoding, which is incompatible to UTF-8 used by Drawio messing up non-ASCII characters (see issue #257).

This fix wraps the decoding function `btoa` by decoding to binary first and encoding the binary to UTF-8.

This fix allows to use UTF-8 characters in drawio diagrams without messing up the output.

Solution based on: https://developer.mozilla.org/en-US/docs/Glossary/Base64