### PR TITLE
fix: Add alignment styles for task list items

### DIFF
--- a/apps/client/src/features/editor/styles/task-list.css
+++ b/apps/client/src/features/editor/styles/task-list.css
@@ -13,6 +13,8 @@ ul[data-type="taskList"] {
             flex: 0 0 auto;
             margin-right: 0.5rem;
             user-select: none;
+            display: flex;
+            align-items: center;
         }
 
         > div {


### PR DESCRIPTION
Labels for task list items are not aligned properly. The commit adds flex and align-items properties to the labels so that the labels are displayed vertically to the center of the parent element

![3](https://github.com/user-attachments/assets/0366258d-fe07-4b16-bbbd-c4bc99f78689)
![chrome_QOehIYMkWP](https://github.com/user-attachments/assets/be28dfb4-c3b6-42a1-bbd0-7b200990bf4b)


Before:
```
ul[data-type=taskList] li>label {
    flex: 0 0 auto;
    margin-right: .5rem;
    -webkit-user-select: none;
    user-select: none;
}
```

After:
```
ul[data-type=taskList] li>label {
    flex: 0 0 auto;
    margin-right: .5rem;
    -webkit-user-select: none;
    user-select: none;
    display: flex;
    align-items: center;
}
```