### PR TITLE
fix: sidebar list when changing workspace

### DIFF
--- a/apps/client/src/features/editor/title-editor.tsx
+++ b/apps/client/src/features/editor/title-editor.tsx
@@ -103,7 +103,7 @@ export function TitleEditor({
         spaceId: page.spaceId,
         entity: ["pages"],
         id: page.id,
-        payload: { title: page.title, slugId: page.slugId },
+        payload: { title: page.title, slugId: page.slugId, parentPageId: page.parentPageId, icon: page.icon },
       };
 
       localEmitter.emit("message", event);

--- a/apps/client/src/features/page/queries/page-query.ts
+++ b/apps/client/src/features/page/queries/page-query.ts
@@ -1,4 +1,5 @@
 import {
+  InfiniteData,
   useInfiniteQuery,
   useMutation,
   useQuery,
@@ -56,7 +57,9 @@ export function useCreatePageMutation() {
   const { t } = useTranslation();
   return useMutation<IPage, Error, Partial<IPageInput>>({
     mutationFn: (data) => createPage(data),
-    onSuccess: (data) => {},
+    onSuccess: (data) => {
+      invalidateOnCreatePage(data.spaceId, data.parentPageId);
+    },
     onError: (error) => {
       notifications.show({ message: t("Failed to create page"), color: "red" });
     },
@@ -85,6 +88,8 @@ export function useUpdatePageMutation() {
       if (pageById) {
         queryClient.setQueryData(["pages", data.id], { ...pageById, ...data });
       }
+
+      invalidateOnUpdatePage(data.spaceId, data.parentPageId, data.id, data.title, data.icon);
     },
   });
 }
@@ -93,8 +98,9 @@ export function useDeletePageMutation() {
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (pageId: string) => deletePage(pageId),
-    onSuccess: () => {
+    onSuccess: (data, pageId) => {
       notifications.show({ message: t("Page deleted successfully") });
+      invalidateOnDeletePage(pageId);
     },
     onError: (error) => {
       notifications.show({ message: t("Failed to delete page"), color: "red" });
@@ -105,6 +111,9 @@ export function useDeletePageMutation() {
 export function useMovePageMutation() {
   return useMutation<void, Error, IMovePage>({
     mutationFn: (data) => movePage(data),
+    onSuccess: () => {
+      invalidateOnMovePage();
+    },
   });
 }
 
@@ -158,5 +167,149 @@ export function useRecentChangesQuery(
     queryKey: ["recent-changes", spaceId],
     queryFn: () => getRecentChanges(spaceId),
     refetchOnMount: true,
+  });
+}
+
+export function invalidateOnCreatePage(spaceId: string, parentPageId: string) {
+  //for create and move invalidate sidebar pages for now (how to do with pagination???)
+  if(parentPageId===null){
+    //invalidate root sidebar pages
+    queryClient.invalidateQueries({
+      queryKey: ["root-sidebar-pages", spaceId],
+    });
+  }else{
+    //force refatch sub sidebar pages 
+    queryClient.refetchQueries({
+      queryKey: ['sidebar-pages', {pageId: parentPageId, spaceId: spaceId}],
+    });
+    //update sub sidebar pages haschildern
+    const subSideBarMatches = queryClient.getQueriesData({
+      queryKey: ['sidebar-pages'],
+      exact: false,
+    });
+    
+    subSideBarMatches.forEach(([key, d]) => {
+      queryClient.setQueryData<IPagination<IPage>>(key, (old) => {
+        return {
+          ...old,
+          items: old.items.map((sidebarPage) =>
+            sidebarPage.id === parentPageId ? { ...sidebarPage, hasChildren: true } : sidebarPage
+          ),
+        };
+      });
+    });
+
+    //update root sidebar pages haschildern
+    const rootSideBarMatches = queryClient.getQueriesData({
+      queryKey: ['root-sidebar-pages', spaceId],
+      exact: false,
+    });
+    
+    rootSideBarMatches.forEach(([key, d]) => {
+      queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(key, (old) => {
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            items: page.items.map((sidebarPage: IPage) =>
+              sidebarPage.id === parentPageId ? { ...sidebarPage, hasChildren: true } : sidebarPage
+            )
+          })),
+        };
+      });
+    });
+  }
+  //update recent changes
+  queryClient.invalidateQueries({
+    queryKey: ["recent-changes", spaceId],
+  });
+  // ---
+}
+
+export function invalidateOnUpdatePage(spaceId: string, parentPageId: string, id: string, title: string, icon: string) {
+  if(parentPageId===null){
+    //update root sidebar pages
+    queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(['root-sidebar-pages', spaceId], (old) => {
+      if (!old) return old;
+      return {
+        ...old,
+        pages: old.pages.map((page) => ({
+          ...page,
+          items: page.items.map((sidebarPage: IPage) =>
+            sidebarPage.id === id ? { ...sidebarPage, title: title, icon: icon } : sidebarPage
+          )
+        })),
+      };
+    });
+  }else{
+    //update sub sidebar pages
+    queryClient.setQueryData<IPagination<IPage>>(['sidebar-pages', {pageId: parentPageId, spaceId: spaceId}], (old) => {
+      if (!old) return old;
+      return {
+        ...old,
+        items: old.items.map((sidebarPage) =>
+          sidebarPage.id === id ? { ...sidebarPage, title: title, icon: icon } : sidebarPage
+        ),
+      };
+    });
+  }
+  //update recent changes
+  queryClient.invalidateQueries({
+    queryKey: ["recent-changes", spaceId],
+  });
+}
+
+export function invalidateOnMovePage() {
+  //for create and move invalidate all sidebars for now (how to do with pagination???)
+  //invalidate all root sidebar pages
+  queryClient.invalidateQueries({
+    queryKey: ["root-sidebar-pages"],
+  });
+  //invalidate all sub sidebar pages
+  queryClient.invalidateQueries({
+    queryKey: ['sidebar-pages'],
+  });
+  // ---
+}
+
+export function invalidateOnDeletePage(pageId: string) {
+  //update root sidebar pages
+  const rootSideBarMatches = queryClient.getQueriesData({
+    queryKey: ['root-sidebar-pages'],
+    exact: false,
+  });
+  
+  rootSideBarMatches.forEach(([key, d]) => {
+    queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(key, (old) => {
+      return {
+        ...old,
+        pages: old.pages.map((page) => ({
+          ...page,
+          items: page.items.filter((sidebarPage: IPage) => sidebarPage.id !== pageId),
+        })),
+      };
+    });
+  });
+  
+  //update sub sidebar pages
+  const subSideBarMatches = queryClient.getQueriesData({
+    queryKey: ['sidebar-pages'],
+    exact: false,
+  });
+  
+  subSideBarMatches.forEach(([key, d]) => {
+    console.log(key)
+    console.log(d)
+    queryClient.setQueryData<IPagination<IPage>>(key, (old) => {
+      return {
+        ...old,
+        items: old.items.filter((sidebarPage: IPage) => sidebarPage.id !== pageId),
+      };
+    });
+  });
+  
+  //update recent changes
+  queryClient.invalidateQueries({
+    queryKey: ["recent-changes"],
   });
 }

