### PR TITLE
Remove version from docker-compose.yml [deprecated]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   docmost:
     image: docmost/docmost:latest


### PR DESCRIPTION
In recents versions of docker the version tag in docker compose files are marked as deprecated.

see [docker formum](https://forums.docker.com/t/docker-compose-yml-version-is-obsolete/141313)

A pull request on the docs repo has also been made [here](https://github.com/docmost/docs/pull/9)