### PR TITLE
fix: Copy/move pages between spaces does not show spaces list

### DIFF
--- a/apps/client/src/features/space/components/sidebar/space-select.tsx
+++ b/apps/client/src/features/space/components/sidebar/space-select.tsx
@@ -81,7 +81,7 @@ export function SpaceSelect({
       nothingFoundMessage={t("No space found")}
       limit={50}
       checkIconPosition="right"
-      comboboxProps={{ width, withinPortal: false }}
+      comboboxProps={{ width, withinPortal: true, position: "bottom" }}
       dropdownOpened={opened}
     />
   );


### PR DESCRIPTION
- fix #1173 

![move](https://github.com/user-attachments/assets/38fe52c1-e3b8-44da-997d-eea5bebefe02)
