### PR TITLE
fix: table header in markdown export

### DIFF
--- a/apps/server/src/integrations/export/export.service.ts
+++ b/apps/server/src/integrations/export/export.service.ts
@@ -76,8 +76,9 @@ export class ExportService {
       </html>`;
     }
 
-    if (format === ExportFormat.Markdown) {
-      return turndown(pageHtml);
+    if (format === ExportFormat.Markdown) { 
+      const newPageHtml = pageHtml.replace(/<colgroup[^>]*>[\s\S]*?<\/colgroup>/gmi, '');
+      return turndown(newPageHtml);
     }
 
     return;


### PR DESCRIPTION
Removing colgroup tags in html string before exporting in markdown

```
From isHeadingRow() function in @joplin/turndown-plugin-gfm :
// A tr is a heading row if:
// - the parent is a THEAD
// - or if its the first child of the TABLE or the first TBODY (possibly
//   following a blank THEAD)
// - and every cell is a TH
````
before -> after
![Screenshot 2025-02-20 201533](https://github.com/user-attachments/assets/a533c309-04e5-42ef-add3-7e5e602f6ff9)
