### PR TITLE
security fix: prevent access to attachment link after page is unshared

### DIFF
--- a/apps/server/src/core/attachment/attachment.controller.ts
+++ b/apps/server/src/core/attachment/attachment.controller.ts
@@ -50,6 +50,8 @@ import { validate as isValidUUID } from 'uuid';
 import { EnvironmentService } from '../../integrations/environment/environment.service';
 import { TokenService } from '../auth/services/token.service';
 import { JwtAttachmentPayload, JwtType } from '../auth/dto/jwt-payload';
+import { ShareService } from '../share/share.service';
+import { ShareInfoDto } from '../share/dto/share.dto';
 
 @Controller()
 export class AttachmentController {
@@ -64,6 +66,7 @@ export class AttachmentController {
     private readonly attachmentRepo: AttachmentRepo,
     private readonly environmentService: EnvironmentService,
     private readonly tokenService: TokenService,
+    private readonly shareService: ShareService,
   ) {}
 
   @UseGuards(JwtAuthGuard)
@@ -223,6 +226,14 @@ export class AttachmentController {
       fileId !== jwtPayload.attachmentId ||
       jwtPayload.workspaceId !== workspace.id
     ) {
+      throw new NotFoundException('File not found');
+    }
+
+    try{
+      const dto = new ShareInfoDto();
+      dto.pageId = jwtPayload.pageId;
+      await this.shareService.getSharedPage(dto, workspace.id);
+    } catch (err) {
       throw new NotFoundException('File not found');
     }
 

--- a/apps/server/src/core/attachment/attachment.module.ts
+++ b/apps/server/src/core/attachment/attachment.module.ts
@@ -6,10 +6,11 @@ import { UserModule } from '../user/user.module';
 import { WorkspaceModule } from '../workspace/workspace.module';
 import { AttachmentProcessor } from './processors/attachment.processor';
 import { TokenModule } from '../auth/token.module';
+import { ShareService } from '../share/share.service';
 
 @Module({
   imports: [StorageModule, UserModule, WorkspaceModule, TokenModule],
   controllers: [AttachmentController],
-  providers: [AttachmentService, AttachmentProcessor],
+  providers: [AttachmentService, AttachmentProcessor, ShareService],
 })
 export class AttachmentModule {}


### PR DESCRIPTION
- fix #1228 

Check if the page is still shared before serving attachments, without waiting for JWT expiration.