### PR TITLE
fix: remove space tree delete shortcut key

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,10 @@
       "apps/*",
       "packages/*"
     ]
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "react-arborist@3.4.0": "patches/react-arborist@3.4.0.patch"
+    }
   }
 }

--- a/patches/react-arborist@3.4.0.patch
+++ b/patches/react-arborist@3.4.0.patch
@@ -1,0 +1,33 @@
+diff --git a/dist/module/components/default-container.js b/dist/module/components/default-container.js
+index 47724f59b482454fe3144dbb98bd16d3df6a9c17..2285e35ea0073a773b7b74e22758056fd3514c1a 100644
+--- a/dist/module/components/default-container.js
++++ b/dist/module/components/default-container.js
+@@ -34,28 +34,6 @@ export function DefaultContainer() {
+                 return;
+             }
+             if (e.key === "Backspace") {
+-                if (!tree.props.onDelete)
+-                    return;
+-                const ids = Array.from(tree.selectedIds);
+-                if (ids.length > 1) {
+-                    let nextFocus = tree.mostRecentNode;
+-                    while (nextFocus && nextFocus.isSelected) {
+-                        nextFocus = nextFocus.nextSibling;
+-                    }
+-                    if (!nextFocus)
+-                        nextFocus = tree.lastNode;
+-                    tree.focus(nextFocus, { scroll: false });
+-                    tree.delete(Array.from(ids));
+-                }
+-                else {
+-                    const node = tree.focusedNode;
+-                    if (node) {
+-                        const sib = node.nextSibling;
+-                        const parent = node.parent;
+-                        tree.focus(sib || parent, { scroll: false });
+-                        tree.delete(node);
+-                    }
+-                }
+                 return;
+             }
+             if (e.key === "Tab" && !e.shiftKey) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  react-arborist@3.4.0:
+    hash: gjrtleyvvmuvu5j5zdnhxauhsu
+    path: patches/react-arborist@3.4.0.patch
+
 importers:
 
   .:
@@ -263,7 +268,7 @@ importers:
         version: 18.3.1
       react-arborist:
         specifier: ^3.4.0
-        version: 3.4.0(@types/node@22.5.2)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.4.0(patch_hash=gjrtleyvvmuvu5j5zdnhxauhsu)(@types/node@22.5.2)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-clear-modal:
         specifier: ^2.0.9
         version: 2.0.9(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -15434,7 +15439,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  react-arborist@3.4.0(@types/node@22.5.2)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-arborist@3.4.0(patch_hash=gjrtleyvvmuvu5j5zdnhxauhsu)(@types/node@22.5.2)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dnd: 14.0.5(@types/node@22.5.2)(@types/react@18.3.5)(react@18.3.1)


### PR DESCRIPTION
In this PR, we patch the [react-arborist](https://www.npmjs.com/package/react-arborist) (used for space tree) package to remove the backspace delete shortcut key.
Closed https://github.com/docmost/docmost/issues/372.