### PR TITLE
feat: set file size in .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,5 @@ SMTP_IGNORETLS=false
 # Postmark driver config
 POSTMARK_TOKEN=
 
+# File uploads
+MAX_FILE_SIZE=50MB

--- a/apps/server/src/core/attachment/attachment.constants.ts
+++ b/apps/server/src/core/attachment/attachment.constants.ts
@@ -16,4 +16,4 @@ export const inlineFileExtensions = [
   '.mp4',
   '.mov',
 ];
-export const MAX_FILE_SIZE = '50MB';
+export const MAX_FILE_SIZE = process.env.MAX_FILE_SIZE ?? '50MB';


### PR DESCRIPTION
Give the option to users to set the max file size using the `MAX_FILE_SIZE` variable in the `.env` config

if no size is provided, 50MB will be used as the default value.

fixes #382 , closes #349 , closes #170