### PR TITLE
fix: enforce 32-character minimum length for APP_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 APP_URL=http://localhost:3000
 PORT=3000
 
-# make sure to replace this.
+# minimum of 32 characters. Generate one with: openssl rand -hex 32
 APP_SECRET=REPLACE_WITH_LONG_SECRET
 
 JWT_TOKEN_EXPIRES_IN=30d

--- a/apps/server/src/integrations/environment/environment.validation.ts
+++ b/apps/server/src/integrations/environment/environment.validation.ts
@@ -4,6 +4,7 @@ import {
   IsNotIn,
   IsOptional,
   IsUrl,
+  MinLength,
   validateSync,
 } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
@@ -36,6 +37,7 @@ export class EnvironmentVariables {
   APP_URL: string;
 
   @IsNotEmpty()
+  @MinLength(32)
   @IsNotIn(['REPLACE_WITH_LONG_SECRET'])
   APP_SECRET: string;
 


### PR DESCRIPTION
For better security, we are enforcing a minimum of 32-character length for the `APP_SECRET` env variable.