### PR TITLE
Allow admins to change the password of members

### DIFF
--- a/apps/client/src/features/workspace/components/members/components/change-user-password.tsx
+++ b/apps/client/src/features/workspace/components/members/components/change-user-password.tsx
@@ -1,0 +1,91 @@
+import { Button, Group, Text, Modal, PasswordInput } from "@mantine/core";
+import * as z from "zod";
+import { useState } from "react";
+import { useDisclosure } from "@mantine/hooks";
+import * as React from "react";
+import { useForm, zodResolver } from "@mantine/form";
+import { changeWorkspaceMemberPassword } from "@/features/workspace/services/workspace-service.ts";
+import { notifications } from "@mantine/notifications";
+import { useTranslation } from "react-i18next";
+
+const formSchema = z.object({
+  actorPassword: z
+    .string({ required_error: "Your password is required" })
+    .min(8),
+  newPassword: z.string({ required_error: "New password is required" }).min(8),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+interface ChangeUserPasswordFormProps {
+  userId: string;
+  userName: string;
+  onClose?: () => void;
+}
+export default function ChangeUserPasswordForm({ userId, userName, onClose }: ChangeUserPasswordFormProps) {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const form = useForm<FormValues>({
+    validate: zodResolver(formSchema),
+    initialValues: {
+      actorPassword: "",
+      newPassword: "",
+    },
+  });
+
+  async function handleSubmit(data: FormValues) {
+    setIsLoading(true);
+    try {
+      await changeWorkspaceMemberPassword({
+        userId: userId,
+        actorPassword: data.actorPassword,
+        newPassword: data.newPassword,
+      });
+      notifications.show({
+        message: t("Password changed successfully for {{userName}}", { userName }),
+      });
+
+      onClose?.();
+    } catch (err) {
+      notifications.show({
+        message: `Error: ${err.response.data.message}`,
+        color: "red",
+      });
+    }
+    setIsLoading(false);
+  }
+  return (
+    <>
+      <Text size="sm" mb="md">
+        {t("You are changing the password for {{userName}}. Enter your current password to confirm this action.", { userName })}
+      </Text>
+      
+      <form onSubmit={form.onSubmit(handleSubmit)}>
+        <PasswordInput
+          label={t("Your current password")}
+          name="actorPassword"
+          placeholder={t("Enter your current password")}
+          variant="filled"
+          mb="md"
+          data-autofocus
+          {...form.getInputProps("actorPassword")}
+        />
+
+        <PasswordInput
+          label={t("New password for {{userName}}", { userName })}
+          placeholder={t("Enter the new password")}
+          variant="filled"
+          mb="md"
+          {...form.getInputProps("newPassword")}
+        />
+
+        <Group justify="flex-end" mt="md">
+          <Button type="submit" disabled={isLoading} loading={isLoading}>
+            {t("Change password")}
+          </Button>
+        </Group>
+      </form>
+    </>
+  );
+}

--- a/apps/client/src/features/workspace/components/members/components/members-action-menu.tsx
+++ b/apps/client/src/features/workspace/components/members/components/members-action-menu.tsx
@@ -1,15 +1,17 @@
 import { Menu, ActionIcon, Text } from "@mantine/core";
 import React from "react";
-import { IconDots, IconTrash } from "@tabler/icons-react";
+import { IconDots, IconTrash, IconPassword } from "@tabler/icons-react";
 import { modals } from "@mantine/modals";
 import { useDeleteWorkspaceMemberMutation } from "@/features/workspace/queries/workspace-query.ts";
 import { useTranslation } from "react-i18next";
 import useUserRole from "@/hooks/use-user-role.tsx";
+import ChangeUserPasswordForm from "@/features/workspace/components/members/components/change-user-password.tsx";
 
 interface Props {
   userId: string;
+  userName: string;
 }
-export default function MemberActionMenu({ userId }: Props) {
+export default function MemberActionMenu({ userId, userName }: Props) {
   const { t } = useTranslation();
   const deleteWorkspaceMemberMutation = useDeleteWorkspaceMemberMutation();
   const { isAdmin } = useUserRole();
@@ -34,6 +36,18 @@ export default function MemberActionMenu({ userId }: Props) {
       onConfirm: onRevoke,
     });
 
+  const openChangePasswordModal = () =>
+    modals.open({
+      title: t("Change password for {{userName}}", { userName }),
+      children: (
+        <ChangeUserPasswordForm
+          userId={userId}
+          userName={userName}
+          onClose={() => modals.closeAll()}
+        />
+      ),
+      centered: true,
+    });
   return (
     <>
       <Menu
@@ -51,6 +65,14 @@ export default function MemberActionMenu({ userId }: Props) {
         </Menu.Target>
 
         <Menu.Dropdown>
+          <Menu.Item
+            onClick={openChangePasswordModal}
+            leftSection={<IconPassword size={16} />}
+            disabled={!isAdmin}
+          >
+            {t("Change password")}
+          </Menu.Item>
+          
           <Menu.Item
             c="red"
             onClick={openRevokeModal}

--- a/apps/client/src/features/workspace/components/members/components/workspace-members-table.tsx
+++ b/apps/client/src/features/workspace/components/members/components/workspace-members-table.tsx
@@ -98,7 +98,7 @@ export default function WorkspaceMembersTable() {
                     />
                   </Table.Td>
                   <Table.Td>
-                    {isAdmin && <MemberActionMenu userId={user.id} />}
+                    {isAdmin && <MemberActionMenu userId={user.id} userName={user.name} />}
                   </Table.Td>
                 </Table.Tr>
               ))

--- a/apps/client/src/features/workspace/services/workspace-service.ts
+++ b/apps/client/src/features/workspace/services/workspace-service.ts
@@ -54,6 +54,14 @@ export async function changeMemberRole(data: {
   await api.post("/workspace/members/change-role", data);
 }
 
+export async function changeWorkspaceMemberPassword(data: {
+  userId: string;
+  newPassword: string;
+  actorPassword: string;
+}): Promise<void> {
+  await api.post("/workspace/members/change-password", data);
+}
+
 export async function getPendingInvitations(
   params?: QueryParams,
 ): Promise<IPagination<IInvitation>> {

--- a/apps/server/src/core/auth/dto/change-password.dto.ts
+++ b/apps/server/src/core/auth/dto/change-password.dto.ts
@@ -11,3 +11,19 @@ export class ChangePasswordDto {
   @IsString()
   newPassword: string;
 }
+
+export class ChangeWorkspaceMemberPasswordDto {
+  @IsNotEmpty()
+  @MinLength(8)
+  @IsString()
+  actorPassword: string;
+
+  @IsNotEmpty()
+  @MinLength(8)
+  @IsString()
+  newPassword: string;
+
+  @IsNotEmpty()
+  @IsString()
+  userId: string;
+}

--- a/apps/server/src/core/workspace/controllers/workspace.controller.ts
+++ b/apps/server/src/core/workspace/controllers/workspace.controller.ts
@@ -33,6 +33,7 @@ import {
 import { EnvironmentService } from '../../../integrations/environment/environment.service';
 import { CheckHostnameDto } from '../dto/check-hostname.dto';
 import { RemoveWorkspaceUserDto } from '../dto/remove-workspace-user.dto';
+import { ChangeWorkspaceMemberPasswordDto } from '../../auth/dto/change-password.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('workspace')
@@ -117,6 +118,27 @@ export class WorkspaceController {
     ) {
       throw new ForbiddenException();
     }
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Post('members/change-password')
+  async changePasswordForWorkspaceMember(
+    @Body() dto: ChangeWorkspaceMemberPasswordDto,
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    const ability = this.workspaceAbility.createForUser(user, workspace);
+    if (
+      ability.cannot(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Member)
+    ) {
+      throw new ForbiddenException();
+    }
+
+    await this.workspaceService.changeUserPassword(
+      dto,
+      user.id,
+      workspace.id,
+    );
   }
 
   @HttpCode(HttpStatus.OK)

--- a/apps/server/src/core/workspace/services/workspace.service.ts
+++ b/apps/server/src/core/workspace/services/workspace.service.ts
@@ -32,7 +32,11 @@ import { AttachmentType } from 'src/core/attachment/attachment.constants';
 import { InjectQueue } from '@nestjs/bullmq';
 import { QueueJob, QueueName } from '../../../integrations/queue/constants';
 import { Queue } from 'bullmq';
-import { generateRandomSuffixNumbers } from '../../../common/helpers';
+import { comparePasswordHash, generateRandomSuffixNumbers, hashPassword } from '../../../common/helpers';
+import { ChangePasswordDto, ChangeWorkspaceMemberPasswordDto } from '../../auth/dto/change-password.dto';
+import ChangePasswordEmail from '@docmost/transactional/emails/change-password-email';
+import ChangeUserPasswordEmail from '@docmost/transactional/emails/change-user-password-email';
+import { MailService } from '../../../integrations/mail/mail.service';
 
 @Injectable()
 export class WorkspaceService {
@@ -47,6 +51,7 @@ export class WorkspaceService {
     private userRepo: UserRepo,
     private environmentService: EnvironmentService,
     private domainService: DomainService,
+    private mailService: MailService,
     @InjectKysely() private readonly db: KyselyDB,
     @InjectQueue(QueueName.ATTACHMENT_QUEUE) private attachmentQueue: Queue,
     @InjectQueue(QueueName.BILLING_QUEUE) private billingQueue: Queue,
@@ -480,5 +485,49 @@ export class WorkspaceService {
     } catch (err) {
       // empty
     }
+  }
+
+  async changeUserPassword(
+    dto: ChangeWorkspaceMemberPasswordDto,
+    userId: string,
+    workspaceId: string,
+  ): Promise<void> {
+    const user = await this.userRepo.findById(dto.userId, workspaceId, {
+      includePassword: true,
+    });
+
+    const actorUser = await this.userRepo.findById(userId, workspaceId, {
+      includePassword: true,
+    });
+
+    if (!user || user.deletedAt || !actorUser || actorUser.deletedAt) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Password from the user that wants to change the password to validate authorization. For ee this needs additional implementation.
+    const comparePasswords = await comparePasswordHash(
+      dto.actorPassword,
+      actorUser.password,
+    );
+
+    if (!comparePasswords) {
+      throw new BadRequestException('Current password is incorrect');
+    }
+
+    const newPasswordHash = await hashPassword(dto.newPassword);
+    await this.userRepo.updateUser(
+      {
+        password: newPasswordHash,
+      },
+      dto.userId,
+      workspaceId,
+    );
+
+    const emailTemplate = ChangeUserPasswordEmail({ username: user.name, actorUsername: actorUser.name });
+    await this.mailService.sendToQueue({
+      to: user.email,
+      subject: 'Your password has been changed',
+      template: emailTemplate,
+    });
   }
 }

--- a/apps/server/src/core/workspace/services/workspace.service.ts
+++ b/apps/server/src/core/workspace/services/workspace.service.ts
@@ -504,6 +504,12 @@ export class WorkspaceService {
       throw new NotFoundException('User not found');
     }
 
+    if (
+      (actorUser.role === UserRole.ADMIN && user.role === UserRole.OWNER)
+    ) {
+      throw new ForbiddenException();
+    }
+
     // Password from the user that wants to change the password to validate authorization. For ee this needs additional implementation.
     const comparePasswords = await comparePasswordHash(
       dto.actorPassword,

--- a/apps/server/src/integrations/transactional/emails/change-user-password-email.tsx
+++ b/apps/server/src/integrations/transactional/emails/change-user-password-email.tsx
@@ -1,0 +1,24 @@
+import { Section, Text } from '@react-email/components';
+import * as React from 'react';
+import { content, paragraph } from '../css/styles';
+import { MailBody } from '../partials/partials';
+
+interface Props {
+  username?: string;
+  actorUsername?: string;
+}
+
+export const ChangeUserPasswordEmail = ({ username, actorUsername }: Props) => {
+  return (
+    <MailBody>
+      <Section style={content}>
+        <Text style={paragraph}>Hi {username},</Text>
+        <Text style={paragraph}>
+          This is to inform you that your password was changed successfully by {actorUsername}.
+        </Text>
+      </Section>
+    </MailBody>
+  );
+};
+
+export default ChangeUserPasswordEmail;


### PR DESCRIPTION
I understand that this feature might not be possible for enterprise use. If that's the case, please close this PR. 

I opened it in case it could be added. It does not let admins change the owner's email. Everything else can already be done by an admin (deleting an account, creating a new one) or by making a new account with the admin role.

It also lets the person know who changed the password.