### PR TITLE
feat: keep track of page contributors

### DIFF
--- a/apps/server/src/collaboration/extensions/persistence.extension.ts
+++ b/apps/server/src/collaboration/extensions/persistence.extension.ts
@@ -1,5 +1,6 @@
 import {
   Extension,
+  onChangePayload,
   onLoadDocumentPayload,
   onStoreDocumentPayload,
 } from '@hocuspocus/server';
@@ -151,5 +152,9 @@ export class PersistenceExtension implements Extension {
         mentions: pageMentions,
       } as IPageBacklinkJob);
     }
+  }
+
+  async onChange(data: onChangePayload) {
+    console.log('new change', data);
   }
 }

--- a/apps/server/src/core/page/page.controller.ts
+++ b/apps/server/src/core/page/page.controller.ts
@@ -46,6 +46,7 @@ export class PageController {
       includeContent: true,
       includeCreator: true,
       includeLastUpdatedBy: true,
+      includeContributors: true,
     });
 
     if (!page) {
@@ -93,7 +94,7 @@ export class PageController {
     }
 
     return this.pageService.update(
-      updatePageDto.pageId,
+      page,
       updatePageDto,
       user.id,
     );

--- a/apps/server/src/core/page/services/page.service.ts
+++ b/apps/server/src/core/page/services/page.service.ts
@@ -112,21 +112,32 @@ export class PageService {
   }
 
   async update(
-    pageId: string,
+    page: Page,
     updatePageDto: UpdatePageDto,
     userId: string,
   ): Promise<Page> {
+    const contributors = new Set<string>(page.contributorIds);
+    contributors.add(userId);
+    const contributorIds = Array.from(contributors);
+
     await this.pageRepo.updatePage(
       {
         title: updatePageDto.title,
         icon: updatePageDto.icon,
         lastUpdatedById: userId,
         updatedAt: new Date(),
+        contributorIds: contributorIds,
       },
-      pageId,
+      page.id,
     );
 
-    return await this.pageRepo.findById(pageId);
+    return await this.pageRepo.findById(page.id, {
+      includeSpace: true,
+      includeContent: true,
+      includeCreator: true,
+      includeLastUpdatedBy: true,
+      includeContributors: true,
+    });
   }
 
   withHasChildren(eb: ExpressionBuilder<DB, 'pages'>) {

--- a/apps/server/src/database/database.module.ts
+++ b/apps/server/src/database/database.module.ts
@@ -47,7 +47,7 @@ types.setTypeParser(types.builtins.INT8, (val) => Number(val));
         log: (event: LogEvent) => {
           if (environmentService.getNodeEnv() !== 'development') return;
           const logger = new Logger(DatabaseModule.name);
-          if (event.level === 'query') {
+          if (event.level) {
             if (process.env.DEBUG_DB?.toLowerCase() === 'true') {
               logger.debug(event.query.sql);
               logger.debug('query time: ' + event.queryDurationMillis + ' ms');

--- a/apps/server/src/database/migrations/20250327T145832-add-collaborators-to-pages.ts
+++ b/apps/server/src/database/migrations/20250327T145832-add-collaborators-to-pages.ts
@@ -1,0 +1,12 @@
+import { type Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('pages')
+    .addColumn('collaborators', sql`uuid[]`, (col) => col)
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.alterTable('pages').dropColumn('collaborators').execute();
+}

--- a/apps/server/src/database/migrations/20250327T145832-add-contributorIds-to-pages.ts
+++ b/apps/server/src/database/migrations/20250327T145832-add-contributorIds-to-pages.ts
@@ -3,10 +3,10 @@ import { type Kysely, sql } from 'kysely';
 export async function up(db: Kysely<any>): Promise<void> {
   await db.schema
     .alterTable('pages')
-    .addColumn('collaborators', sql`uuid[]`, (col) => col)
+    .addColumn('contributor_ids', sql`uuid[]`, (col) => col.defaultTo("{}"))
     .execute();
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
-  await db.schema.alterTable('pages').dropColumn('collaborators').execute();
+  await db.schema.alterTable('pages').dropColumn('contributor_ids').execute();
 }

--- a/apps/server/src/database/repos/page/page.repo.ts
+++ b/apps/server/src/database/repos/page/page.repo.ts
@@ -10,9 +10,9 @@ import {
 import { PaginationOptions } from '@docmost/db/pagination/pagination-options';
 import { executeWithPagination } from '@docmost/db/pagination/pagination';
 import { validate as isValidUUID } from 'uuid';
-import { ExpressionBuilder } from 'kysely';
+import { ExpressionBuilder, sql } from 'kysely';
 import { DB } from '@docmost/db/types/db';
-import { jsonObjectFrom } from 'kysely/helpers/postgres';
+import { jsonArrayFrom, jsonObjectFrom } from 'kysely/helpers/postgres';
 import { SpaceMemberRepo } from '@docmost/db/repos/space/space-member.repo';
 
 @Injectable()
@@ -38,6 +38,7 @@ export class PageRepo {
     'createdAt',
     'updatedAt',
     'deletedAt',
+    'contributorIds',
   ];
 
   async findById(
@@ -48,6 +49,7 @@ export class PageRepo {
       includeSpace?: boolean;
       includeCreator?: boolean;
       includeLastUpdatedBy?: boolean;
+      includeContributors?: boolean;
       withLock?: boolean;
       trx?: KyselyTransaction;
     },
@@ -66,6 +68,10 @@ export class PageRepo {
 
     if (opts?.includeLastUpdatedBy) {
       query = query.select((eb) => this.withLastUpdatedBy(eb));
+    }
+
+    if (opts?.includeContributors) {
+      query = query.select((eb) => this.withContributors(eb));
     }
 
     if (opts?.includeSpace) {
@@ -187,6 +193,15 @@ export class PageRepo {
         .select(['users.id', 'users.name', 'users.avatarUrl'])
         .whereRef('users.id', '=', 'pages.lastUpdatedById'),
     ).as('lastUpdatedBy');
+  }
+
+  withContributors(eb: ExpressionBuilder<DB, 'pages'>) {
+    return jsonArrayFrom(
+      eb
+        .selectFrom('users')
+        .select(['users.id', 'users.name', 'users.avatarUrl'])
+        .whereRef('users.id', '=', sql`ANY(${eb.ref('pages.contributorIds')})`),
+    ).as('contributors');
   }
 
   async getPageAndDescendants(parentPageId: string) {

--- a/apps/server/src/database/types/db.d.ts
+++ b/apps/server/src/database/types/db.d.ts
@@ -160,6 +160,7 @@ export interface PageHistory {
 }
 
 export interface Pages {
+  collaborators: string[] | null;
   content: Json | null;
   coverPhoto: string | null;
   createdAt: Generated<Timestamp>;

--- a/apps/server/src/database/types/db.d.ts
+++ b/apps/server/src/database/types/db.d.ts
@@ -160,8 +160,8 @@ export interface PageHistory {
 }
 
 export interface Pages {
-  collaborators: string[] | null;
   content: Json | null;
+  contributorIds: Generated<string[] | null>;
   coverPhoto: string | null;
   createdAt: Generated<Timestamp>;
   creatorId: string | null;


### PR DESCRIPTION
In this PR, we introduced changes to keep track of users who contribute to a page.
We have added a new `contributorIds` column to the `pages` table.