### PR TITLE
feat: auto focus emoji-picker search when opened

### DIFF
--- a/apps/client/src/components/ui/emoji-picker.tsx
+++ b/apps/client/src/components/ui/emoji-picker.tsx
@@ -72,6 +72,7 @@ function EmojiPicker({
         <Suspense fallback={null}>
           <Picker
             data={async () => (await import("@emoji-mart/data")).default}
+            autoFocus={true}
             onEmojiSelect={handleEmojiSelect}
             perLine={8}
             skinTonePosition="search"


### PR DESCRIPTION
Added attribute to make emoji-picker automatically focus the search bar when opened.


## Example

Before:
![before](https://github.com/user-attachments/assets/f0022e4f-c62f-42c3-be1e-c7bd6df9d320)

After:
![after](https://github.com/user-attachments/assets/b35b28ef-6417-4dbe-91d2-2bc57154def1)