### PR TITLE
fix(editor): prevent text color removal from other list items when se…

### DIFF
--- a/apps/client/src/features/editor/components/bubble-menu/color-selector.tsx
+++ b/apps/client/src/features/editor/components/bubble-menu/color-selector.tsx
@@ -156,13 +156,11 @@ export const ColorSelector: FC<ColorSelectorProps> = ({
                   )
                 }
                 onClick={() => {
-                  editor.commands.unsetColor();
-                  name !== "Default" &&
-                    editor
-                      .chain()
-                      .focus()
-                      .setColor(color || "")
-                      .run();
+                  if (name === "Default") {
+                    editor.commands.unsetColor();
+                  } else {
+                    editor.chain().focus().setColor(color || "").run();
+                  }
                   setIsOpen(false);
                 }}
                 style={{ border: "none" }}


### PR DESCRIPTION
prevent text color removal from other list items when setting color in lists

Only unset color when 'Default' is selected. This ensures setting color on one list item does not remove it from others.

Closes https://github.com/docmost/docmost/discussions/978, https://github.com/docmost/docmost/issues/1287