### PR TITLE
Fix: Prevent premature focus change in TitleEditor when pressing Enter during IME composition

### DIFF
--- a/apps/client/src/features/editor/title-editor.tsx
+++ b/apps/client/src/features/editor/title-editor.tsx
@@ -129,8 +129,12 @@ export function TitleEditor({
   }, [titleEditor]);
 
   function handleTitleKeyDown(event) {
-    if (!titleEditor || !pageEditor || event.shiftKey || event.nativeEvent.isComposing) return;
-
+    if (!titleEditor || !pageEditor || event.shiftKey) return;
+    
+    // Prevent focus shift when IME composition is active 
+    // `keyCode === 229` is added to support Safari where `isComposing` may not be reliable
+    if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) return;
+    
     const { key } = event;
     const { $head } = titleEditor.state.selection;
 

--- a/apps/client/src/features/editor/title-editor.tsx
+++ b/apps/client/src/features/editor/title-editor.tsx
@@ -129,7 +129,7 @@ export function TitleEditor({
   }, [titleEditor]);
 
   function handleTitleKeyDown(event) {
-    if (!titleEditor || !pageEditor || event.shiftKey) return;
+    if (!titleEditor || !pageEditor || event.shiftKey || event.nativeEvent.isComposing) return;
 
     const { key } = event;
     const { $head } = titleEditor.state.selection;


### PR DESCRIPTION
## Problem
When users are typing using an IME (Input Method Editor) in the `<TitleEditor>` component, pressing the `Enter` key is sometimes required to confirm the text conversion. However, in some cases, pressing `Enter` during composition is mistakenly interpreted as an input completion event, causing an unintended focus shift.

This issue primarily affects:
- **Japanese IME users** who frequently confirm input using the `Enter` key.
- **Chinese IME users** who manually confirm conversion using `Enter` (though many rely on the spacebar or automatic conversion).

## Solution
To address this, the `isComposing` property is checked during `keydown` events. If `isComposing === true` when `Enter` is pressed, the default action is prevented to ensure that focus remains on the input field.

### **Code Change**
The `handleTitleKeyDown` function in TitleEditor component has been updated by adding `|| event.nativeEvent.isComposing` to the early return condition. This prevents unintended focus shift when the IME composition is active.

## Impact
- Ensures smoother user experience for Japanese and Chinese IME users in **TitleEditor**.
- Prevents unintended focus loss and submission behavior.
- No effect on non-IME users or those who use spacebar-based conversion.

## References
- [MDN: isComposing](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing)

Thanks!
