### PR TITLE
Only allow changing the email if the correct password is provided

### DIFF
--- a/apps/server/src/core/user/dto/update-user.dto.ts
+++ b/apps/server/src/core/user/dto/update-user.dto.ts
@@ -21,4 +21,8 @@ export class UpdateUserDto extends PartialType(
   @IsOptional()
   @IsString()
   locale: string;
+
+  @IsOptional()
+  @IsString()
+  password: string;
 }


### PR DESCRIPTION
The email is not used in the frontend. 
Though it is possible to change it using only the authToken. Because this is not used anywhere right now, we could either remove it or add a password prompt. However, this will not work for OIDC. 

I opted for the way to remain functionality and add password protection if someone relies on it.

Since this could be a serious security issue, please consider merging as soon as possible or removing the possibility while it is not being used.

A frontend implementation (with password protection) can be found at my personal fork: https://github.com/Vito0912/bettermost/tree/personal (https://github.com/Vito0912/bettermost/commit/e020a4b817ef7cb8f7f91370f4c9b3cfcade7a27)