### PR TITLE
feat: add `HOST` env option to listen on a different interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 APP_URL=http://localhost:3000
 PORT=3000
 
+# the interface to listen on (use '::' for ipv6 support)
+HOST=0.0.0.0
+
 # make sure to replace this.
 APP_SECRET=REPLACE_WITH_LONG_SECRET
 

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -65,7 +65,7 @@ async function bootstrap() {
   app.useGlobalInterceptors(new TransformHttpResponseInterceptor());
   app.enableShutdownHooks();
 
-  await app.listen(process.env.PORT || 3000, '0.0.0.0');
+  await app.listen(process.env.PORT || 3000, process.env.HOST || '0.0.0.0');
 }
 
 bootstrap();


### PR DESCRIPTION
This PR adds the `HOST` env variable to let users choose which interface the webapp should listen on.

I think it would be preferable for `::` which listens on IPv4 & IPv6 to be the default in the future as that's what most servers do, and IPv6 adoption is increasing. For now though, this change allows users to enable support manually while keeping existing configs intact.
