### PR TITLE
fix(i18n): add translations for system sidebar 'system' header

### DIFF
--- a/apps/client/public/locales/de-DE/translation.json
+++ b/apps/client/public/locales/de-DE/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "Erfolgreich importiert",
   "Successfully restored": "Erfolgreich wiederhergestellt",
   "System settings": "Systemeinstellungen",
+  "System": "System",
   "Theme": "Design",
   "To change your email, you have to enter your password and new email.": "Um Ihre E-Mail-Adresse zu ändern, müssen Sie Ihr Passwort und Ihre neue E-Mail-Adresse eingeben.",
   "Toggle full page width": "Volle Seitenbreite umschalten",

--- a/apps/client/public/locales/en-US/translation.json
+++ b/apps/client/public/locales/en-US/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "Successfully imported",
   "Successfully restored": "Successfully restored",
   "System settings": "System settings",
+  "System": "System",
   "Theme": "Theme",
   "To change your email, you have to enter your password and new email.": "To change your email, you have to enter your password and new email.",
   "Toggle full page width": "Toggle full page width",

--- a/apps/client/public/locales/es-ES/translation.json
+++ b/apps/client/public/locales/es-ES/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "Importado con éxito",
   "Successfully restored": "Restaurado con éxito",
   "System settings": "Configuración del sistema",
+  "System": "Sistema",
   "Theme": "Tema",
   "To change your email, you have to enter your password and new email.": "Para cambiar tu correo electrónico, debes ingresar tu contraseña y nuevo correo electrónico.",
   "Toggle full page width": "Alternar el ancho de página completa",

--- a/apps/client/public/locales/fr-FR/translation.json
+++ b/apps/client/public/locales/fr-FR/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "Importé avec succès",
   "Successfully restored": "Restauré avec succès",
   "System settings": "Paramètres système",
+  "System": "Système",
   "Theme": "Thème",
   "To change your email, you have to enter your password and new email.": "Pour changer votre email, vous devez entrer votre mot de passe et votre nouvel email.",
   "Toggle full page width": "Basculer sur la largeur complète de la page",

--- a/apps/client/public/locales/it-IT/translation.json
+++ b/apps/client/public/locales/it-IT/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "Importato con successo",
   "Successfully restored": "Ripristinato con successo",
   "System settings": "Impostazioni di sistema",
+  "System": "Sistema",
   "Theme": "Tema",
   "To change your email, you have to enter your password and new email.": "Per cambiare la tua email, devi inserire la tua password e la nuova email.",
   "Toggle full page width": "Attiva/disattiva pagina a larghezza intera",

--- a/apps/client/public/locales/ja-JP/translation.json
+++ b/apps/client/public/locales/ja-JP/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "インポートに成功しました",
   "Successfully restored": "正常に復元されました",
   "System settings": "システム設定",
+  "System": "システム",
   "Theme": "テーマ",
   "To change your email, you have to enter your password and new email.": "メールアドレスを変更するには、パスワードと新しいメールアドレスを入力する必要があります。",
   "Toggle full page width": "ページ幅を切り替える",

--- a/apps/client/public/locales/ko-KR/translation.json
+++ b/apps/client/public/locales/ko-KR/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "가져오기 완료",
   "Successfully restored": "복원 완료",
   "System settings": "시스템 설정",
+  "System": "시스템",
   "Theme": "배경",
   "To change your email, you have to enter your password and new email.": "이메일을 변경하려면 현재 비밀번호와 새 이메일을 입력해야 합니다.",
   "Toggle full page width": "전체 페이지 너비 전환",

--- a/apps/client/public/locales/nl-NL/translation.json
+++ b/apps/client/public/locales/nl-NL/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "Succesvol geïmporteerd",
   "Successfully restored": "Succesvol hersteld",
   "System settings": "Systeem instellingen",
+  "System": "Systeem",
   "Theme": "Thema",
   "To change your email, you have to enter your password and new email.": "Om uw e-mailadres te wijzigen, moet u uw wachtwoord en nieuwe e-mail invullen.",
   "Toggle full page width": "Schakel volledige pagina breedte in",

--- a/apps/client/public/locales/pt-BR/translation.json
+++ b/apps/client/public/locales/pt-BR/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "Importado com sucesso",
   "Successfully restored": "Restaurado com sucesso",
   "System settings": "Configurações do sistema",
+  "System": "Sistema",
   "Theme": "Tema",
   "To change your email, you have to enter your password and new email.": "Para alterar seu email, você precisa inserir sua senha e o novo email.",
   "Toggle full page width": "Alternar para largura total da página",

--- a/apps/client/public/locales/ru-RU/translation.json
+++ b/apps/client/public/locales/ru-RU/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "Успешно импортировано",
   "Successfully restored": "Успешно восстановлено",
   "System settings": "Системные настройки",
+  "System": "Система",
   "Theme": "Тема",
   "To change your email, you have to enter your password and new email.": "Чтобы изменить электронную почту, вам нужно ввести пароль и новый адрес.",
   "Toggle full page width": "Переключить ширину на всю страницу",

--- a/apps/client/public/locales/zh-CN/translation.json
+++ b/apps/client/public/locales/zh-CN/translation.json
@@ -169,6 +169,7 @@
   "Successfully imported": "成功导入",
   "Successfully restored": "恢复成功",
   "System settings": "系统设置",
+  "System": "系统",
   "Theme": "主题",
   "To change your email, you have to enter your password and new email.": "要更改您的电子邮箱，您需要输入密码和新的电子邮箱地址。",
   "Toggle full page width": "切换全页宽度",


### PR DESCRIPTION
Hi, i have noticed that translations aren't added for this header. I have added that for all locales. 
<img width="306" alt="Screenshot 2025-04-24 at 17 28 52" src="https://github.com/user-attachments/assets/5845706d-d911-495b-98b2-84257fc9cc79" />
