### PR TITLE
feat: add extra ligatures

### DIFF
--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -37,6 +37,7 @@ import {
   Excalidraw,
   Embed,
   Mention,
+  ExtraLigatures,
 } from "@docmost/editor-ext";
 import {
   randomElement,
@@ -130,6 +131,7 @@ export const mainExtensions = [
     multicolor: true,
   }),
   Typography,
+  ExtraLigatures,
   TrailingNode,
   GlobalDragHandle,
   TextStyle,

--- a/packages/editor-ext/src/index.ts
+++ b/packages/editor-ext/src/index.ts
@@ -18,3 +18,4 @@ export * from "./lib/embed";
 export * from "./lib/mention";
 export * from "./lib/markdown";
 export * from "./lib/embed-provider";
+export * from "./lib/extra-ligatures";

--- a/packages/editor-ext/src/lib/extra-ligatures.ts
+++ b/packages/editor-ext/src/lib/extra-ligatures.ts
@@ -1,0 +1,23 @@
+import { Extension, textInputRule } from '@tiptap/core'
+
+export const ExtraLigatures = Extension.create({
+  name: 'extraLigatures',
+
+  addInputRules() {
+
+    return [
+      textInputRule({
+        find: /=>$/,
+        replace: '⇒',
+      }),
+      textInputRule({
+        find: />=$/,
+        replace: '≥',
+      }),
+      textInputRule({
+        find: /<=$/,
+        replace: '≤',
+      }),
+    ]
+  },
+})


### PR DESCRIPTION
I created new typographic conversions (ligatures)
- There is already a lot of existing conversions : ->, !=, +/-
(full list : https://tiptap.dev/docs/editor/extensions/functionality/typography#rules)
        
- I added 3 missing conversions : =>, >=, <=

Here is a gif demonstrating the changes:

![extra-ligatures](https://github.com/user-attachments/assets/74899f73-5f35-45bf-b536-a88a5d4bf863)
