### PR TITLE
fix: accept invitation password hashing

### DIFF
--- a/apps/server/src/core/workspace/services/workspace-invitation.service.ts
+++ b/apps/server/src/core/workspace/services/workspace-invitation.service.ts
@@ -16,7 +16,6 @@ import {
 } from '@docmost/db/types/entity.types';
 import { MailService } from '../../../integrations/mail/mail.service';
 import InvitationEmail from '@docmost/transactional/emails/invitation-email';
-import { hashPassword } from '../../../common/helpers';
 import { GroupUserRepo } from '@docmost/db/repos/group/group-user.repo';
 import InvitationAcceptedEmail from '@docmost/transactional/emails/invitation-accepted-email';
 import { EnvironmentService } from '../../../integrations/environment/environment.service';
@@ -163,7 +162,6 @@ export class WorkspaceInvitationService {
       throw new BadRequestException('Invalid invitation token');
     }
 
-    const password = await hashPassword(dto.password);
     let newUser: User;
 
     try {
@@ -173,7 +171,7 @@ export class WorkspaceInvitationService {
             name: dto.name,
             email: invitation.email,
             emailVerifiedAt: new Date(),
-            password: password,
+            password: dto.password,
             role: invitation.role,
             invitedById: invitation.invitedById,
             workspaceId: workspaceId,


### PR DESCRIPTION
The password is hashed twice in acceptInvitation func and in insertUser func so we get an error when we compare the password hash when we login after invitation.