### PR TITLE
fixes infinite rendering when selecting member to add to space

### DIFF
--- a/apps/client/src/features/space/components/add-space-members-modal.tsx
+++ b/apps/client/src/features/space/components/add-space-members-modal.tsx
@@ -19,14 +19,6 @@ export default function AddSpaceMembersModal({
   const [role, setRole] = useState<string>(SpaceRole.WRITER);
   const addSpaceMemberMutation = useAddSpaceMemberMutation();
 
-  const handleMultiSelectChange = (value: string[]) => {
-    setMemberIds(value);
-  };
-
-  const handleRoleSelection = (role: string) => {
-    setRole(role);
-  };
-
   const handleSubmit = async () => {
     // member can be a users or groups
     const userIds = memberIds
@@ -55,9 +47,9 @@ export default function AddSpaceMembersModal({
         <Divider size="xs" mb="xs" />
 
         <Stack>
-          <MultiMemberSelect onChange={handleMultiSelectChange} />
+          <MultiMemberSelect onChange={setMemberIds} />
           <SpaceMemberRole
-            onSelect={handleRoleSelection}
+            onSelect={setRole}
             defaultRole={role}
             label={t("Select role")}
           />

--- a/apps/client/src/features/space/components/multi-member-select.tsx
+++ b/apps/client/src/features/space/components/multi-member-select.tsx
@@ -81,23 +81,24 @@ export function MultiMemberSelect({ onChange }: MultiMemberSelectProps) {
           : [...updatedGroups, { group: groupName, items: newItemsFiltered }];
       };
 
-      // Merge user items into groups
-      const updatedUserGroups = mergeItemsIntoGroups(
-        data,
-        userItems,
-        t("Select a user"),
-      );
-
-      // Merge group items into groups
-      const finalData = mergeItemsIntoGroups(
-        updatedUserGroups,
-        groupItems,
-        t("Select a group"),
-      );
-
-      setData(finalData);
+      setData((oldData) => {
+        // Merge user items into groups
+        const updatedUserGroups = mergeItemsIntoGroups(
+          oldData,
+          userItems,
+          t("Select a user"),
+        );
+  
+        // Merge group items into groups
+        const finalData = mergeItemsIntoGroups(
+          updatedUserGroups,
+          groupItems,
+          t("Select a group"),
+        );
+        return finalData
+      });
     }
-  }, [suggestion, data]);
+  }, [suggestion, setData]);
 
   return (
     <MultiSelect


### PR DESCRIPTION
Just noticed that `MultiMemberSelect` components renders infinitely when you type in a name to select a member to add to a space. The root cause is because `useEffect` in this component is depend on a state variable `data` which is updated every time running the callback of `useEffect`. It can be fixed by removing the use of `data` variable by replacing it with the argument passed in `setData`. See the code diff for details.