### PR TITLE
feat: add stats to standalone collab server

### DIFF
--- a/apps/server/src/collaboration/collaboration.module.ts
+++ b/apps/server/src/collaboration/collaboration.module.ts
@@ -16,6 +16,7 @@ import { HistoryListener } from './listeners/history.listener';
     PersistenceExtension,
     HistoryListener,
   ],
+  exports: [CollaborationGateway],
   imports: [TokenModule],
 })
 export class CollaborationModule implements OnModuleInit, OnModuleDestroy {

--- a/apps/server/src/collaboration/server/collab-app.module.ts
+++ b/apps/server/src/collaboration/server/collab-app.module.ts
@@ -7,6 +7,7 @@ import { DatabaseModule } from '@docmost/db/database.module';
 import { QueueModule } from '../../integrations/queue/queue.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { HealthModule } from '../../integrations/health/health.module';
+import { CollaborationController } from './collaboration.controller';
 
 @Module({
   imports: [
@@ -17,7 +18,12 @@ import { HealthModule } from '../../integrations/health/health.module';
     HealthModule,
     EventEmitterModule.forRoot(),
   ],
-  controllers: [AppController],
+  controllers: [
+    AppController,
+    ...(process.env.COLLAB_SHOW_STATS.toLowerCase() === 'true'
+      ? [CollaborationController]
+      : []),
+  ],
   providers: [AppService],
 })
-export class CollabAppAppModule {}
+export class CollabAppModule {}

--- a/apps/server/src/collaboration/server/collab-main.ts
+++ b/apps/server/src/collaboration/server/collab-main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { CollabAppAppModule } from './collab-app.module';
+import { CollabAppModule } from './collab-app.module';
 import {
   FastifyAdapter,
   NestFastifyApplication,
@@ -10,7 +10,7 @@ import { Logger } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
-    CollabAppAppModule,
+    CollabAppModule,
     new FastifyAdapter({
       ignoreTrailingSlash: true,
       ignoreDuplicateSlashes: true,

--- a/apps/server/src/collaboration/server/collaboration.controller.ts
+++ b/apps/server/src/collaboration/server/collaboration.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { CollaborationGateway } from '../collaboration.gateway';
+
+@Controller('collab')
+export class CollaborationController {
+  constructor(private readonly collaborationGateway: CollaborationGateway) {}
+
+  @Get('stats')
+  async getStats() {
+    return {
+      connections: this.collaborationGateway.getConnectionCount(),
+      documents: this.collaborationGateway.getDocumentCount(),
+    };
+  }
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -4,7 +4,7 @@ import {
   FastifyAdapter,
   NestFastifyApplication,
 } from '@nestjs/platform-fastify';
-import { NotFoundException, ValidationPipe } from '@nestjs/common';
+import { Logger, NotFoundException, ValidationPipe } from '@nestjs/common';
 import { TransformHttpResponseInterceptor } from './common/interceptors/http-response.interceptor';
 import fastifyMultipart from '@fastify/multipart';
 import { WsRedisIoAdapter } from './ws/adapter/ws-redis.adapter';
@@ -65,7 +65,14 @@ async function bootstrap() {
   app.useGlobalInterceptors(new TransformHttpResponseInterceptor());
   app.enableShutdownHooks();
 
-  await app.listen(process.env.PORT || 3000, '0.0.0.0');
+  const logger = new Logger('NestApplication');
+
+  const port = process.env.PORT || 3000;
+  await app.listen(port, '0.0.0.0', () => {
+    logger.log(
+      `Listening on http://127.0.0.1:${port} / ${process.env.APP_URL}`,
+    );
+  });
 }
 
 bootstrap();


### PR DESCRIPTION
Introduce `api/collab/stats` endpoint to the standalone collab server.
This shows the total connections and open document count.
Ideally, this should be a protected endpoint.

The endpoint is registered if `COLLAB_SHOW_STATS=true` is set.