### PR TITLE
fix(table-hover): adjust height to prevent unexpected scrollbar

### DIFF
--- a/apps/client/src/features/editor/styles/table.css
+++ b/apps/client/src/features/editor/styles/table.css
@@ -47,7 +47,7 @@
 
     .column-resize-handle {
       background-color: #adf;
-      bottom: -2px;
+      bottom: -1px;
       position: absolute;
       right: -2px;
       pointer-events: none;


### PR DESCRIPTION
fix: Hover table style height error causing scrollbar to appear #1108
https://github.com/docmost/docmost/issues/1108

Before
![](https://pan.polarws.moe/f/Rx9ca/%E5%B1%8F%E5%B9%95%E6%88%AA%E5%9B%BE%202025-05-01%20034953.png)

After
![](https://pan.polarws.moe/f/paouW/%E5%B1%8F%E5%B9%95%E6%88%AA%E5%9B%BE%202025-05-01%20034804.png)

The multi-line table has already been tested