### PR TITLE
feat: publish spaces and let anonymous users access to pages in published spaces

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -7,7 +7,7 @@ import AccountSettings from "@/pages/settings/account/account-settings";
 import WorkspaceMembers from "@/pages/settings/workspace/workspace-members";
 import WorkspaceSettings from "@/pages/settings/workspace/workspace-settings";
 import Groups from "@/pages/settings/group/groups";
-import GroupInfo from "./pages/settings/group/group-info";
+import GroupInfo from "@/pages/settings/group/group-info";
 import Spaces from "@/pages/settings/space/spaces.tsx";
 import { Error404 } from "@/components/ui/error-404.tsx";
 import AccountPreferences from "@/pages/settings/account/account-preferences.tsx";
@@ -17,7 +17,7 @@ import Layout from "@/components/layouts/global/layout.tsx";
 import { ErrorBoundary } from "react-error-boundary";
 import InviteSignup from "@/pages/auth/invite-signup.tsx";
 import ForgotPassword from "@/pages/auth/forgot-password.tsx";
-import PasswordReset from "./pages/auth/password-reset";
+import PasswordReset from "@/pages/auth/password-reset";
 import Billing from "@/ee/billing/pages/billing.tsx";
 import CloudLogin from "@/ee/pages/cloud-login.tsx";
 import CreateWorkspace from "@/ee/pages/create-workspace.tsx";
@@ -26,6 +26,9 @@ import { useTranslation } from "react-i18next";
 import Security from "@/ee/security/pages/security.tsx";
 import License from "@/ee/licence/pages/license.tsx";
 import { useRedirectToCloudSelect } from "@/ee/hooks/use-redirect-to-cloud-select.tsx";
+import UserAgnosticLayout from "@/components/layouts/global/user-agnostic-layout";
+import SharedPage from "@/pages/page/shared-page";
+import SharedSpaceHome from "@/pages/space/shared-space-home";
 
 export default function App() {
   const { t } = useTranslation();
@@ -52,6 +55,21 @@ export default function App() {
         )}
 
         <Route path={"/p/:pageSlug"} element={<PageRedirect />} />
+
+        <Route path={"/share"} element={<UserAgnosticLayout />}>
+          <Route path={"s/:spaceSlug"} element={<SharedSpaceHome />} />
+          <Route
+            path={"s/:spaceSlug/p/:pageSlug"}
+            element={
+              <ErrorBoundary
+                fallback={<>{t("Failed to load page. An error occurred.")}</>}
+              >
+                <SharedPage />
+              </ErrorBoundary>
+            }
+          />
+          <Route path={"p/:pageSlug"} element={<PageRedirect />} />
+        </Route>
 
         <Route element={<Layout />}>
           <Route path={"/home"} element={<Home />} />

