### PR TITLE
Fix: Close Popover When Clicking Outside in SwitchSpace Component

### DIFF
--- a/apps/client/src/features/space/components/sidebar/switch-space.tsx
+++ b/apps/client/src/features/space/components/sidebar/switch-space.tsx
@@ -13,7 +13,7 @@ interface SwitchSpaceProps {
 
 export function SwitchSpace({ spaceName, spaceSlug }: SwitchSpaceProps) {
   const navigate = useNavigate();
-  const [opened, { close, open }] = useDisclosure(false);
+  const [opened, { close, open, toggle }] = useDisclosure(false);
 
   const handleSelect = (value: string) => {
     if (value) {
@@ -29,6 +29,7 @@ export function SwitchSpace({ spaceName, spaceSlug }: SwitchSpaceProps) {
       withArrow
       shadow="md"
       opened={opened}
+      onChange={toggle}
     >
       <Popover.Target>
         <Button


### PR DESCRIPTION
This PR fixes an issue where the popover in the SwitchSpace component does not close when clicking outside.

Since SwitchSpace is a controlled component, the state needs to be toggled via onChange. This change ensures that the popover properly closes when expected.

![before](https://github.com/user-attachments/assets/d875f4d5-f4db-4d28-a4c5-c83ef426cdbc)
![after](https://github.com/user-attachments/assets/7e78fbe1-2642-4f9e-967c-0d9ba8a52c77)

Reference: [mantinedev/mantine#7019](https://github.com/mantinedev/mantine/issues/7019)