### PR TITLE
add `COPY patches` on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ COPY --from=builder /app/packages/editor-ext/package.json /app/packages/editor-e
 COPY --from=builder /app/package.json /app/package.json
 COPY --from=builder /app/pnpm*.yaml /app/
 
+# Copy patches
+COPY --from=builder /app/patches /app/patches
+
 RUN npm install -g pnpm
 
 RUN chown -R node:node /app


### PR DESCRIPTION
Hi.

I've added missing COPY patches in Dockerfile.

without COPY patches, docker build must be failed.

```
0.586 Scope: all 3 workspace projects
0.742  ENOENT  ENOENT: no such file or directory, open '/app/patches/react-arborist@3.4.0.patch'
0.742 
0.742 pnpm: ENOENT: no such file or directory, open '/app/patches/react-arborist@3.4.0.patch'
0.742     at async open (node:internal/fs/promises:637:25)
0.742     at async Object.readFile (node:internal/fs/promises:1246:14)
0.742     at async createBase32HashFromFile (/usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:10395:23)
0.742     at async /usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:140353:17
0.742     at async /usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:140330:24
0.742     at async Promise.all (index 0)
0.742     at async pMapValue (/usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:140329:7)
0.742     at async _install (/usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:196676:134)
0.742     at async mutateModules (/usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:196635:23)
0.742     at async recursive (/usr/local/lib/node_modules/pnpm/dist/pnpm.cjs:198153:50)
```