### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   docmost:
     image: docmost/docmost:latest


### PR DESCRIPTION
Docker Compose Files have deprecated use of version tags.

Installing using compose.yaml files shows up the below error: 
`The attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion.`