--- a/apps/client/src/features/page/services/page-service.ts
+++ b/apps/client/src/features/page/services/page-service.ts
@@ -10,6 +10,7 @@ import {
 } from "@/features/page/types/page.types";
 import { IAttachment, IPagination } from "@/lib/types.ts";
 import { saveAs } from "file-saver";
+import { InfiniteData } from "@tanstack/react-query";
 
 export async function createPage(data: Partial<IPage>): Promise<IPage> {
   const req = await api.post<IPage>("/pages/create", data);
@@ -50,6 +51,32 @@ export async function getSidebarPages(
 ): Promise<IPagination<IPage>> {
   const req = await api.post("/pages/sidebar-pages", params);
   return req.data;
+}
+
+export async function getAllSidebarPages(
+  params: SidebarPagesParams,
+): Promise<InfiniteData<IPagination<IPage>, unknown>> {
+  let page = 1;
+  let hasNextPage = false;
+  const pages: IPagination<IPage>[] = [];
+  const pageParams: number[] = [];
+
+  do {
+    const req = await api.post("/pages/sidebar-pages", { ...params, page: page });
+
+    const data: IPagination<IPage> = req.data;
+    pages.push(data);
+    pageParams.push(page);
+
+    hasNextPage = data.meta.hasNextPage;
+
+    page += 1;
+  } while (hasNextPage);
+
+  return {
+    pageParams,
+    pages,
+  };
 }
 
 export async function getPageBreadcrumbs(

--- a/apps/client/src/features/page/tree/atoms/tree-data-atom.ts
+++ b/apps/client/src/features/page/tree/atoms/tree-data-atom.ts
@@ -1,4 +1,19 @@
 import { atom } from "jotai";
 import { SpaceTreeNode } from "@/features/page/tree/types";
+import { appendNodeChildren } from "../utils";
 
 export const treeDataAtom = atom<SpaceTreeNode[]>([]);
+
+// Atom
+export const appendNodeChildrenAtom = atom(
+  null,
+  (
+    get,
+    set,
+    { parentId, children }: { parentId: string; children: SpaceTreeNode[] }
+  ) => {
+    const currentTree = get(treeDataAtom);
+    const updatedTree = appendNodeChildren(currentTree, parentId, children);
+    set(treeDataAtom, updatedTree);
+  }
+);

--- a/apps/client/src/features/page/tree/components/space-tree.tsx
+++ b/apps/client/src/features/page/tree/components/space-tree.tsx
@@ -24,7 +24,7 @@ import {
   IconPointFilled,
   IconTrash,
 } from "@tabler/icons-react";
-import { treeDataAtom } from "@/features/page/tree/atoms/tree-data-atom.ts";
+import { appendNodeChildrenAtom, treeDataAtom } from "@/features/page/tree/atoms/tree-data-atom.ts";
 import clsx from "clsx";
 import EmojiPicker from "@/components/ui/emoji-picker.tsx";
 import { useTreeMutation } from "@/features/page/tree/hooks/use-tree-mutation.ts";
@@ -237,6 +237,7 @@ function Node({ node, style, dragHandle, tree }: NodeRendererProps<any>) {
   const { t } = useTranslation();
   const updatePageMutation = useUpdatePageMutation();
   const [treeData, setTreeData] = useAtom(treeDataAtom);
+  const [, appendChildren] = useAtom(appendNodeChildrenAtom);
   const emit = useQueryEmit();
   const { spaceSlug } = useParams();
   const timerRef = useRef(null);
@@ -262,9 +263,10 @@ function Node({ node, style, dragHandle, tree }: NodeRendererProps<any>) {
 
   async function handleLoadChildren(node: NodeApi<SpaceTreeNode>) {
     if (!node.data.hasChildren) return;
-    if (node.data.children && node.data.children.length > 0) {
-      return;
-    }
+    // in conflict with use-query-subscription.ts => case "addTreeNode":
+    // if (node.data.children && node.data.children.length > 0) {
+    //   return;
+    // }
 
     try {
       const params: SidebarPagesParams = {
@@ -280,13 +282,10 @@ function Node({ node, style, dragHandle, tree }: NodeRendererProps<any>) {
 
       const childrenTree = buildTree(newChildren.items);
 
-      const updatedTreeData = appendNodeChildren(
-        treeData,
-        node.data.id,
-        childrenTree,
-      );
-
-      setTreeData(updatedTreeData);
+      appendChildren({
+        parentId: node.data.id,
+        children: childrenTree,
+      });
     } catch (error) {
       console.error("Failed to fetch children:", error);
     }
@@ -304,17 +303,17 @@ function Node({ node, style, dragHandle, tree }: NodeRendererProps<any>) {
 
   const handleEmojiSelect = (emoji: { native: string }) => {
     handleUpdateNodeIcon(node.id, emoji.native);
-    updatePageMutation.mutateAsync({ pageId: node.id, icon: emoji.native });
-
-    setTimeout(() => {
-      emit({
-        operation: "updateOne",
-        spaceId: node.data.spaceId,
-        entity: ["pages"],
-        id: node.id,
-        payload: { icon: emoji.native },
-      });
-    }, 50);
+    updatePageMutation.mutateAsync({ pageId: node.id, icon: emoji.native }).then((data) => {
+      setTimeout(() => {
+        emit({
+          operation: "updateOne",
+          spaceId: node.data.spaceId,
+          entity: ["pages"],
+          id: node.id,
+          payload: { icon: emoji.native, parentPageId: data.parentPageId},
+        });
+      }, 50);
+    });
   };
 
   const handleRemoveEmoji = () => {
@@ -576,6 +575,12 @@ interface PageArrowProps {
 }
 
 function PageArrow({ node, onExpandTree }: PageArrowProps) {
+  useEffect(() => {
+    if(node.isOpen){
+      onExpandTree();
+    }
+  }, []);
+
   return (
     <ActionIcon
       size={20}

--- a/apps/client/src/features/page/tree/hooks/use-tree-mutation.ts
+++ b/apps/client/src/features/page/tree/hooks/use-tree-mutation.ts
@@ -206,6 +206,23 @@ export function useTreeMutation<T>(spaceId: string) {
     }
   };
 
+  const isPageInNode = (
+    node: { data: SpaceTreeNode; children?: any[] },
+    pageSlug: string
+  ): boolean => {
+    if (node.data.slugId === pageSlug) {
+      return true;
+    }
+    for (const item of node.children) {
+      if (item.data.slugId === pageSlug) {
+        return true;
+      } else {
+        return isPageInNode(item, pageSlug);
+      }
+    }
+    return false;
+  };
+
   const onDelete: DeleteHandler<T> = async (args: { ids: string[] }) => {
     try {
       await deletePageMutation.mutateAsync(args.ids[0]);
@@ -218,8 +235,7 @@ export function useTreeMutation<T>(spaceId: string) {
       tree.drop({ id: args.ids[0] });
       setData(tree.data);
 
-      // navigate only if the current url is same as the deleted page
-      if (pageSlug && node.data.slugId === pageSlug.split("-")[1]) {
+      if (pageSlug && isPageInNode(node, pageSlug.split("-")[1])) {
         navigate(getSpaceUrl(spaceSlug));
       }
 

--- a/apps/client/src/features/page/tree/hooks/use-tree-mutation.ts
+++ b/apps/client/src/features/page/tree/hooks/use-tree-mutation.ts
@@ -93,7 +93,7 @@ export function useTreeMutation<T>(spaceId: string) {
     return data;
   };
 
-  const onMove: MoveHandler<T> = (args: {
+  const onMove: MoveHandler<T> = async (args: {
     dragIds: string[];
     dragNodes: NodeApi<T>[];
     parentId: string | null;
@@ -176,7 +176,7 @@ export function useTreeMutation<T>(spaceId: string) {
     };
 
     try {
-      movePageMutation.mutateAsync(payload);
+      await movePageMutation.mutateAsync(payload);
 
       setTimeout(() => {
         emit({

--- a/apps/client/src/features/websocket/types/types.ts
+++ b/apps/client/src/features/websocket/types/types.ts
@@ -1,4 +1,5 @@
 import { SpaceTreeNode } from "@/features/page/tree/types.ts";
+import { IPage } from "@/features/page/types/page.types";
 
 export type InvalidateEvent = {
   operation: "invalidate";
@@ -12,7 +13,7 @@ export type UpdateEvent = {
   spaceId: string;
   entity: Array<string>;
   id: string;
-  payload: Partial<any>;
+  payload: Partial<IPage>;
 };
 
 export type DeleteEvent = {
@@ -20,7 +21,7 @@ export type DeleteEvent = {
   spaceId: string;
   entity: Array<string>;
   id: string;
-  payload?: Partial<any>;
+  payload?: Partial<IPage>;
 };
 
 export type AddTreeNodeEvent = {

--- a/apps/client/src/features/websocket/use-query-subscription.ts
+++ b/apps/client/src/features/websocket/use-query-subscription.ts
@@ -1,8 +1,11 @@
 import React from "react";
 import { socketAtom } from "@/features/websocket/atoms/socket-atom.ts";
 import { useAtom } from "jotai";
-import { useQueryClient } from "@tanstack/react-query";
+import { InfiniteData, useQueryClient } from "@tanstack/react-query";
 import { WebSocketEvent } from "@/features/websocket/types";
+import { IPage } from "../page/types/page.types";
+import { IPagination } from "@/lib/types";
+import { invalidateOnCreatePage, invalidateOnDeletePage, invalidateOnMovePage, invalidateOnUpdatePage } from "../page/queries/page-query";
 
 export const useQuerySubscription = () => {
   const queryClient = useQueryClient();
@@ -21,6 +24,16 @@ export const useQuerySubscription = () => {
             queryKey: [...data.entity, data.id].filter(Boolean),
           });
           break;
+        case "addTreeNode":
+          invalidateOnCreatePage(data.payload.data.spaceId, data.payload.data.parentPageId);
+          break;
+        case "moveTreeNode":
+          invalidateOnMovePage();
+          break;
+        case "deleteTreeNode":
+          const pageId = data.payload.node.id;
+          invalidateOnDeletePage(pageId);
+          break;
         case "updateOne":
           entity = data.entity[0];
           if (entity === "pages") {
@@ -37,7 +50,11 @@ export const useQuerySubscription = () => {
               ...data.payload,
             });
           }
-
+          
+          if (entity === "pages") {
+            invalidateOnUpdatePage(data.spaceId, data.payload.parentPageId, data.id, data.payload.title, data.payload.icon);
+          }
+          
           /*
           queryClient.setQueriesData(
             { queryKey: [data.entity, data.id] },
@@ -49,7 +66,7 @@ export const useQuerySubscription = () => {
                 : update(oldData as Record<string, unknown>);
             },
           );
-      */
+      */          
           break;
       }
     });

--- a/apps/client/src/features/websocket/use-query-subscription.ts
+++ b/apps/client/src/features/websocket/use-query-subscription.ts
@@ -25,7 +25,7 @@ export const useQuerySubscription = () => {
           });
           break;
         case "addTreeNode":
-          invalidateOnCreatePage(data.payload.data.spaceId, data.payload.data.parentPageId);
+          invalidateOnCreatePage(data.payload.data);
           break;
         case "moveTreeNode":
           invalidateOnMovePage();


### PR DESCRIPTION
- fix #1113 
![invalidate](https://github.com/user-attachments/assets/4bc8c24c-18e5-4653-8625-75e6922888ce)


- refactor: realtime page actions
- update tab "recently updated" in collab
![recent](https://github.com/user-attachments/assets/22f43278-e17d-4106-8156-e4b115a2c5a5)

- remember tree state when changing workspace
![tree](https://github.com/user-attachments/assets/b4540426-e492-4350-a730-1adfe8c72a3e)

- navigate in overview if current page is in deleted node
![navigate](https://github.com/user-attachments/assets/a3303826-77e3-4ace-ba66-292886672083)


