### PR TITLE
Fix image cut in half when exporting to PDF

### DIFF
--- a/apps/client/src/features/page/components/header/page-header-menu.tsx
+++ b/apps/client/src/features/page/components/header/page-header-menu.tsx
@@ -73,8 +73,22 @@ function PageActionMenu({ readOnly }: PageActionMenuProps) {
   };
 
   const handlePrint = () => {
+    // Create a style element
+    const style = document.createElement('style');
+    style.type = 'text/css';
+    style.media = 'print';
+    style.appendChild(document.createTextNode(`
+      img {
+        page-break-inside: avoid;
+      }
+    `));
+    // Append the style element to the document head
+    document.head.appendChild(style);
+  
     setTimeout(() => {
       window.print();
+      // Remove the style element after printing
+      document.head.removeChild(style);
     }, 250);
   };
 


### PR DESCRIPTION
**Description:**
This pull request fixes the issue where images are cut in half when exporting the page to PDF. The `handlePrint` function was updated to inject CSS that avoids page breaks inside images.

**Changes:**
- Updated the `handlePrint` function in `page-header-menu.tsx` to include a CSS rule that ensures images are not split across pages when printing.

**Testing:**
- Tested locally by exporting pages with images to PDF and verifying that images are not cut in half.