### PR TITLE
fix: properly support redis database numbers

### DIFF
--- a/apps/server/src/collaboration/collaboration.gateway.ts
+++ b/apps/server/src/collaboration/collaboration.gateway.ts
@@ -36,6 +36,7 @@ export class CollaborationGateway {
           port: this.redisConfig.port,
           options: {
             password: this.redisConfig.password,
+            db: this.redisConfig.db,
             retryStrategy: createRetryStrategy(),
           },
         }),

--- a/apps/server/src/common/helpers/utils.ts
+++ b/apps/server/src/common/helpers/utils.ts
@@ -18,15 +18,25 @@ export async function comparePasswordHash(
 export type RedisConfig = {
   host: string;
   port: number;
+  db: number;
   password?: string;
 };
 
 export function parseRedisUrl(redisUrl: string): RedisConfig {
   // format - redis[s]://[[username][:password]@][host][:port][/db-number]
-  const { hostname, port, password } = new URL(redisUrl);
+  const { hostname, port, password, pathname } = new URL(redisUrl);
   const portInt = parseInt(port, 10);
 
-  return { host: hostname, port: portInt, password };
+  let db: number = 0;
+  // extract db value if present
+  if (pathname.length > 1) {
+    const value = pathname.slice(1);
+    if (!isNaN(parseInt(value))){
+      db = parseInt(value, 10);
+    }
+  }
+
+  return { host: hostname, port: portInt, password, db };
 }
 
 export function createRetryStrategy() {

--- a/apps/server/src/integrations/queue/queue.module.ts
+++ b/apps/server/src/integrations/queue/queue.module.ts
@@ -15,6 +15,7 @@ import { QueueName } from './constants';
             host: redisConfig.host,
             port: redisConfig.port,
             password: redisConfig.password,
+            db: redisConfig.db,
             retryStrategy: createRetryStrategy(),
           },
           defaultJobOptions: {


### PR DESCRIPTION
Fix to properly support redis database numbers.
`REDIS_URL=redis://127.0.0.1:6379/1`

Closes https://github.com/docmost/docmost/issues/498.