### PR TITLE
chore: docker-compose hint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,39 +1,39 @@
 version: '3'
 
 services:
-  docmost:
-    image: docmost/docmost:latest
-    depends_on:
-      - db
-      - redis
-    environment:
-      APP_URL: 'http://localhost:3000'
-      APP_SECRET: 'REPLACE_WITH_LONG_SECRET'
-      DATABASE_URL: 'postgresql://docmost:STRONG_DB_PASSWORD@db:5432/docmost?schema=public'
-      REDIS_URL: 'redis://redis:6379'
-    ports:
-      - "3000:3000"
-    restart: unless-stopped
-    volumes:
-      - docmost:/app/data/storage
+    docmost:
+        image: docmost/docmost:latest
+        depends_on:
+            - db
+            - redis
+        environment:
+            APP_URL: 'http://localhost:3000'
+            APP_SECRET: 'REPLACE_WITH_LONG_SECRET' # Minimum field length is 32 characters
+            DATABASE_URL: 'postgresql://docmost:STRONG_DB_PASSWORD@db:5432/docmost?schema=public'
+            REDIS_URL: 'redis://redis:6379'
+        ports:
+            - '3000:3000'
+        restart: unless-stopped
+        volumes:
+            - docmost:/app/data/storage
 
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_DB: docmost
-      POSTGRES_USER: docmost
-      POSTGRES_PASSWORD: STRONG_DB_PASSWORD
-    restart: unless-stopped
-    volumes:
-      - db_data:/var/lib/postgresql/data
+    db:
+        image: postgres:16-alpine
+        environment:
+            POSTGRES_DB: docmost
+            POSTGRES_USER: docmost
+            POSTGRES_PASSWORD: STRONG_DB_PASSWORD
+        restart: unless-stopped
+        volumes:
+            - db_data:/var/lib/postgresql/data
 
-  redis:
-    image: redis:7.2-alpine
-    restart: unless-stopped
-    volumes:
-      - redis_data:/data
+    redis:
+        image: redis:7.2-alpine
+        restart: unless-stopped
+        volumes:
+            - redis_data:/data
 
 volumes:
-  docmost:
-  db_data:
-  redis_data:
+    docmost:
+    db_data:
+    redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,39 +1,39 @@
 version: '3'
 
 services:
-    docmost:
-        image: docmost/docmost:latest
-        depends_on:
-            - db
-            - redis
-        environment:
-            APP_URL: 'http://localhost:3000'
-            APP_SECRET: 'REPLACE_WITH_LONG_SECRET' # Minimum field length is 32 characters
-            DATABASE_URL: 'postgresql://docmost:STRONG_DB_PASSWORD@db:5432/docmost?schema=public'
-            REDIS_URL: 'redis://redis:6379'
-        ports:
-            - '3000:3000'
-        restart: unless-stopped
-        volumes:
-            - docmost:/app/data/storage
+  docmost:
+    image: docmost/docmost:latest
+    depends_on:
+      - db
+      - redis
+    environment:
+      APP_URL: 'http://localhost:3000'
+      APP_SECRET: 'REPLACE_WITH_LONG_SECRET' # Minimum field length is 32 characters
+      DATABASE_URL: 'postgresql://docmost:STRONG_DB_PASSWORD@db:5432/docmost?schema=public'
+      REDIS_URL: 'redis://redis:6379'
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    volumes:
+      - docmost:/app/data/storage
 
-    db:
-        image: postgres:16-alpine
-        environment:
-            POSTGRES_DB: docmost
-            POSTGRES_USER: docmost
-            POSTGRES_PASSWORD: STRONG_DB_PASSWORD
-        restart: unless-stopped
-        volumes:
-            - db_data:/var/lib/postgresql/data
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: docmost
+      POSTGRES_USER: docmost
+      POSTGRES_PASSWORD: STRONG_DB_PASSWORD
+    restart: unless-stopped
+    volumes:
+      - db_data:/var/lib/postgresql/data
 
-    redis:
-        image: redis:7.2-alpine
-        restart: unless-stopped
-        volumes:
-            - redis_data:/data
+  redis:
+    image: redis:7.2-alpine
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
 
 volumes:
-    docmost:
-    db_data:
-    redis_data:
+  docmost:
+  db_data:
+  redis_data:


### PR DESCRIPTION
I deployed Docmost several times over time and each time I forgot that the secret key field length cannot be less than 32 characters. As a result, after building, the NestJS validator was triggered and the image did not run. I think it is reasonable to leave a comment about the length of this field, despite the fact that it is in the documentation. It is simpler.