### PR TITLE
feat: use environment variable in docker-compose.yml for configurability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       - db
       - redis
     environment:
-      APP_URL: 'http://localhost:3000'
-      APP_SECRET: 'REPLACE_WITH_LONG_SECRET'
-      DATABASE_URL: 'postgresql://docmost:STRONG_DB_PASSWORD@db:5432/docmost?schema=public'
+      APP_URL: "$APP_URL"
+      APP_SECRET: "$APP_SECRET"
+      DATABASE_URL: "postgresql://docmost:${POSTGRES_PASSWORD}@db:5432/docmost?schema=public"
       REDIS_URL: 'redis://redis:6379'
     ports:
       - "3000:3000"
@@ -22,7 +22,7 @@ services:
     environment:
       POSTGRES_DB: docmost
       POSTGRES_USER: docmost
-      POSTGRES_PASSWORD: STRONG_DB_PASSWORD
+      POSTGRES_PASSWORD: "$POSTGRES_PASSWORD"
     restart: unless-stopped
     volumes:
       - db_data:/var/lib/postgresql/data


### PR DESCRIPTION
This PR updates the docker-compose.yml file to replace hard-coded configuration values with environment variable substitutions. Instead of directly editing the docker-compose.yml file to change configurations during [the installation](https://docmost.com/docs/installation#replace-the-default-configs), users can now supply values via a .env file.

> [!IMPORTANT]
> If this gets merged, we need to merge this PR in the documentation: https://github.com/docmost/docs/pull/14  
