### PR TITLE
feat: support `socket://` protocol in `DATABASE_URL`

### DIFF
--- a/apps/server/src/integrations/environment/environment.validation.ts
+++ b/apps/server/src/integrations/environment/environment.validation.ts
@@ -14,7 +14,7 @@ export class EnvironmentVariables {
   @IsNotEmpty()
   @IsUrl(
     {
-      protocols: ['postgres', 'postgresql'],
+      protocols: ['postgres', 'postgresql', 'socket'],
       require_tld: false,
       allow_underscores: true,
     },


### PR DESCRIPTION
Hi, first of all, thanks for open-sourcing this useful application.🙂

This PR allows `socket://` protocol in `DATABASE_URL`, in addition to `postgres://` etc.

Because it is required to connect to PostgreSQL with `pg` via a UNIX socket.

ref.
- [Connecting – node-postgres](https://node-postgres.com/features/connecting#unix-domain-sockets)
- [node-postgres/packages/pg-connection-string at master · brianc/node-postgres](https://github.com/brianc/node-postgres/tree/master/packages/pg-connection-string#connection-strings)