### PR TITLE
Fix: breadcrumb clipping

### DIFF
--- a/apps/client/src/features/page/components/breadcrumbs/breadcrumb.module.css
+++ b/apps/client/src/features/page/components/breadcrumbs/breadcrumb.module.css
@@ -1,11 +1,11 @@
 .breadcrumbs {
-    flex: 1 1 auto;
     display: flex;
     align-items: center;
     overflow: hidden;
 
     a {
         color: var(--mantine-color-default-color);
+        line-height: inherit;
     }
 
     .mantine-Breadcrumbs-breadcrumb {


### PR DESCRIPTION
Hopefully fixes #410.

Before: 
![before](https://github.com/user-attachments/assets/679c18aa-401f-4626-83a8-441faebc8eda)

After:
![after](https://github.com/user-attachments/assets/bc9c2d98-acc1-4064-abcf-4043c0020716)