### PR TITLE
Fix: Ensure only one emoji list appears 

### DIFF
--- a/apps/client/src/components/ui/emoji-picker.tsx
+++ b/apps/client/src/components/ui/emoji-picker.tsx
@@ -8,6 +8,7 @@ import {
 import { useClickOutside, useDisclosure, useWindowEvent } from "@mantine/hooks";
 import { Suspense } from "react";
 const Picker = React.lazy(() => import("@emoji-mart/react"));
+import { useTranslation } from "react-i18next";
 
 export interface EmojiPickerInterface {
   onEmojiSelect: (emoji: any) => void;
@@ -22,6 +23,7 @@ function EmojiPicker({
   removeEmojiAction,
   readOnly,
 }: EmojiPickerInterface) {
+  const { t } = useTranslation();
   const [opened, handlers] = useDisclosure(false);
   const { colorScheme } = useMantineColorScheme();
   const [target, setTarget] = useState<HTMLElement | null>(null);
@@ -88,7 +90,7 @@ function EmojiPicker({
           }}
           onClick={handleRemoveEmoji}
         >
-          Remove
+          {t("Remove")}
         </Button>
       </Popover.Dropdown>
     </Popover>

--- a/apps/client/src/components/ui/emoji-picker.tsx
+++ b/apps/client/src/components/ui/emoji-picker.tsx
@@ -1,20 +1,19 @@
-import React, { ReactNode,useRef,useEffect  } from 'react';
+import React, { ReactNode, useState } from "react";
 import {
   ActionIcon,
   Popover,
   Button,
   useMantineColorScheme,
-} from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
-import { Suspense } from 'react';
-const Picker = React.lazy(() => import('@emoji-mart/react'));
+} from "@mantine/core";
+import { useClickOutside, useDisclosure } from "@mantine/hooks";
+import { Suspense } from "react";
+const Picker = React.lazy(() => import("@emoji-mart/react"));
 
 export interface EmojiPickerInterface {
   onEmojiSelect: (emoji: any) => void;
   icon: ReactNode;
   removeEmojiAction: () => void;
   readOnly: boolean;
- 
 }
 
 function EmojiPicker({
@@ -25,6 +24,14 @@ function EmojiPicker({
 }: EmojiPickerInterface) {
   const [opened, handlers] = useDisclosure(false);
   const { colorScheme } = useMantineColorScheme();
+  const [target, setTarget] = useState<HTMLElement | null>(null);
+  const [dropdown, setDropdown] = useState<HTMLDivElement | null>(null);
+
+  useClickOutside(
+    () => handlers.close(),
+    ["mousedown", "touchstart"],
+    [dropdown, target],
+  );
 
   const handleEmojiSelect = (emoji) => {
     onEmojiSelect(emoji);
@@ -35,45 +42,24 @@ function EmojiPicker({
     removeEmojiAction();
     handlers.close();
   };
-  const targetRef = useRef(null); 
-  const dropdownRef = useRef(null);
-  
-  useEffect(() => {
-    const closeOpenMenus = (e: any) => {
-      if (
-        opened &&
-        targetRef.current &&
-        dropdownRef.current &&
-        !targetRef.current.contains(e.target) &&
-        !dropdownRef.current.contains(e.target)
-      ) {
-        handlers.close();
-      }
-    };
-
-      document.addEventListener('mousedown', closeOpenMenus);
-    return () => {
-      document.removeEventListener('mousedown', closeOpenMenus);
-    };
-  }, [opened]);
 
   return (
     <Popover
-    opened={opened}
+      opened={opened}
       onClose={handlers.close}
       width={332}
       position="bottom"
       disabled={readOnly}
     >
-      <Popover.Target ref={targetRef}>
-        <ActionIcon c="gray" variant="transparent" onClick={handlers.toggle} >
+      <Popover.Target ref={setTarget}>
+        <ActionIcon c="gray" variant="transparent" onClick={handlers.toggle}>
           {icon}
         </ActionIcon>
       </Popover.Target>
-      <Popover.Dropdown bg="000" style={{ border: 'none' }} ref={dropdownRef}>
+      <Popover.Dropdown bg="000" style={{ border: "none" }} ref={setDropdown}>
         <Suspense fallback={null}>
           <Picker
-            data={async () => (await import('@emoji-mart/data')).default}
+            data={async () => (await import("@emoji-mart/data")).default}
             onEmojiSelect={handleEmojiSelect}
             perLine={8}
             skinTonePosition="search"
@@ -85,10 +71,10 @@ function EmojiPicker({
           c="gray"
           size="xs"
           style={{
-            position: 'absolute',
+            position: "absolute",
             zIndex: 2,
-            bottom: '1rem',
-            right: '1rem',
+            bottom: "1rem",
+            right: "1rem",
           }}
           onClick={handleRemoveEmoji}
         >

--- a/apps/client/src/components/ui/emoji-picker.tsx
+++ b/apps/client/src/components/ui/emoji-picker.tsx
@@ -70,7 +70,7 @@ function EmojiPicker({
           {icon}
         </ActionIcon>
       </Popover.Target>
-      <Popover.Dropdown bg="000" style={{ border: 'none' }} ref={ref2}>
+      <Popover.Dropdown bg="000" style={{ border: 'none' }} ref={dropdownRef}>
         <Suspense fallback={null}>
           <Picker
             data={async () => (await import('@emoji-mart/data')).default}

--- a/apps/client/src/components/ui/emoji-picker.tsx
+++ b/apps/client/src/components/ui/emoji-picker.tsx
@@ -5,7 +5,7 @@ import {
   Button,
   useMantineColorScheme,
 } from "@mantine/core";
-import { useClickOutside, useDisclosure } from "@mantine/hooks";
+import { useClickOutside, useDisclosure, useWindowEvent } from "@mantine/hooks";
 import { Suspense } from "react";
 const Picker = React.lazy(() => import("@emoji-mart/react"));
 
@@ -33,6 +33,15 @@ function EmojiPicker({
     [dropdown, target],
   );
 
+  // We need this because the default Mantine popover closeOnEscape does not work
+  useWindowEvent("keydown", (event) => {
+    if (opened && event.key === "Escape") {
+      event.stopPropagation();
+      event.preventDefault();
+      handlers.close();
+    }
+  });
+
   const handleEmojiSelect = (emoji) => {
     onEmojiSelect(emoji);
     handlers.close();
@@ -50,6 +59,7 @@ function EmojiPicker({
       width={332}
       position="bottom"
       disabled={readOnly}
+      closeOnEscape={true}
     >
       <Popover.Target ref={setTarget}>
         <ActionIcon c="gray" variant="transparent" onClick={handlers.toggle}>

--- a/apps/client/src/components/ui/emoji-picker.tsx
+++ b/apps/client/src/components/ui/emoji-picker.tsx
@@ -70,7 +70,7 @@ function EmojiPicker({
           {icon}
         </ActionIcon>
       </Popover.Target>
-      <Popover.Dropdown bg="000" style={{ border: 'none' }} ref={dropdownRef}>
+      <Popover.Dropdown bg="000" style={{ border: 'none' }} ref={ref2}>
         <Suspense fallback={null}>
           <Picker
             data={async () => (await import('@emoji-mart/data')).default}

--- a/apps/client/src/components/ui/emoji-picker.tsx
+++ b/apps/client/src/components/ui/emoji-picker.tsx
@@ -7,7 +7,8 @@ import {
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { Suspense } from 'react';
-
+import { nodeIdAtom } from '@/features/page/tree/atoms/node-id-atom.ts';
+import { useAtom } from "jotai";
 const Picker = React.lazy(() => import('@emoji-mart/react'));
 
 export interface EmojiPickerInterface {
@@ -15,6 +16,7 @@ export interface EmojiPickerInterface {
   icon: ReactNode;
   removeEmojiAction: () => void;
   readOnly: boolean;
+  nodeId:string;
 }
 
 function EmojiPicker({
@@ -22,30 +24,32 @@ function EmojiPicker({
   icon,
   removeEmojiAction,
   readOnly,
+  nodeId,
 }: EmojiPickerInterface) {
   const [opened, handlers] = useDisclosure(false);
   const { colorScheme } = useMantineColorScheme();
+  const [nodeIdValueAtom,setNodeIdValueAtom]=useAtom(nodeIdAtom)
 
   const handleEmojiSelect = (emoji) => {
     onEmojiSelect(emoji);
-    handlers.close();
+    setNodeIdValueAtom(null);
   };
 
   const handleRemoveEmoji = () => {
     removeEmojiAction();
-    handlers.close();
+    setNodeIdValueAtom(null);
   };
 
   return (
     <Popover
-      opened={opened}
+      opened={nodeIdValueAtom===nodeId}
       onClose={handlers.close}
       width={332}
       position="bottom"
       disabled={readOnly}
     >
       <Popover.Target>
-        <ActionIcon c="gray" variant="transparent" onClick={handlers.toggle}>
+        <ActionIcon c="gray" variant="transparent" onClick={()=>setNodeIdValueAtom((prev:string|null)=>prev===nodeId?null:nodeId)}>
           {icon}
         </ActionIcon>
       </Popover.Target>

--- a/apps/client/src/features/page/tree/atoms/node-id-atom.ts
+++ b/apps/client/src/features/page/tree/atoms/node-id-atom.ts
@@ -1,0 +1,2 @@
+import { atom } from "jotai";
+export const nodeIdAtom=atom<string|null>(null);

--- a/apps/client/src/features/page/tree/atoms/node-id-atom.ts
+++ b/apps/client/src/features/page/tree/atoms/node-id-atom.ts
@@ -1,2 +1,0 @@
-import { atom } from "jotai";
-export const nodeIdAtom=atom<string|null>(null);

--- a/apps/client/src/features/page/tree/components/space-tree.tsx
+++ b/apps/client/src/features/page/tree/components/space-tree.tsx
@@ -342,8 +342,7 @@ function Node({ node, style, dragHandle, tree }: NodeRendererProps<any>) {
               )
             }
             readOnly={tree.props.disableEdit as boolean}
-            removeEmojiAction={handleRemoveEmoji}
-                  
+            removeEmojiAction={handleRemoveEmoji}      
           />
         </div>
 

--- a/apps/client/src/features/page/tree/components/space-tree.tsx
+++ b/apps/client/src/features/page/tree/components/space-tree.tsx
@@ -343,7 +343,7 @@ function Node({ node, style, dragHandle, tree }: NodeRendererProps<any>) {
             }
             readOnly={tree.props.disableEdit as boolean}
             removeEmojiAction={handleRemoveEmoji}
-            nodeId={node.id}
+                  
           />
         </div>
 

--- a/apps/client/src/features/page/tree/components/space-tree.tsx
+++ b/apps/client/src/features/page/tree/components/space-tree.tsx
@@ -15,7 +15,8 @@ import {
   IconChevronDown,
   IconChevronRight,
   IconDotsVertical,
-  IconFileDescription, IconFileExport,
+  IconFileDescription,
+  IconFileExport,
   IconLink,
   IconPlus,
   IconPointFilled,
@@ -139,13 +140,13 @@ export default function SpaceTree({ spaceId, readOnly }: SpaceTreeProps) {
             flatTreeItems = [
               ...flatTreeItems,
               ...children.filter(
-                (child) => !flatTreeItems.some((item) => item.id === child.id)
+                (child) => !flatTreeItems.some((item) => item.id === child.id),
               ),
             ];
           };
 
           const fetchPromises = ancestors.map((ancestor) =>
-            fetchAndUpdateChildren(ancestor)
+            fetchAndUpdateChildren(ancestor),
           );
 
           // Wait for all fetch operations to complete
@@ -159,7 +160,7 @@ export default function SpaceTree({ spaceId, readOnly }: SpaceTreeProps) {
             const updatedTree = appendNodeChildren(
               data,
               rootChild.id,
-              rootChild.children
+              rootChild.children,
             );
             setData(updatedTree);
 
@@ -254,7 +255,7 @@ function Node({ node, style, dragHandle, tree }: NodeRendererProps<any>) {
       const updatedTreeData = appendNodeChildren(
         treeData,
         node.data.id,
-        childrenTree
+        childrenTree,
       );
 
       setTreeData(updatedTreeData);
@@ -342,7 +343,7 @@ function Node({ node, style, dragHandle, tree }: NodeRendererProps<any>) {
               )
             }
             readOnly={tree.props.disableEdit as boolean}
-            removeEmojiAction={handleRemoveEmoji}      
+            removeEmojiAction={handleRemoveEmoji}
           />
         </div>
 
@@ -466,9 +467,7 @@ function NodeMenu({ node, treeApi }: NodeMenuProps) {
 
               <Menu.Item
                 c="red"
-                leftSection={
-                  <IconTrash size={16} />
-                }
+                leftSection={<IconTrash size={16} />}
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();

--- a/apps/client/src/features/page/tree/components/space-tree.tsx
+++ b/apps/client/src/features/page/tree/components/space-tree.tsx
@@ -343,6 +343,7 @@ function Node({ node, style, dragHandle, tree }: NodeRendererProps<any>) {
             }
             readOnly={tree.props.disableEdit as boolean}
             removeEmojiAction={handleRemoveEmoji}
+            nodeId={node.id}
           />
         </div>
 


### PR DESCRIPTION
Resolve: #570 

The solution I tried is to use a shared variable to save the nodeId. I used the Atom state management system so that all components of the pages can access it. If we click on an emoji page, we store the nodeId in the Atom, and this will trigger the list of emojis to open. If we click again on the same page, we store null to close it.

Please review this approach, and if you know a better solution, let me know.

![General-Docmost-Personal-MicrosoftEdge2024-12-2001-47-50-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/82867270-619b-4430-9f21-1d420114b433)


