### PR TITLE
[#313] feat: Add TLS support (with Caddy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# your domain, e.g https://example.com
-APP_URL=http://localhost:3000
+# your domain, e.g., "example.com" or "docmost.localhost" or even "localhost"
+DOMAIN=localhost
 PORT=3000
+APP_URL=https://${DOMAIN}:${PORT}
 
 # make sure to replace this.
 APP_SECRET=REPLACE_WITH_LONG_SECRET

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,4 @@
+{$DOMAIN}
+
+tls internal
+reverse_proxy docmost:{$PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
       APP_SECRET: 'REPLACE_WITH_LONG_SECRET'
       DATABASE_URL: 'postgresql://docmost:STRONG_DB_PASSWORD@db:5432/docmost?schema=public'
       REDIS_URL: 'redis://redis:6379'
-    ports:
-      - "3000:3000"
     restart: unless-stopped
     volumes:
       - docmost:/app/data/storage
@@ -33,7 +31,24 @@ services:
     volumes:
       - redis_data:/data
 
+  reverse_proxy:
+    image: caddy:latest
+    restart: unless-stopped
+    container_name: caddy_proxy
+    environment:
+      DOMAIN: ${DOMAIN}
+      PORT: ${PORT}
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+
 volumes:
   docmost:
   db_data:
   redis_data:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
- Add Caddy service in `docker-compose.yml` as a reverse-proxy.
- Update `.env.example` with `DOMAIN` (also rework `APP_URL`) as Caddyfile now uses `DOMAIN` and `PORT` envars.
- Remove ports for `docman` service as we only need access through 443.

Refs: #313