--- a/apps/client/src/components/common/shared-recent-changes.tsx
+++ b/apps/client/src/components/common/shared-recent-changes.tsx
@@ -1,0 +1,86 @@
+import {
+  Text,
+  Group,
+  UnstyledButton,
+  Badge,
+  Table,
+  ActionIcon,
+} from '@mantine/core';
+import {Link} from 'react-router-dom';
+import PageListSkeleton from '@/components/ui/page-list-skeleton.tsx';
+import { buildPageUrl } from '@/features/page/page.utils.ts';
+import { formattedDate } from '@/lib/time.ts';
+import { useSharedRecentChangesQuery } from '@/features/page/queries/shared-page-query.ts';
+import { IconFileDescription } from '@tabler/icons-react';
+import { getSpaceUrl } from '@/lib/config.ts';
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  spaceId?: string;
+}
+
+export default function SharedRecentChanges({spaceId}: Props) {
+  const { t } = useTranslation();
+  const {data: pages, isLoading, isError} = useSharedRecentChangesQuery(spaceId);
+
+  if (isLoading) {
+    return <PageListSkeleton/>;
+  }
+
+  if (isError) {
+    return <Text>{t("Failed to fetch recent pages")}</Text>;
+  }
+
+  return pages && pages.items.length > 0 ? (
+    <Table.ScrollContainer minWidth={500}>
+      <Table highlightOnHover verticalSpacing="sm">
+        <Table.Tbody>
+          {pages.items.map((page) => (
+            <Table.Tr key={page.id}>
+              <Table.Td>
+                <UnstyledButton
+                  component={Link}
+                  to={buildPageUrl(page?.space.slug, page.slugId, page.title)}
+                >
+                  <Group wrap="nowrap">
+                    {page.icon || (
+                      <ActionIcon variant='transparent' color='gray' size={18}>
+                        <IconFileDescription size={18}/>
+                      </ActionIcon>
+                    )}
+
+                    <Text fw={500} size="md" lineClamp={1}>
+                      {page.title || t("Untitled")}
+                    </Text>
+                  </Group>
+                </UnstyledButton>
+              </Table.Td>
+              {!spaceId && (
+                <Table.Td>
+                  <Badge
+                    color="blue"
+                    variant="light"
+                    component={Link}
+                    to={getSpaceUrl(page?.space.slug)}
+                    style={{cursor: 'pointer'}}
+                  >
+                    {page?.space.name}
+                  </Badge>
+                </Table.Td>
+              )}
+              <Table.Td>
+                <Text c="dimmed" style={{whiteSpace: 'nowrap'}} size="xs" fw={500}>
+                  {formattedDate(page.updatedAt)}
+                </Text>
+              </Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    </Table.ScrollContainer>
+  ) : (
+    <Text size="md" ta="center">
+      {t("No pages yet")}
+    </Text>
+  );
+}

--- a/apps/client/src/components/layouts/global/user-agnostic-app-header.tsx
+++ b/apps/client/src/components/layouts/global/user-agnostic-app-header.tsx
@@ -1,0 +1,56 @@
+import { Group, Text, Tooltip } from "@mantine/core";
+import { useAtom } from "jotai";
+import {
+  desktopSidebarAtom,
+  mobileSidebarAtom,
+} from "@/components/layouts/global/hooks/atoms/sidebar-atom.ts";
+import { useToggleSidebar } from "@/components/layouts/global/hooks/hooks/use-toggle-sidebar.ts";
+import SidebarToggle from "@/components/ui/sidebar-toggle-button.tsx";
+import { useTranslation } from "react-i18next";
+
+export function UserAgnosticAppHeader() {
+  const { t } = useTranslation();
+  const [mobileOpened] = useAtom(mobileSidebarAtom);
+  const toggleMobile = useToggleSidebar(mobileSidebarAtom);
+
+  const [desktopOpened] = useAtom(desktopSidebarAtom);
+  const toggleDesktop = useToggleSidebar(desktopSidebarAtom);
+
+  const isHomeRoute = location.pathname.startsWith("/home");
+
+  return (
+    <>
+      <Group h="100%" px="md" justify="space-between" wrap={"nowrap"}>
+        <Group wrap="nowrap">
+          {!isHomeRoute && (
+            <>
+              <Tooltip label={t("Sidebar toggle")}>
+                <SidebarToggle
+                  aria-label={t("Sidebar toggle")}
+                  opened={mobileOpened}
+                  onClick={toggleMobile}
+                  hiddenFrom="sm"
+                  size="sm"
+                />
+              </Tooltip>
+
+              <Tooltip label={t("Sidebar toggle")}>
+                <SidebarToggle
+                  aria-label={t("Sidebar toggle")}
+                  opened={desktopOpened}
+                  onClick={toggleDesktop}
+                  visibleFrom="sm"
+                  size="sm"
+                />
+              </Tooltip>
+            </>
+          )}
+
+          <Text size="lg" fw={600}>
+            Docmost
+          </Text>
+        </Group>
+      </Group>
+    </>
+  );
+}

--- a/apps/client/src/components/layouts/global/user-agnostic-layout.tsx
+++ b/apps/client/src/components/layouts/global/user-agnostic-layout.tsx
@@ -1,0 +1,92 @@
+import { Outlet } from "react-router-dom";
+import { AppShell } from "@mantine/core";
+import React, { useEffect, useRef, useState } from "react";
+import { useAtom } from "jotai";
+import { 
+  desktopSidebarAtom,
+  mobileSidebarAtom,
+  sidebarWidthAtom
+} from "@/components/layouts/global/hooks/atoms/sidebar-atom.ts";
+import classes from "./app-shell.module.css";
+import { useTrialEndAction } from "@/ee/hooks/use-trial-end-action.tsx";
+import { SharedSpaceSidebar } from "@/features/space/components/sidebar/shared-space-sidebar";
+import { UserAgnosticAppHeader } from "@/components/layouts/global/user-agnostic-app-header";
+
+export default function UserAgnosticLayout() {
+  useTrialEndAction();
+  const [mobileOpened] = useAtom(mobileSidebarAtom);
+  const [desktopOpened] = useAtom(desktopSidebarAtom);
+  const [sidebarWidth, setSidebarWidth] = useAtom(sidebarWidthAtom);
+  const [isResizing, setIsResizing] = useState(false);
+  const sidebarRef = useRef(null);
+
+  const startResizing = React.useCallback((mouseDownEvent) => {
+    mouseDownEvent.preventDefault();
+    setIsResizing(true);
+  }, []);
+
+  const stopResizing = React.useCallback(() => {
+    setIsResizing(false);
+  }, []);
+
+  const resize = React.useCallback(
+    (mouseMoveEvent) => {
+      if (isResizing) {
+        const newWidth =
+          mouseMoveEvent.clientX -
+          sidebarRef.current.getBoundingClientRect().left;
+        if (newWidth < 220) {
+          setSidebarWidth(220);
+          return;
+        }
+        if (newWidth > 600) {
+          setSidebarWidth(600);
+          return;
+        }
+        setSidebarWidth(newWidth);
+      }
+    },
+    [isResizing],
+  );
+
+  useEffect(() => {
+    //https://codesandbox.io/p/sandbox/kz9de
+    window.addEventListener("mousemove", resize);
+    window.addEventListener("mouseup", stopResizing);
+    return () => {
+      window.removeEventListener("mousemove", resize);
+      window.removeEventListener("mouseup", stopResizing);
+    };
+  }, [resize, stopResizing]);
+
+  return (
+    <AppShell
+      header={{ height: 45 }}
+      navbar={{
+          width: sidebarWidth,
+          breakpoint: "sm",
+          collapsed: {
+            mobile: !mobileOpened,
+            desktop: !desktopOpened,
+          },
+        }
+      }
+      padding="md"
+    >
+      <AppShell.Header px="md" className={classes.header}>
+        <UserAgnosticAppHeader />
+      </AppShell.Header>
+      <AppShell.Navbar
+        className={classes.navbar}
+        withBorder={false}
+        ref={sidebarRef}
+      >
+        <div className={classes.resizeHandle} onMouseDown={startResizing} />
+        <SharedSpaceSidebar />
+      </AppShell.Navbar>
+      <AppShell.Main>
+          <Outlet />
+      </AppShell.Main>
+    </AppShell>
+  );
+}

--- a/apps/client/src/features/editor/components/attachment/shared-attachment-view.tsx
+++ b/apps/client/src/features/editor/components/attachment/shared-attachment-view.tsx
@@ -1,0 +1,48 @@
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { Group, Text, Paper, ActionIcon } from "@mantine/core";
+import { getSharedFileUrl } from "@/lib/config.ts";
+import { IconDownload, IconPaperclip } from "@tabler/icons-react";
+import { useHover } from "@mantine/hooks";
+import { formatBytes } from "@/lib";
+
+export default function SharedAttachmentView(props: NodeViewProps) {
+  const { node, selected } = props;
+  const { url, name, size } = node.attrs;
+  const { hovered, ref } = useHover();
+
+  return (
+    <NodeViewWrapper>
+      <Paper withBorder p="4px" ref={ref} data-drag-handle>
+        <Group
+          justify="space-between"
+          gap="xl"
+          style={{ cursor: "pointer" }}
+          wrap="nowrap"
+          h={25}
+        >
+          <Group justify="space-between" wrap="nowrap">
+            <IconPaperclip size={20} />
+
+            <Text component="span" size="md" truncate="end">
+              {name}
+            </Text>
+
+            <Text component="span" size="sm" c="dimmed" inline>
+              {formatBytes(size)}
+            </Text>
+          </Group>
+
+          {selected || hovered ? (
+            <a href={getSharedFileUrl(url)} target="_blank">
+              <ActionIcon variant="default" aria-label="download file">
+                <IconDownload size={18} />
+              </ActionIcon>
+            </a>
+          ) : (
+            ""
+          )}
+        </Group>
+      </Paper>
+    </NodeViewWrapper>
+  );
+}

--- a/apps/client/src/features/editor/components/drawio/shared-drawio-view.tsx
+++ b/apps/client/src/features/editor/components/drawio/shared-drawio-view.tsx
@@ -1,0 +1,53 @@
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { ActionIcon, Card, Image, Text } from "@mantine/core";
+import { getSharedFileUrl } from "@/lib/config.ts";
+import clsx from "clsx";
+import { IconEdit } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+
+export default function SharedDrawioView(props: NodeViewProps) {
+  const { t } = useTranslation();
+  const { node, selected } = props;
+  const { src, title, width } = node.attrs;
+
+  return (
+    <NodeViewWrapper>
+      {src ? (
+        <div style={{ position: "relative" }}>
+          <Image
+            radius="md"
+            fit="contain"
+            w={width}
+            src={getSharedFileUrl(src)}
+            alt={title}
+            className={clsx(
+              selected ? "ProseMirror-selectednode" : "",
+              "alignCenter",
+            )}
+          />
+        </div>
+      ) : (
+        <Card
+          radius="md"
+          p="xs"
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+          withBorder
+        >
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <ActionIcon variant="transparent" color="gray">
+              <IconEdit size={18} />
+            </ActionIcon>
+
+            <Text component="span" size="lg" c="dimmed">
+              {t("Not available")}
+            </Text>
+          </div>
+        </Card>
+      )}
+    </NodeViewWrapper>
+  );
+}

--- a/apps/client/src/features/editor/components/embed/shared-embed-view.tsx
+++ b/apps/client/src/features/editor/components/embed/shared-embed-view.tsx
@@ -1,0 +1,58 @@
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { useMemo } from "react";
+import { ActionIcon, AspectRatio, Card, Text } from "@mantine/core";
+import { IconEdit } from "@tabler/icons-react";
+import { getEmbedUrlAndProvider } from "@/features/editor/components/embed/providers.ts";
+import { useTranslation } from "react-i18next";
+
+export default function SharedEmbedView(props: NodeViewProps) {
+  const { t } = useTranslation();
+  const { node } = props;
+  const { src } = node.attrs;
+
+  const embedUrl = useMemo(() => {
+    if (src) {
+      return getEmbedUrlAndProvider(src).embedUrl;
+    }
+    return null;
+  }, [src]);
+
+  return (
+    <NodeViewWrapper>
+      {embedUrl ? (
+        <>
+          <AspectRatio ratio={16 / 9}>
+            <iframe
+              src={embedUrl}
+              allow="encrypted-media"
+              sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+              allowFullScreen
+              frameBorder="0"
+            ></iframe>
+          </AspectRatio>
+        </>
+      ) : (
+        <Card
+          radius="md"
+          p="xs"
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+          withBorder
+        >
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <ActionIcon variant="transparent" color="gray">
+              <IconEdit size={18} />
+            </ActionIcon>
+
+            <Text component="span" size="lg" c="dimmed">
+              {t("Not available")}
+            </Text>
+          </div>
+        </Card>
+      )}
+    </NodeViewWrapper>
+  );
+}

--- a/apps/client/src/features/editor/components/excalidraw/shared-excalidraw-view.tsx
+++ b/apps/client/src/features/editor/components/excalidraw/shared-excalidraw-view.tsx
@@ -1,0 +1,53 @@
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { ActionIcon, Card, Image, Text } from "@mantine/core";
+import { getSharedFileUrl } from "@/lib/config.ts";
+import clsx from "clsx";
+import { IconEdit } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+
+export default function SharedExcalidrawView(props: NodeViewProps) {
+  const { t } = useTranslation();
+  const { node, selected } = props;
+  const { src, title, width } = node.attrs;
+
+  return (
+    <NodeViewWrapper>
+      {src ? (
+        <div style={{ position: "relative" }}>
+          <Image
+            radius="md"
+            fit="contain"
+            w={width}
+            src={getSharedFileUrl(src)}
+            alt={title}
+            className={clsx(
+              selected ? "ProseMirror-selectednode" : "",
+              "alignCenter",
+            )}
+          />
+        </div>
+      ) : (
+        <Card
+          radius="md"
+          p="xs"
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+          withBorder
+        >
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <ActionIcon variant="transparent" color="gray">
+              <IconEdit size={18} />
+            </ActionIcon>
+
+            <Text component="span" size="lg" c="dimmed">
+              {t("Not available")}
+            </Text>
+          </div>
+        </Card>
+      )}
+    </NodeViewWrapper>
+  );
+}

--- a/apps/client/src/features/editor/components/image/shared-image-view.tsx
+++ b/apps/client/src/features/editor/components/image/shared-image-view.tsx
@@ -1,0 +1,29 @@
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { useMemo } from "react";
+import { Image } from "@mantine/core";
+import { getSharedFileUrl } from "@/lib/config.ts";
+
+export default function SharedImageView(props: NodeViewProps) {
+  const { node } = props;
+  const { src, width, align, title } = node.attrs;
+
+  const alignClass = useMemo(() => {
+    if (align === "left") return "alignLeft";
+    if (align === "right") return "alignRight";
+    if (align === "center") return "alignCenter";
+    return "alignCenter";
+  }, [align]);
+
+  return (
+    <NodeViewWrapper>
+      <Image
+        radius="md"
+        fit="contain"
+        w={width}
+        src={getSharedFileUrl(src)}
+        alt={title}
+        className={alignClass}
+      />
+    </NodeViewWrapper>
+  );
+}

--- a/apps/client/src/features/editor/components/mention/shared-mention-view.tsx
+++ b/apps/client/src/features/editor/components/mention/shared-mention-view.tsx
@@ -1,0 +1,56 @@
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { ActionIcon, Anchor, Text } from "@mantine/core";
+import { IconFileDescription } from "@tabler/icons-react";
+import { Link, useParams } from "react-router-dom";
+import { buildPageUrl } from "@/features/page/page.utils.ts";
+import classes from "./mention.module.css";
+import { useSharedPageQuery } from "@/features/page/queries/shared-page-query";
+
+export default function SharedMentionView(props: NodeViewProps) {
+  const { node } = props;
+  const { label, entityType, entityId, slugId } = node.attrs;
+  const { spaceSlug } = useParams();
+  const {
+    data: page,
+    isLoading,
+    isError,
+  } = useSharedPageQuery({ pageId: entityType === "page" ? slugId : null });
+
+  return (
+    <NodeViewWrapper style={{ display: "inline" }}>
+      {entityType === "user" && (
+        <Text className={classes.userMention} component="span">
+          @{label}
+        </Text>
+      )}
+
+      {entityType === "page" && (
+        <Anchor
+          component={Link}
+          fw={500}
+          to={buildPageUrl(spaceSlug, slugId, label)}
+          underline="never"
+          className={classes.pageMentionLink}
+        >
+          {page?.icon ? (
+            <span style={{ marginRight: "4px" }}>{page.icon}</span>
+          ) : (
+            <ActionIcon
+              variant="transparent"
+              color="gray"
+              component="span"
+              size={18}
+              style={{ verticalAlign: "text-bottom" }}
+            >
+              <IconFileDescription size={18} />
+            </ActionIcon>
+          )}
+
+          <span className={classes.pageMentionText}>
+            {page?.title || label}
+          </span>
+        </Anchor>
+      )}
+    </NodeViewWrapper>
+  );
+}

--- a/apps/client/src/features/editor/components/video/shared-video-view.tsx
+++ b/apps/client/src/features/editor/components/video/shared-video-view.tsx
@@ -1,0 +1,29 @@
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { useMemo } from "react";
+import { getSharedFileUrl } from "@/lib/config.ts";
+import clsx from "clsx";
+
+export default function SharedVideoView(props: NodeViewProps) {
+  const { node, selected } = props;
+  const { src, width, align } = node.attrs;
+
+  const alignClass = useMemo(() => {
+    if (align === "left") return "alignLeft";
+    if (align === "right") return "alignRight";
+    if (align === "center") return "alignCenter";
+    return "alignCenter";
+  }, [align]);
+
+  return (
+    <NodeViewWrapper>
+      <video
+        preload="metadata"
+        width={width}
+        controls
+        src={getSharedFileUrl(src)}
+        className={clsx(selected ? "ProseMirror-selectednode" : "", alignClass)}
+        style={{ display: "block" }}
+      />
+    </NodeViewWrapper>
+  );
+}

--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -85,6 +85,8 @@ lowlight.register("fortran", fortran);
 lowlight.register("haskell", haskell);
 lowlight.register("scala", scala);
 
+export { lowlight }
+
 export const mainExtensions = [
   StarterKit.configure({
     history: false,

--- a/apps/client/src/features/editor/extensions/readonly-editor-extensions.ts
+++ b/apps/client/src/features/editor/extensions/readonly-editor-extensions.ts
@@ -1,0 +1,129 @@
+import { StarterKit } from "@tiptap/starter-kit";
+import { TextAlign } from "@tiptap/extension-text-align";
+import { TaskList } from "@tiptap/extension-task-list";
+import { TaskItem } from "@tiptap/extension-task-item";
+import { Underline } from "@tiptap/extension-underline";
+import { Superscript } from "@tiptap/extension-superscript";
+import SubScript from "@tiptap/extension-subscript";
+import { Highlight } from "@tiptap/extension-highlight";
+import { Typography } from "@tiptap/extension-typography";
+import { TextStyle } from "@tiptap/extension-text-style";
+import { Color } from "@tiptap/extension-color";
+import Table from "@tiptap/extension-table";
+import TableHeader from "@tiptap/extension-table-header";
+import {
+  Comment,
+  Details,
+  DetailsContent,
+  DetailsSummary,
+  MathBlock,
+  MathInline,
+  TableCell,
+  TableRow,
+  TrailingNode,
+  TiptapImage,
+  Callout,
+  TiptapVideo,
+  LinkExtension,
+  Selection,
+  Attachment,
+  CustomCodeBlock,
+  Drawio,
+  Excalidraw,
+  Embed,
+  Mention,
+} from "@docmost/editor-ext";
+import MathInlineView from "@/features/editor/components/math/math-inline.tsx";
+import MathBlockView from "@/features/editor/components/math/math-block.tsx";
+import GlobalDragHandle from "tiptap-extension-global-drag-handle";
+import { Youtube } from "@tiptap/extension-youtube";
+import CalloutView from "@/features/editor/components/callout/callout-view.tsx";
+import CodeBlockView from "@/features/editor/components/code-block/code-block-view.tsx";
+import SharedEmbedView from "@/features/editor/components/embed/shared-embed-view.tsx";
+import mentionRenderItems from "@/features/editor/components/mention/mention-suggestion.ts";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import { CharacterCount } from "@tiptap/extension-character-count";
+import { Placeholder } from "@tiptap/extension-placeholder";
+import { lowlight } from "@/features/editor/extensions/extensions";
+import SharedMentionView from "@/features/editor/components/mention/shared-mention-view.tsx";
+import SharedImageView from "@/features/editor/components/image/shared-image-view";
+import SharedVideoView from "@/features/editor/components/video/shared-video-view";
+import SharedAttachmentView from "@/features/editor/components/attachment/shared-attachment-view";
+import SharedDrawioView from "@/features/editor/components/drawio/shared-drawio-view";
+import i18n from "@/i18n.ts";
+import "@/features/editor/styles/index.css";
+
+export const readonlyEditorExtensions = [
+  StarterKit.configure({
+    history: false,
+    dropcursor: { width: 3, color: "#70CFF8" },
+    codeBlock: false,
+    code: { HTMLAttributes: { spellcheck: false } },
+  }),
+  Placeholder.configure({
+    placeholder: ({ node }) => {
+      if (node.type.name === "heading") {
+        return i18n.t("Heading {{level}}", { level: node.attrs.level });
+      }
+      if (node.type.name === "detailsSummary") {
+        return i18n.t("Toggle title");
+      }
+      if (node.type.name === "paragraph") {
+        return i18n.t('Write anything. Enter "/" for commands');
+      }
+    },
+    includeChildren: true,
+    showOnlyWhenEditable: true,
+  }),
+  TextAlign.configure({ types: ["heading", "paragraph"] }),
+  TaskList,
+  TaskItem.configure({ nested: true }),
+  Underline,
+  LinkExtension.configure({ openOnClick: false }),
+  Superscript,
+  SubScript,
+  Highlight.configure({ multicolor: true }),
+  Typography,
+  TrailingNode,
+  GlobalDragHandle,
+  TextStyle,
+  Color,
+  Comment.configure({ HTMLAttributes: { class: "comment-mark" } }),
+  Mention.configure({
+    suggestion: {
+      allowSpaces: true,
+      items: () => [],
+      // @ts-ignore
+      render: mentionRenderItems,
+    },
+    HTMLAttributes: { class: "mention" },
+  }).extend({ addNodeView: () => ReactNodeViewRenderer(SharedMentionView) }),
+  Table.configure({
+    resizable: true,
+    lastColumnResizable: false,
+    allowTableNodeSelection: true,
+  }),
+  TableRow,
+  TableCell,
+  TableHeader,
+  MathInline.configure({ view: MathInlineView }),
+  MathBlock.configure({ view: MathBlockView }),
+  Details,
+  DetailsSummary,
+  DetailsContent,
+  Youtube.configure({ addPasteHandler: false, controls: true, nocookie: true }),
+  TiptapImage.configure({ view: SharedImageView, allowBase64: false }),
+  TiptapVideo.configure({ view: SharedVideoView }),
+  Callout.configure({ view: CalloutView }),
+  CustomCodeBlock.configure({
+    view: CodeBlockView,
+    lowlight,
+    HTMLAttributes: { spellcheck: false },
+  }),
+  Selection,
+  Attachment.configure({ view: SharedAttachmentView }),
+  Drawio.configure({ view: SharedDrawioView }),
+  Excalidraw.configure({ view: SharedImageView }),
+  Embed.configure({ view: SharedEmbedView }),
+  CharacterCount
+] as any;

--- a/apps/client/src/features/editor/readonly-editor.tsx
+++ b/apps/client/src/features/editor/readonly-editor.tsx
@@ -1,0 +1,51 @@
+import classes from "@/features/editor/styles/editor.module.css";
+import { Container } from "@mantine/core";
+import { EditorProvider, useEditor, EditorContent } from "@tiptap/react";
+import { readonlyEditorExtensions } from "@/features/editor/extensions/readonly-editor-extensions";
+import { useTranslation } from "react-i18next";
+import { Document } from "@tiptap/extension-document";
+import { Heading } from "@tiptap/extension-heading";
+import { Text } from "@tiptap/extension-text";
+import { Placeholder } from "@tiptap/extension-placeholder";
+import "@/features/editor/styles/index.css";
+
+export interface ReadonlyEditorProps {
+  title: string;
+  content: string;
+}
+
+export function ReadonlyEditor({ title, content }: ReadonlyEditorProps) {
+  const { t } = useTranslation();
+  
+  const titleEditor = useEditor({
+    extensions: [
+      Document.extend({ content: "heading" }),
+      Heading.configure({ levels: [1] }),
+      Text,
+      Placeholder.configure({
+        placeholder: t("Untitled"),
+        showOnlyWhenEditable: false,
+      }),
+    ],
+    editable: false,
+    content: title,
+    immediatelyRender: true,
+    shouldRerenderOnTransaction: false,
+  });
+
+  return (
+    <Container
+      fluid={false}
+      size={900}
+      className={classes.editor}
+    >
+      <EditorContent editor={titleEditor} />
+      <EditorProvider
+        editable={false}
+        immediatelyRender={true}
+        extensions={readonlyEditorExtensions}
+        content={content}
+      ></EditorProvider>
+    </Container>
+  );
+}

--- a/apps/client/src/features/page/page.utils.ts
+++ b/apps/client/src/features/page/page.utils.ts
@@ -1,3 +1,4 @@
+import { Location } from "react-router-dom"
 import slugify from "@sindresorhus/slugify";
 
 const buildPageSlug = (pageSlugId: string, pageTitle?: string): string => {
@@ -15,9 +16,11 @@ export const buildPageUrl = (
   spaceName: string,
   pageSlugId: string,
   pageTitle?: string,
+  share?: boolean
 ): string => {
-  if (spaceName === undefined) {
-    return `/${buildPageSlug(pageSlugId, pageTitle)}`;
-  }
-  return `/s/${spaceName}/${buildPageSlug(pageSlugId, pageTitle)}`;
+  const isSharedPrefixed = window.location.pathname.startsWith("/share") || share
+  const sharedPrefix = isSharedPrefixed ? "/share" : ""
+  const spacePrefix = spaceName === undefined ? "" : `/s/${spaceName}`
+  const pagePath = `${buildPageSlug(pageSlugId, pageTitle)}`
+  return `${sharedPrefix}${spacePrefix}/${pagePath}`;
 };

--- a/apps/client/src/features/page/queries/page-query.ts
+++ b/apps/client/src/features/page/queries/page-query.ts
@@ -112,7 +112,7 @@ export function useGetSidebarPagesQuery(
   data: SidebarPagesParams,
 ): UseQueryResult<IPagination<IPage>, Error> {
   return useQuery({
-    queryKey: ["sidebar-pages", data],
+    queryKey: ["sidebar-pages", data.spaceId],
     queryFn: () => getSidebarPages(data),
   });
 }
@@ -144,7 +144,7 @@ export function usePageBreadcrumbsQuery(
 export async function fetchAncestorChildren(params: SidebarPagesParams) {
   // not using a hook here, so we can call it inside a useEffect hook
   const response = await queryClient.fetchQuery({
-    queryKey: ["sidebar-pages", params],
+    queryKey: ["sidebar-pages", params.spaceId],
     queryFn: () => getSidebarPages(params),
     staleTime: 30 * 60 * 1000,
   });

--- a/apps/client/src/features/page/queries/shared-page-query.ts
+++ b/apps/client/src/features/page/queries/shared-page-query.ts
@@ -1,0 +1,92 @@
+import {
+  useInfiniteQuery,
+  useQuery,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import {
+  IPage,
+  IPageInput,
+  SidebarPagesParams,
+} from "@/features/page/types/page.types";
+import { IPagination } from "@/lib/types.ts";
+import { queryClient } from "@/main.tsx";
+import { buildTree } from "@/features/page/tree/utils";
+import { useEffect } from "react";
+import { validate as isValidUuid } from "uuid";
+import { getSharedPageBreadcrumbs, getSharedPageById, getSharedRecentChanges, getSharedSidebarPages } from "@/features/page/services/shared-page-service";
+
+export function useSharedPageQuery(
+  pageInput: Partial<IPageInput>,
+): UseQueryResult<IPage, Error> {
+  const query = useQuery({
+    queryKey: ["pages", pageInput.pageId],
+    queryFn: () => getSharedPageById(pageInput),
+    enabled: !!pageInput.pageId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  useEffect(() => {
+    if (query.data) {
+      if (isValidUuid(pageInput.pageId)) {
+        queryClient.setQueryData(["pages", query.data.slugId], query.data);
+      } else {
+        queryClient.setQueryData(["pages", query.data.id], query.data);
+      }
+    }
+  }, [query.data]);
+
+  return query;
+}
+
+export function useGetSharedSidebarPagesQuery(
+  data: SidebarPagesParams,
+): UseQueryResult<IPagination<IPage>, Error> {
+  return useQuery({
+    queryKey: ["sidebar-pages", data.spaceId],
+    queryFn: () => getSharedSidebarPages(data),
+  });
+}
+
+export function useGetRootSharedSidebarPagesQuery(data: SidebarPagesParams) {
+  return useInfiniteQuery({
+    queryKey: ["root-sidebar-pages", data.spaceId],
+    queryFn: async ({ pageParam }) => {
+      return getSharedSidebarPages({ spaceId: data.spaceId, page: pageParam });
+    },
+    initialPageParam: 1,
+    getPreviousPageParam: (firstPage) =>
+      firstPage.meta.hasPrevPage ? firstPage.meta.page - 1 : undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.meta.hasNextPage ? lastPage.meta.page + 1 : undefined,
+  });
+}
+
+export function useSharedPageBreadcrumbsQuery(
+  pageId: string,
+): UseQueryResult<Partial<IPage[]>, Error> {
+  return useQuery({
+    queryKey: ["breadcrumbs", pageId],
+    queryFn: () => getSharedPageBreadcrumbs(pageId),
+    enabled: !!pageId,
+  });
+}
+
+export async function fetchSharedAncestorChildren(params: SidebarPagesParams) {
+  // not using a hook here, so we can call it inside a useEffect hook
+  const response = await queryClient.fetchQuery({
+    queryKey: ["sidebar-pages", params],
+    queryFn: () => getSharedSidebarPages(params),
+    staleTime: 30 * 60 * 1000,
+  });
+  return buildTree(response.items);
+}
+
+export function useSharedRecentChangesQuery(
+  spaceId?: string,
+): UseQueryResult<IPagination<IPage>, Error> {
+  return useQuery({
+    queryKey: ["recent-changes", spaceId],
+    queryFn: () => getSharedRecentChanges(spaceId),
+    refetchOnMount: true,
+  });
+}

--- a/apps/client/src/features/page/services/shared-page-service.ts
+++ b/apps/client/src/features/page/services/shared-page-service.ts
@@ -1,0 +1,49 @@
+import api from "@/lib/api-client";
+import {
+  IExportPageParams,
+  IPage,
+  IPageInput,
+  SidebarPagesParams,
+} from "@/features/page/types/page.types";
+import { IPagination } from "@/lib/types.ts";
+import { saveAs } from "file-saver";
+
+export async function getSharedPageById(
+  pageInput: Partial<IPageInput>,
+): Promise<IPage> {
+  const req = await api.post<IPage>("/share/pages/info", pageInput);
+  return req.data;
+}
+
+export async function getSharedSidebarPages(
+  params: SidebarPagesParams,
+): Promise<IPagination<IPage>> {
+  const req = await api.post("/share/pages/sidebar-pages", params);
+  return req.data;
+}
+
+export async function getSharedPageBreadcrumbs(
+  pageId: string,
+): Promise<Partial<IPage[]>> {
+  const req = await api.post("/share/pages/breadcrumbs", { pageId });
+  return req.data;
+}
+
+export async function getSharedRecentChanges(
+  spaceId?: string,
+): Promise<IPagination<IPage>> {
+  const req = await api.post("/share/pages/recent", { spaceId });
+  return req.data;
+}
+
+export async function exportSharedPage(data: IExportPageParams): Promise<void> {
+  const req = await api.post("/share/pages/export", data, {
+    responseType: "blob",
+  });
+
+  const fileName = req?.headers["content-disposition"]
+    .split("filename=")[1]
+    .replace(/"/g, "");
+
+  saveAs(req.data, decodeURIComponent(fileName));
+}

--- a/apps/client/src/features/page/tree/hooks/use-tree-mutation.ts
+++ b/apps/client/src/features/page/tree/hooks/use-tree-mutation.ts
@@ -57,7 +57,7 @@ export function useTreeMutation<T>(spaceId: string) {
       position: createdPage.position,
       spaceId: createdPage.spaceId,
       parentPageId: createdPage.parentPageId,
-      children: [],
+      children: []
     } as any;
 
     let lastIndex: number;

--- a/apps/client/src/features/page/tree/utils/utils.ts
+++ b/apps/client/src/features/page/tree/utils/utils.ts
@@ -24,7 +24,7 @@ export function buildTree(pages: IPage[]): SpaceTreeNode[] {
       hasChildren: page.hasChildren,
       spaceId: page.spaceId,
       parentPageId: page.parentPageId,
-      children: [],
+      children: []
     };
   });
 

--- a/apps/client/src/features/search/queries/shared-search-query.ts
+++ b/apps/client/src/features/search/queries/shared-search-query.ts
@@ -1,0 +1,13 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { searchSharedPage } from "@/features/search/services/shared-search-service";
+import { IPageSearch, IPageSearchParams } from "@/features/search/types/search.types";
+
+export function useSharedPageSearchQuery(
+  params: IPageSearchParams,
+): UseQueryResult<IPageSearch[], Error> {
+  return useQuery({
+    queryKey: ["page-search", params],
+    queryFn: () => searchSharedPage(params),
+    enabled: !!params.query,
+  });
+}

--- a/apps/client/src/features/search/services/shared-search-service.ts
+++ b/apps/client/src/features/search/services/shared-search-service.ts
@@ -1,0 +1,21 @@
+import api from "@/lib/api-client";
+import {
+  IPageSearch,
+  IPageSearchParams,
+  ISuggestionResult,
+  SearchSuggestionParams,
+} from "@/features/search/types/search.types";
+
+export async function searchSharedPage(
+  params: IPageSearchParams,
+): Promise<IPageSearch[]> {
+  const req = await api.post<IPageSearch[]>("/share/search", params);
+  return req.data;
+}
+
+export async function sharedSearchSuggestions(
+  params: SearchSuggestionParams,
+): Promise<ISuggestionResult> {
+  const req = await api.post<ISuggestionResult>("/share/search/suggest", params);
+  return req.data;
+}

--- a/apps/client/src/features/search/shared-search-spotlight.tsx
+++ b/apps/client/src/features/search/shared-search-spotlight.tsx
@@ -1,0 +1,80 @@
+import { Group, Center, Text } from "@mantine/core";
+import { Spotlight } from "@mantine/spotlight";
+import { IconSearch } from "@tabler/icons-react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useDebouncedValue } from "@mantine/hooks";
+import { useSharedPageSearchQuery } from "@/features/search/queries/shared-search-query";
+import { buildPageUrl } from "@/features/page/page.utils.ts";
+import { getPageIcon } from "@/lib";
+import { useTranslation } from "react-i18next";
+
+interface SharedSearchSpotlightProps {
+  spaceId?: string;
+}
+export function SharedSearchSpotlight({ spaceId }: SharedSearchSpotlightProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const [debouncedSearchQuery] = useDebouncedValue(query, 300);
+
+  const {
+    data: searchResults
+  } = useSharedPageSearchQuery({ query: debouncedSearchQuery, spaceId });
+
+  const pages = (
+    searchResults && searchResults.length > 0 ? searchResults : []
+  ).map((page) => (
+    <Spotlight.Action
+      key={page.id}
+      onClick={() =>
+        navigate(buildPageUrl(page.space.slug, page.slugId, page.title))
+      }
+    >
+      <Group wrap="nowrap" w="100%">
+        <Center>{getPageIcon(page?.icon)}</Center>
+
+        <div style={{ flex: 1 }}>
+          <Text>{page.title}</Text>
+
+          {page?.highlight && (
+            <Text
+              opacity={0.6}
+              size="xs"
+              dangerouslySetInnerHTML={{ __html: page.highlight }}
+            />
+          )}
+        </div>
+      </Group>
+    </Spotlight.Action>
+  ));
+
+  return (
+    <>
+      <Spotlight.Root
+        query={query}
+        onQueryChange={setQuery}
+        scrollable
+        overlayProps={{
+          backgroundOpacity: 0.55,
+        }}
+      >
+        <Spotlight.Search
+          placeholder={t("Search...")}
+          leftSection={<IconSearch size={20} stroke={1.5} />}
+        />
+        <Spotlight.ActionsList>
+          {query.length === 0 && pages.length === 0 && (
+            <Spotlight.Empty>{t("Start typing to search...")}</Spotlight.Empty>
+          )}
+
+          {query.length > 0 && pages.length === 0 && (
+            <Spotlight.Empty>{t("No results found...")}</Spotlight.Empty>
+          )}
+
+          {pages.length > 0 && pages}
+        </Spotlight.ActionsList>
+      </Spotlight.Root>
+    </>
+  );
+}

--- a/apps/client/src/features/space/components/publish-space-button.tsx
+++ b/apps/client/src/features/space/components/publish-space-button.tsx
@@ -1,0 +1,23 @@
+import { Button } from "@mantine/core";
+import React from "react";
+import { usePublishMutation, useSpaceQuery } from "@/features/space/queries/space-query.ts";
+import { useTranslation } from "react-i18next";
+
+interface PublishSpaceButtonProps {
+  spaceId: string;
+}
+
+export default function PublishSpaceButton({ spaceId }: PublishSpaceButtonProps) {
+  const { t } = useTranslation();
+  const { data: space } = useSpaceQuery(spaceId);
+  const publishSpaceMutation = usePublishMutation();
+
+  const buttonLabel = space?.isPublished ? t("Unpublish space") : t("Publish space")
+
+  const onClick = () => publishSpaceMutation.mutateAsync({
+    spaceId,
+    publish: !space?.isPublished
+  })
+
+  return <Button onClick={onClick}>{buttonLabel}</Button>;
+}

--- a/apps/client/src/features/space/components/settings-modal.tsx
+++ b/apps/client/src/features/space/components/settings-modal.tsx
@@ -1,7 +1,8 @@
-import {Modal, Tabs, rem, Group, ScrollArea, Text} from "@mantine/core";
+import React from "react";
+import {Modal, Tabs, rem, Group, Text} from "@mantine/core";
 import SpaceMembersList from "@/features/space/components/space-members.tsx";
 import AddSpaceMembersModal from "@/features/space/components/add-space-members-modal.tsx";
-import React, {useMemo} from "react";
+import PublishSpaceButton from "@/features/space/components/publish-space-button";
 import SpaceDetails from "@/features/space/components/space-details.tsx";
 import {useSpaceQuery} from "@/features/space/queries/space-query.ts";
 import {useSpaceAbility} from "@/features/space/permissions/use-space-ability.ts";
@@ -74,7 +75,12 @@ export default function SpaceSettingsModal({
                     {spaceAbility.can(
                       SpaceCaslAction.Manage,
                       SpaceCaslSubject.Member,
-                    ) && <AddSpaceMembersModal spaceId={space?.id}/>}
+                    ) && (
+                      <>
+                        <AddSpaceMembersModal spaceId={space?.id}/>
+                        <PublishSpaceButton spaceId={space?.id}/>
+                      </>
+                    )}
                   </Group>
 
                   <SpaceMembersList

--- a/apps/client/src/features/space/components/shared-space-home-tabs.tsx
+++ b/apps/client/src/features/space/components/shared-space-home-tabs.tsx
@@ -1,0 +1,30 @@
+import { Text, Tabs, Space } from "@mantine/core";
+import { IconClockHour3 } from "@tabler/icons-react";
+import SharedRecentChanges from "@/components/common/shared-recent-changes.tsx";
+import { useParams } from "react-router-dom";
+import { useGetSharedSpaceBySlugQuery } from "@/features/space/queries/shared-space-query.ts";
+import { useTranslation } from "react-i18next";
+
+export default function SharedSpaceHomeTabs() {
+  const { t } = useTranslation();
+  const { spaceSlug } = useParams();
+  const { data: space } = useGetSharedSpaceBySlugQuery(spaceSlug);
+
+  return (
+    <Tabs defaultValue="recent">
+      <Tabs.List>
+        <Tabs.Tab value="recent" leftSection={<IconClockHour3 size={18} />}>
+          <Text size="sm" fw={500}>
+            {t("Recently updated")}
+          </Text>
+        </Tabs.Tab>
+      </Tabs.List>
+
+      <Space my="md" />
+
+      <Tabs.Panel value="recent">
+        {space?.id && <SharedRecentChanges spaceId={space.id} />}
+      </Tabs.Panel>
+    </Tabs>
+  );
+}

--- a/apps/client/src/features/space/components/sidebar/shared-space-sidebar.tsx
+++ b/apps/client/src/features/space/components/sidebar/shared-space-sidebar.tsx
@@ -1,0 +1,107 @@
+import {
+  Avatar,
+  Group,
+  Text,
+  UnstyledButton,
+} from "@mantine/core";
+import { spotlight } from "@mantine/spotlight";
+import {
+  IconHome,
+  IconSearch,
+} from "@tabler/icons-react";
+import classes from "./space-sidebar.module.css";
+import switchSpaceClasses from "./switch-space.module.css";
+import { SharedSearchSpotlight } from "@/features/search/shared-search-spotlight.tsx";
+import { Link, useLocation, useParams } from "react-router-dom";
+import clsx from "clsx";
+import { getSpaceUrl } from "@/lib/config.ts";
+import { useTranslation } from "react-i18next";
+import { useGetSharedSpaceBySlugQuery } from "@/features/space/queries/shared-space-query";
+import SharedSpaceTree from "@/features/page/tree/components/shared-space-tree";
+
+export function SharedSpaceSidebar() {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const { spaceSlug } = useParams();
+  const { data: space } = useGetSharedSpaceBySlugQuery(spaceSlug);
+
+  if (!space) {
+    return <></>;
+  }
+
+  return (
+    <>
+      <div className={classes.navbar}>
+        <div
+          className={classes.section}
+          style={{
+            border: "none",
+            marginTop: 2,
+            marginBottom: 3,
+          }}
+        >
+          <div className={classes.spaceName}>
+            <Avatar
+              size={20}
+              color="initials"
+              variant="filled"
+              name={space?.name}
+            />
+            <Text size="md" fw={500} lineClamp={1}>
+              {space?.name}
+            </Text>
+          </div>
+        </div>
+
+        <div className={classes.section}>
+          <div className={classes.menuItems}>
+            <UnstyledButton
+              component={Link}
+              to={getSpaceUrl(spaceSlug)}
+              className={clsx(
+                classes.menu,
+                location.pathname.toLowerCase() === getSpaceUrl(spaceSlug)
+                  ? classes.activeButton
+                  : "",
+              )}
+            >
+              <div className={classes.menuItemInner}>
+                <IconHome
+                  size={18}
+                  className={classes.menuItemIcon}
+                  stroke={2}
+                />
+                <span>{t("Overview")}</span>
+              </div>
+            </UnstyledButton>
+
+            <UnstyledButton className={classes.menu} onClick={spotlight.open}>
+              <div className={classes.menuItemInner}>
+                <IconSearch
+                  size={18}
+                  className={classes.menuItemIcon}
+                  stroke={2}
+                />
+                <span>{t("Search")}</span>
+              </div>
+            </UnstyledButton>
+          </div>
+        </div>
+
+        <div className={clsx(classes.section, classes.sectionPages)}>
+          <Group className={classes.pagesHeader} justify="space-between">
+            <Text size="xs" fw={500} c="dimmed">
+              {t("Pages")}
+            </Text>
+          </Group>
+
+          <div className={classes.pages}>
+            <SharedSpaceTree spaceId={space.id} />
+          </div>
+        </div>
+      </div>
+
+      <SharedSearchSpotlight spaceId={space.id} />
+    </>
+  );
+}

--- a/apps/client/src/features/space/components/sidebar/space-sidebar.module.css
+++ b/apps/client/src/features/space/components/sidebar/space-sidebar.module.css
@@ -94,3 +94,20 @@
     background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-6));
     color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-0));
 }
+
+.spaceName {
+    width: 100%;
+    color: light-dark(var(--mantine-color-dark-4), var(--mantine-color-dark-0));
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding-top: var(--mantine-spacing-xs);
+    padding-bottom: var(--mantine-spacing-xs);
+    padding-right: var(--mantine-spacing-sm);
+    padding-left: var(--mantine-spacing-md);
+
+    & > *:not(:first-child) {
+        margin-left: var(--mantine-spacing-sm);
+    }
+}
+  

--- a/apps/client/src/features/space/components/sidebar/space-sidebar.tsx
+++ b/apps/client/src/features/space/components/sidebar/space-sidebar.tsx
@@ -106,16 +106,21 @@ export function SpaceSidebar() {
               </div>
             </UnstyledButton>
 
-            <UnstyledButton className={classes.menu} onClick={openSettings}>
-              <div className={classes.menuItemInner}>
-                <IconSettings
-                  size={18}
-                  className={classes.menuItemIcon}
-                  stroke={2}
-                />
-                <span>{t("Space settings")}</span>
-              </div>
-            </UnstyledButton>
+            {spaceAbility.can(
+              SpaceCaslAction.Manage,
+              SpaceCaslSubject.Settings,
+            ) && (
+              <UnstyledButton className={classes.menu} onClick={openSettings}>
+                <div className={classes.menuItemInner}>
+                  <IconSettings
+                    size={18}
+                    className={classes.menuItemIcon}
+                    stroke={2}
+                  />
+                  <span>{t("Space settings")}</span>
+                </div>
+              </UnstyledButton>
+            )}
 
             {spaceAbility.can(
               SpaceCaslAction.Manage,

--- a/apps/client/src/features/space/queries/shared-space-query.ts
+++ b/apps/client/src/features/space/queries/shared-space-query.ts
@@ -1,0 +1,52 @@
+import { validate as isValidUuid } from "uuid";
+import { useEffect } from "react";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { queryClient } from "@/main.tsx";
+import { ISpace } from "@/features/space/types/space.types";
+import { getSharedSpaceById } from "@/features/space/services/shared-space-service";
+import { getSharedRecentChanges } from "@/features/page/services/shared-page-service";
+
+export function useSharedSpaceQuery(spaceId: string): UseQueryResult<ISpace, Error> {
+  const query = useQuery({
+    queryKey: ["space", spaceId],
+    queryFn: () => getSharedSpaceById(spaceId),
+    enabled: !!spaceId,
+  });
+  useEffect(() => {
+    if (query.data) {
+      if (isValidUuid(spaceId)) {
+        queryClient.setQueryData(["space", query.data.slug], query.data);
+      } else {
+        queryClient.setQueryData(["space", query.data.id], query.data);
+      }
+    }
+  }, [query.data]);
+
+  return query;
+}
+
+export const prefetchSharedSpace = (spaceSlug: string, spaceId?: string) => {
+  queryClient.prefetchQuery({
+    queryKey: ["space", spaceSlug],
+    queryFn: () => getSharedSpaceById(spaceSlug),
+  });
+
+  if (spaceId) {
+    // this endpoint only accepts uuid for now
+    queryClient.prefetchQuery({
+      queryKey: ["recent-changes", spaceId],
+      queryFn: () => getSharedRecentChanges(spaceId),
+    });
+  }
+};
+
+export function useGetSharedSpaceBySlugQuery(
+  spaceId: string,
+): UseQueryResult<ISpace, Error> {
+  return useQuery({
+    queryKey: ["space", spaceId],
+    queryFn: () => getSharedSpaceById(spaceId),
+    enabled: !!spaceId,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/client/src/features/space/queries/space-query.ts
+++ b/apps/client/src/features/space/queries/space-query.ts
@@ -8,6 +8,7 @@ import {
 import {
   IAddSpaceMember,
   IChangeSpaceMemberRole,
+  IPublishSpace,
   IRemoveSpaceMember,
   ISpace,
   ISpaceMember,
@@ -228,6 +229,27 @@ export function useChangeSpaceMemberRoleMutation() {
       // due to pagination levels, change in cache instead
       queryClient.refetchQueries({
         queryKey: ["spaceMembers", variables.spaceId],
+      });
+    },
+    onError: (error) => {
+      const errorMessage = error["response"]?.data?.message;
+      notifications.show({ message: errorMessage, color: "red" });
+    },
+  });
+}
+
+export function usePublishMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<ISpace, Error, IPublishSpace>({
+    mutationFn: ({ spaceId, publish }) => updateSpace({
+      spaceId,
+      isPublished: publish
+    }),
+    onSuccess: (data, variables) => {
+      notifications.show({ message: "Published space successfully" });
+      queryClient.invalidateQueries({
+        queryKey: ["space", variables.spaceId],
       });
     },
     onError: (error) => {

--- a/apps/client/src/features/space/services/shared-space-service.ts
+++ b/apps/client/src/features/space/services/shared-space-service.ts
@@ -1,0 +1,20 @@
+import api from "@/lib/api-client";
+import { IExportSpaceParams, ISpace } from "@/features/space/types/space.types";
+import { saveAs } from "file-saver";
+
+export async function getSharedSpaceById(spaceId: string): Promise<ISpace> {
+  const req = await api.post<ISpace>("/share/spaces/info", { spaceId });
+  return req.data;
+}
+
+export async function exportSharedSpace(data: IExportSpaceParams): Promise<void> {
+  const req = await api.post("/share/spaces/export", data, {
+    responseType: "blob",
+  });
+
+  const fileName = req?.headers["content-disposition"]
+    .split("filename=")[1]
+    .replace(/"/g, "");
+
+  saveAs(req.data, decodeURIComponent(fileName));
+}

--- a/apps/client/src/features/space/types/space.types.ts
+++ b/apps/client/src/features/space/types/space.types.ts
@@ -13,6 +13,7 @@ export interface ISpace {
   slug: string;
   hostname: string;
   creatorId: string;
+  isPublished: boolean;
   createdAt: Date;
   updatedAt: Date;
   memberCount?: number;
@@ -68,10 +69,15 @@ export interface SpaceGroupInfo {
   type: "group";
 }
 
-export type ISpaceMember = { role: string } & (SpaceUserInfo | SpaceGroupInfo);
+export type ISpaceMember = { role: SpaceRole } & (SpaceUserInfo | SpaceGroupInfo);
 
 export interface IExportSpaceParams {
   spaceId: string;
   format: ExportFormat;
   includeAttachments?: boolean;
+}
+
+export interface IPublishSpace {
+  spaceId: string;
+  publish: boolean;
 }

--- a/apps/client/src/lib/config.ts
+++ b/apps/client/src/lib/config.ts
@@ -49,7 +49,9 @@ export function getAvatarUrl(avatarUrl: string) {
 }
 
 export function getSpaceUrl(spaceSlug: string) {
-  return "/s/" + spaceSlug;
+  const isSharedPrefixed = window.location.pathname.startsWith("/share")
+  const sharedPrefix = isSharedPrefixed ? "/share" : ""
+  return sharedPrefix + "/s/" + spaceSlug;
 }
 
 export function getFileUrl(src: string) {
@@ -63,6 +65,24 @@ export function getFileUrl(src: string) {
     return getBackendUrl() + src;
   }
   return src;
+}
+
+export function getSharedFileUrl(src: string) {
+  if (!src) return src;
+
+  let url = src
+  if (!src.startsWith("http")) {
+    if (src.startsWith("/api/")) {
+      // Remove the '/api' prefix
+      url = getBackendUrl() + src.substring(4);
+    } else {
+      url = getBackendUrl() + src;
+    }
+  }
+  
+  url = url.replace("/api/files/", "/api/share/files/");
+
+  return url
 }
 
 export function getFileUploadSizeLimit() {

--- a/apps/client/src/pages/page/shared-page.tsx
+++ b/apps/client/src/pages/page/shared-page.tsx
@@ -1,0 +1,52 @@
+import { useParams } from "react-router-dom";
+import { Helmet } from "react-helmet-async";
+import { useTranslation } from "react-i18next";
+import { extractPageSlugId } from "@/lib";
+import HistoryModal from "@/features/page-history/components/history-modal";
+import { useSharedPageQuery } from "@/features/page/queries/shared-page-query";
+import { useGetSharedSpaceBySlugQuery } from "@/features/space/queries/shared-space-query";
+import { ReadonlyEditor } from "@/features/editor/readonly-editor";
+
+export default function SharedPage() {
+  const { t } = useTranslation();
+  const { pageSlug } = useParams();
+  const {
+    data: page,
+    isLoading,
+    isError,
+    error,
+  } = useSharedPageQuery({ pageId: extractPageSlugId(pageSlug) });
+  const { data: space } = useGetSharedSpaceBySlugQuery(page?.space?.slug);
+
+  if (isLoading) {
+    return <></>;
+  }
+
+  if (isError || !page) {
+    if ([401, 403, 404].includes(error?.["status"])) {
+      return <div>{t("Page not found")}</div>;
+    }
+    return <div>{t("Error fetching page data.")}</div>;
+  }
+
+  if (!space) {
+    return <></>;
+  }
+
+  return (
+    page && (
+      <div>
+        <Helmet>
+          <title>{`${page?.icon || ""}  ${page?.title || t("untitled")}`}</title>
+        </Helmet>
+
+        <ReadonlyEditor
+          key={page.id}
+          title={page.title}
+          content={page.content}
+        />
+        <HistoryModal pageId={page.id} />
+      </div>
+    )
+  );
+}

--- a/apps/client/src/pages/space/shared-space-home.tsx
+++ b/apps/client/src/pages/space/shared-space-home.tsx
@@ -1,0 +1,22 @@
+import {Container} from "@mantine/core";
+import SharedSpaceHomeTabs from "@/features/space/components/shared-space-home-tabs.tsx";
+import {useParams} from "react-router-dom";
+import {useGetSharedSpaceBySlugQuery} from "@/features/space/queries/shared-space-query.ts";
+import {getAppName} from "@/lib/config.ts";
+import {Helmet} from "react-helmet-async";
+
+export default function SpaceHome() {
+    const {spaceSlug} = useParams();
+    const {data: space} = useGetSharedSpaceBySlugQuery(spaceSlug);
+
+    return (
+        <>
+            <Helmet>
+                <title>{space?.name || 'Overview'} - {getAppName()}</title>
+            </Helmet>
+            <Container size={"800"} pt="xl">
+                {space && <SharedSpaceHomeTabs/>}
+            </Container>
+        </>
+    );
+}

--- a/apps/server/src/common/helpers/types/permission.ts
+++ b/apps/server/src/common/helpers/types/permission.ts
@@ -2,6 +2,7 @@ export enum UserRole {
   OWNER = 'owner',
   ADMIN = 'admin', // can have owner permissions but cannot delete workspace
   MEMBER = 'member',
+  GUEST = 'guest',
 }
 
 export enum SpaceRole {

--- a/apps/server/src/common/helpers/utils.ts
+++ b/apps/server/src/common/helpers/utils.ts
@@ -1,5 +1,9 @@
 import * as path from 'path';
 import * as bcrypt from 'bcrypt';
+import { User } from '@docmost/db/types/entity.types';
+import { validate as isValidUUID } from 'uuid';
+import { UserRole } from './types/permission';
+import { PaginationResult } from '@docmost/db/pagination/pagination';
 
 export const envPath = path.resolve(process.cwd(), '..', '..', '.env');
 
@@ -61,4 +65,25 @@ export function extractDateFromUuid7(uuid7: string) {
   const timestamp = parseInt(highBitsHex, 16);
 
   return new Date(timestamp);
+}
+
+export const anonymous: User = {
+  id: 'anonymous',
+  name: 'Anonymous',
+  role: UserRole.GUEST,
+  avatarUrl: '',
+  email: '',
+  invitedById: '',
+  locale: '',
+  password: '',
+  settings: '',
+  timezone: '',
+  workspaceId: '',
+  createdAt: undefined,
+  deactivatedAt: undefined,
+  deletedAt: undefined,
+  emailVerifiedAt: undefined,
+  lastActiveAt: undefined,
+  lastLoginAt: undefined,
+  updatedAt: undefined
 }

--- a/apps/server/src/core/casl/abilities/workspace-ability.factory.ts
+++ b/apps/server/src/core/casl/abilities/workspace-ability.factory.ts
@@ -24,6 +24,8 @@ export default class WorkspaceAbilityFactory {
         return buildWorkspaceAdminAbility();
       case UserRole.MEMBER:
         return buildWorkspaceMemberAbility();
+      case UserRole.GUEST:
+        return buildWorkspaceGuestAbility();
       default:
         throw new NotFoundException('Workspace permissions not found');
     }
@@ -69,5 +71,12 @@ function buildWorkspaceMemberAbility() {
   can(WorkspaceCaslAction.Read, WorkspaceCaslSubject.Group);
   can(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Attachment);
 
+  return build();
+}
+
+function buildWorkspaceGuestAbility() {
+  const { build } = new AbilityBuilder<MongoAbility<IWorkspaceAbility>>(
+    createMongoAbility,
+  );
   return build();
 }

--- a/apps/server/src/core/core.module.ts
+++ b/apps/server/src/core/core.module.ts
@@ -15,6 +15,7 @@ import { SpaceModule } from './space/space.module';
 import { GroupModule } from './group/group.module';
 import { CaslModule } from './casl/casl.module';
 import { DomainMiddleware } from '../common/middlewares/domain.middleware';
+import { ShareModule } from './share/share.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { DomainMiddleware } from '../common/middlewares/domain.middleware';
     SpaceModule,
     GroupModule,
     CaslModule,
+    ShareModule
   ],
 })
 export class CoreModule implements NestModule {

--- a/apps/server/src/core/page/services/page.service.ts
+++ b/apps/server/src/core/page/services/page.service.ts
@@ -161,7 +161,7 @@ export class PageService {
         'position',
         'parentPageId',
         'spaceId',
-        'creatorId',
+        'creatorId'
       ])
       .select((eb) => this.withHasChildren(eb))
       .orderBy('position', 'asc')

--- a/apps/server/src/core/search/search.module.ts
+++ b/apps/server/src/core/search/search.module.ts
@@ -5,5 +5,6 @@ import { SearchService } from './search.service';
 @Module({
   controllers: [SearchController],
   providers: [SearchService],
+  exports: [SearchService],
 })
 export class SearchModule {}

--- a/apps/server/src/core/share/share.controller.spec.ts
+++ b/apps/server/src/core/share/share.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ShareController } from './share.controller';
+
+describe('ShareController', () => {
+  let controller: ShareController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ShareController]
+    }).compile();
+
+    controller = module.get<ShareController>(ShareController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/server/src/core/share/share.controller.ts
+++ b/apps/server/src/core/share/share.controller.ts
@@ -1,0 +1,227 @@
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Get,
+  Post,
+  UnauthorizedException,
+  Res,
+  Param,
+  Logger,
+} from '@nestjs/common';
+import { PaginationOptions } from '@docmost/db/pagination/pagination-options';
+import SpaceAbilityFactory from '../casl/abilities/space-ability.factory';
+import { SpaceCaslAction, SpaceCaslSubject, } from '../casl/interfaces/space-ability.type';
+import { anonymous } from 'src/common/helpers';
+import { SpaceRole } from 'src/common/helpers/types/permission';
+import { SpaceService } from '../space/services/space.service';
+import { SpaceIdDto } from '../space/dto/space-id.dto';
+import { PageService } from '../page/services/page.service';
+import { PageRepo } from '@docmost/db/repos/page/page.repo';
+import { PageIdDto, PageInfoDto } from '../page/dto/page.dto';
+import { RecentPageDto } from '../page/dto/recent-page.dto';
+import { SidebarPageDto } from '../page/dto/sidebar-page.dto';
+import { SearchService } from '../search/search.service';
+import { SearchDTO } from '../search/dto/search.dto';
+import { StorageService } from 'src/integrations/storage/storage.service';
+import { AttachmentRepo } from '@docmost/db/repos/attachment/attachment.repo';
+import {FastifyReply} from 'fastify';
+import {validate as isValidUUID} from 'uuid';
+import { inlineFileExtensions } from '../attachment/attachment.constants';
+
+@Controller('share')
+export class ShareController {
+  private readonly logger = new Logger(ShareController.name);
+
+  constructor(
+    private readonly spaceService: SpaceService,
+    private readonly spaceAbility: SpaceAbilityFactory,
+    private readonly pageService: PageService,
+    private readonly pageRepo: PageRepo,
+    private readonly searchService: SearchService,
+    private readonly storageService: StorageService,
+    private readonly attachmentRepo: AttachmentRepo,
+  ) {}
+
+  @HttpCode(HttpStatus.OK)
+  @Post('spaces/info')
+  async getSpaceInfo(
+    @Body() spaceIdDto: SpaceIdDto,
+  ) {
+    const space = await this.spaceService.getSpaceInfo(spaceIdDto.spaceId);
+
+    if (!space) {
+      throw new NotFoundException('Space not found');
+    }
+
+    const ability = await this.spaceAbility.createForUser(anonymous, space.id);
+    if (ability.cannot(SpaceCaslAction.Read, SpaceCaslSubject.Settings)) {
+      throw new ForbiddenException();
+    }
+
+    return {
+      ...space,
+      membership: {
+        userId: anonymous.id,
+        role: SpaceRole.READER,
+        permissions: ability.rules,
+      }
+    }
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Post('pages/info')
+  async getPage(@Body() dto: PageInfoDto) {
+    const page = await this.pageRepo.findById(dto.pageId, {
+      includeSpace: true,
+      includeContent: true,
+      includeCreator: true,
+      includeLastUpdatedBy: true,
+    });
+
+    if (!page) {
+      throw new NotFoundException('Page not found');
+    }
+
+    const ability = await this.spaceAbility.createForUser(anonymous, page.spaceId);
+    if (ability.cannot(SpaceCaslAction.Read, SpaceCaslSubject.Page)) {
+      throw new ForbiddenException();
+    }
+
+    return page;
+  }
+  
+  @HttpCode(HttpStatus.OK)
+  @Post('pages/recent')
+  async getRecentPages(
+    @Body() recentPageDto: RecentPageDto,
+    @Body() pagination: PaginationOptions,
+  ) {
+    if (recentPageDto.spaceId) {
+      const ability = await this.spaceAbility.createForUser(
+        anonymous,
+        recentPageDto.spaceId,
+      );
+
+      if (ability.cannot(SpaceCaslAction.Read, SpaceCaslSubject.Page)) {
+        throw new ForbiddenException();
+      }
+
+      return this.pageService.getRecentSpacePages(
+        recentPageDto.spaceId,
+        pagination,
+      );
+    }
+
+    return this.pageService.getRecentPages(anonymous.id, pagination);
+  }
+  
+  @HttpCode(HttpStatus.OK)
+  @Post('pages/sidebar-pages')
+  async getSidebarPages(
+    @Body() dto: SidebarPageDto,
+    @Body() pagination: PaginationOptions,
+  ) {
+    const ability = await this.spaceAbility.createForUser(anonymous, dto.spaceId);
+    if (ability.cannot(SpaceCaslAction.Read, SpaceCaslSubject.Page)) {
+      throw new ForbiddenException();
+    }
+
+    let pageId = null;
+    if (dto.pageId) {
+      const page = await this.pageRepo.findById(dto.pageId);
+      if (page.spaceId !== dto.spaceId) {
+        throw new ForbiddenException();
+      }
+      pageId = page.id;
+    }
+
+    return this.pageService.getSidebarPages(dto.spaceId, pagination, pageId);
+  }
+  
+  @HttpCode(HttpStatus.OK)
+  @Post('pages/breadcrumbs')
+  async getPageBreadcrumbs(@Body() dto: PageIdDto) {
+    const page = await this.pageRepo.findById(dto.pageId);
+    if (!page) {
+      throw new NotFoundException('Page not found');
+    }
+
+    const ability = await this.spaceAbility.createForUser(anonymous, page.spaceId);
+    if (ability.cannot(SpaceCaslAction.Read, SpaceCaslSubject.Page)) {
+      throw new ForbiddenException();
+    }
+    return this.pageService.getPageBreadCrumbs(page.id);
+  }
+  
+  @HttpCode(HttpStatus.OK)
+  @Post('search')
+  async pageSearch(@Body() searchDto: SearchDTO) {
+    if (searchDto.spaceId) {
+      const ability = await this.spaceAbility.createForUser(
+        anonymous,
+        searchDto.spaceId,
+      );
+
+      if (ability.cannot(SpaceCaslAction.Read, SpaceCaslSubject.Page)) {
+        throw new ForbiddenException();
+      }
+
+      return this.searchService.searchPage(searchDto.query, searchDto);
+    }
+
+    throw new UnauthorizedException();
+  }
+
+  @Get('/files/:fileId/:fileName')
+  async getFile(
+      @Res() res: FastifyReply,
+      @Param('fileId') fileId: string,
+      @Param('fileName') fileName?: string,
+  ) {
+      if (!isValidUUID(fileId)) {
+          throw new NotFoundException('Invalid file id');
+      }
+
+      const attachment = await this.attachmentRepo.findById(fileId);
+      if (
+          !attachment ||
+          !attachment.pageId ||
+          !attachment.spaceId
+      ) {
+          throw new NotFoundException();
+      }
+
+      const spaceAbility = await this.spaceAbility.createForUser(
+          anonymous,
+          attachment.spaceId,
+      );
+
+      if (spaceAbility.cannot(SpaceCaslAction.Read, SpaceCaslSubject.Page)) {
+          throw new ForbiddenException();
+      }
+
+      try {
+          const fileStream = await this.storageService.read(attachment.filePath);
+          res.headers({
+              'Content-Type': attachment.mimeType,
+              'Cache-Control': 'private, max-age=3600',
+          });
+
+          if (!inlineFileExtensions.includes(attachment.fileExt)) {
+              res.header(
+                  'Content-Disposition',
+                  `attachment; filename="${encodeURIComponent(attachment.fileName)}"`,
+              );
+          }
+
+          return res.send(fileStream);
+      } catch (err) {
+          this.logger.error(err);
+          throw new NotFoundException('File not found');
+      }
+  }
+}

--- a/apps/server/src/core/share/share.module.ts
+++ b/apps/server/src/core/share/share.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ShareController } from './share.controller';
+import { SpaceModule } from '../space/space.module';
+import { PageModule } from '../page/page.module';
+import { SearchModule } from '../search/search.module';
+import { ExportModule } from 'src/integrations/export/export.module';
+
+@Module({
+  controllers: [ShareController],
+  imports: [SpaceModule, PageModule, SearchModule, ExportModule]
+})
+export class ShareModule {}

--- a/apps/server/src/core/space/dto/create-space.dto.ts
+++ b/apps/server/src/core/space/dto/create-space.dto.ts
@@ -1,5 +1,6 @@
 import {
   IsAlphanumeric,
+  IsBoolean,
   IsOptional,
   IsString,
   MaxLength,
@@ -22,4 +23,8 @@ export class CreateSpaceDto {
   @MaxLength(50)
   @IsAlphanumeric()
   slug: string;
+  
+  @IsOptional()
+  @IsBoolean()
+  isPublished?: boolean;
 }

--- a/apps/server/src/core/space/services/space-member.service.ts
+++ b/apps/server/src/core/space/services/space-member.service.ts
@@ -66,7 +66,7 @@ export class SpaceMemberService {
    */
   async getSpaceMembers(
     spaceId: string,
-    workspaceId: string,
+    workspaceId: string | undefined,
     pagination: PaginationOptions,
   ) {
     const space = await this.spaceRepo.findById(spaceId, workspaceId);

--- a/apps/server/src/core/space/services/space.service.ts
+++ b/apps/server/src/core/space/services/space.service.ts
@@ -110,13 +110,14 @@ export class SpaceService {
         name: updateSpaceDto.name,
         description: updateSpaceDto.description,
         slug: updateSpaceDto.slug,
+        isPublished: updateSpaceDto.isPublished,
       },
       updateSpaceDto.spaceId,
       workspaceId,
     );
   }
 
-  async getSpaceInfo(spaceId: string, workspaceId: string): Promise<Space> {
+  async getSpaceInfo(spaceId: string, workspaceId?: string): Promise<Space> {
     const space = await this.spaceRepo.findById(spaceId, workspaceId, {
       includeMemberCount: true,
     });

--- a/apps/server/src/database/migrations/20250314T023059-spaces-publish.ts
+++ b/apps/server/src/database/migrations/20250314T023059-spaces-publish.ts
@@ -1,0 +1,13 @@
+import { type Kysely } from 'kysely'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('spaces')
+    .addColumn('is_published', 'boolean', (col) => col.defaultTo(false).notNull())
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.alterTable('spaces').dropColumn('is_published').execute();
+}
+  

--- a/apps/server/src/database/repos/space/space.repo.ts
+++ b/apps/server/src/database/repos/space/space.repo.ts
@@ -19,7 +19,7 @@ export class SpaceRepo {
 
   async findById(
     spaceId: string,
-    workspaceId: string,
+    workspaceId?: string,
     opts?: { includeMemberCount?: boolean; trx?: KyselyTransaction },
   ): Promise<Space> {
     const db = dbOrTx(this.db, opts?.trx);
@@ -28,7 +28,10 @@ export class SpaceRepo {
       .selectFrom('spaces')
       .selectAll('spaces')
       .$if(opts?.includeMemberCount, (qb) => qb.select(this.withMemberCount))
-      .where('workspaceId', '=', workspaceId);
+    
+    if (workspaceId) {
+      query = query.where('workspaceId', '=', workspaceId);
+    }
 
     if (isValidUUID(spaceId)) {
       query = query.where('id', '=', spaceId);
@@ -40,16 +43,20 @@ export class SpaceRepo {
 
   async findBySlug(
     slug: string,
-    workspaceId: string,
+    workspaceId?: string,
     opts?: { includeMemberCount: boolean },
   ): Promise<Space> {
-    return await this.db
+    let query = this.db
       .selectFrom('spaces')
       .selectAll('spaces')
       .$if(opts?.includeMemberCount, (qb) => qb.select(this.withMemberCount))
       .where(sql`LOWER(slug)`, '=', sql`LOWER(${slug})`)
-      .where('workspaceId', '=', workspaceId)
-      .executeTakeFirst();
+    
+    if (workspaceId) {
+      query = query.where('workspaceId', '=', workspaceId);
+    }
+
+    return await query.executeTakeFirst();
   }
 
   async slugExists(

--- a/apps/server/src/database/types/db.d.ts
+++ b/apps/server/src/database/types/db.d.ts
@@ -207,6 +207,7 @@ export interface Spaces {
   updatedAt: Generated<Timestamp>;
   visibility: Generated<string>;
   workspaceId: string;
+  isPublished: boolean;
 }
 
 export interface Users {

--- a/apps/server/src/integrations/export/export.module.ts
+++ b/apps/server/src/integrations/export/export.module.ts
@@ -7,5 +7,6 @@ import { StorageModule } from '../storage/storage.module';
   imports: [StorageModule],
   providers: [ExportService],
   controllers: [ExportController],
+  exports: [ExportService],
 })
 export class ExportModule {}


### PR DESCRIPTION
See demo: https://doc.hoie.kim/share/s/public/p/product-specification-T76LEgs2eq

This might resolve feature request #203 and #23

Note that there's a subtle difference: some requested a feature to publish pages while others wanted a feature to publish the whole spaces. This PR adds feature to publish spaces and all pages in published spaces will be accessible by anonymous users.

~~User interface changes:~~
* ~~`Publish space` button will be added next to `Add space members` button in `Space settings` -> `Members` modal.~~
* ~~Anonymous users won't have user icon and dropdown menu on the upper right hand corner~~
* ~~Anonymous users won't have space list dropdown or space setting menu in the side bar~~
* ~~Anonymous users won't have user preference update buttons in the page kebab menu~~

~~Authentication mechanism changes:~~
* ~~`JwtAuthGuard` won't throw exception if the "referer" header in the request implies that the request is from a published space. Due to this change I added anonymous user handling mechanisms for a few controllers~~
*  ~~When the request is from a published space, `AuthUser` decorator will return anonymous user object. This object represents a hypothetical user data that is actually not stored in DB. This user object is useful when resolving `workspaceAbility` and `spaceAbility`.~~

## Updates on March 17, 2025

User interface changes:
* `Publish space` button will be added next to `Add space members` button in `Space settings` -> `Members` modal.
* Published spaces have "Copy shared link" button in page header menu and page tree menu.
* Shared pages and spaces are accessible via URL starts with `/share`, such as `/share/s/myspace/p/mypage`, etc.

<img width="250" alt="space-setting-modal-screen" src="https://github.com/user-attachments/assets/8124b62d-36df-4114-aed9-47545f75cb74" />
<img width="250" alt="not-shared-page-screen" src="https://github.com/user-attachments/assets/7f4bd3b5-6830-4ef9-813b-ade935f91a26" />
<img width="250" alt="shared-page-screen" src="https://github.com/user-attachments/assets/3d38e4c1-58aa-4b17-80ef-6d660fe37617" />

Both backend and frontend endpoints for shared space are separated from the existing ones and have separate authorization process. To do this I created `ShareController` that has similar methods with `SpaceController` and `PageController` but does not have `JwtAuthGuard`. Instead it authorizes requests from unidentified users if the space in question is a "published" space.
