### PR TITLE
fix: remove docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   docmost:
     image: docmost/docmost:latest


### PR DESCRIPTION
`version` is now obsolete in docker compose:

> WARN[0000] /root/docmost/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

https://github.com/compose-spec/compose-spec/blob/bd68b92774bf1a86c647d40ce6076918aba18835/spec.md?plain=1#L187-L195

https://github.com/docker/compose/issues/11628