### PR TITLE
Codeblock: download, title, line wrapping, header

### DIFF
--- a/apps/client/public/locales/en-US/translation.json
+++ b/apps/client/public/locales/en-US/translation.json
@@ -223,8 +223,6 @@
   "Invite link": "Invite link",
   "Copy": "Copy",
   "Copied": "Copied",
-  "Download code": "Download code",
-  "Toggle line wrap": "Toggle line wrap",
   "Select a user": "Select a user",
   "Select a group": "Select a group",
   "Export all pages and attachments in this space.": "Export all pages and attachments in this space.",
@@ -359,10 +357,6 @@
   "Default page edit mode": "Default page edit mode",
   "Choose your preferred page edit mode. Avoid accidental edits.": "Choose your preferred page edit mode. Avoid accidental edits.",
   "Reading": "Reading",
-  "Enable line wrap": "Enable line wrap",
-  "Disable line wrap": "Disable line wrap",
-  "Hide header": "Hide header",
-  "Show header": "Show header",
   "Delete member": "Delete member",
   "Member deleted successfully": "Member deleted successfully",
   "Are you sure you want to delete this workspace member? This action is irreversible.": "Are you sure you want to delete this workspace member? This action is irreversible.",
@@ -395,5 +389,9 @@
   "Failed to share page": "Failed to share page",
   "Copy page": "Copy page",
   "Copy page to a different space.": "Copy page to a different space.",
-  "Page copied successfully": "Page copied successfully"
+  "Page copied successfully": "Page copied successfully",
+  "Download code": "Download code",
+  "Toggle line wrap": "Toggle line wrap",
+  "Enable line wrap": "Enable line wrap",
+  "Disable line wrap": "Disable line wrap"
 }

--- a/apps/client/src/features/editor/components/code-block/code-block-view.tsx
+++ b/apps/client/src/features/editor/components/code-block/code-block-view.tsx
@@ -1,7 +1,13 @@
 import { NodeViewContent, NodeViewProps, NodeViewWrapper } from "@tiptap/react";
-import { ActionIcon, CopyButton, Group, Select, Tooltip, TextInput } from "@mantine/core";
+import { ActionIcon, CopyButton, Group, Select, Tooltip } from "@mantine/core";
 import { useEffect, useState } from "react";
-import { IconCheck, IconCopy, IconDownload, IconTextWrap, IconTextWrapDisabled, IconEyeOff, IconEye } from "@tabler/icons-react";
+import {
+  IconCheck,
+  IconCopy,
+  IconDownload,
+  IconTextWrap,
+  IconTextWrapDisabled,
+} from "@tabler/icons-react";
 import classes from "./code-block.module.css";
 import React from "react";
 import { Suspense } from "react";
@@ -14,20 +20,15 @@ const MermaidView = React.lazy(
 export default function CodeBlockView(props: NodeViewProps) {
   const { t } = useTranslation();
   const { node, updateAttributes, extension, editor, getPos } = props;
-  const { language, title, wrapLines = true, hideHeader = false } = node.attrs;
+  const { language, wrap } = node.attrs;
   const [languageValue, setLanguageValue] = useState<string | null>(
     language || null,
   );
-  const [titleValue, setTitleValue] = useState<string>(title || "");
   const [isSelected, setIsSelected] = useState(false);
 
   useEffect(() => {
     setLanguageValue(language || null);
   }, [language]);
-
-  useEffect(() => {
-    setTitleValue(title || "");
-  }, [title]);
 
   useEffect(() => {
     const updateSelection = () => {
@@ -53,40 +54,29 @@ export default function CodeBlockView(props: NodeViewProps) {
     });
   }
 
-  function changeTitle(title: string) {
-    setTitleValue(title);
-    updateAttributes({
-      title: title || null,
-    });
-  }
-
   function toggleWrapLines() {
     updateAttributes({
-      wrapLines: !wrapLines,
-    });
-  }
-
-  function toggleHeaderVisibility() {
-    updateAttributes({
-      hideHeader: !hideHeader,
+      wrap: !wrap,
     });
   }
 
   function downloadCode() {
     const content = node?.textContent || "";
-    let filename = titleValue || "code";
-    
-    const hasExtension = filename.includes('.') && filename.lastIndexOf('.') > filename.lastIndexOf('/');
+    let filename = "code";
+
+    const hasExtension =
+      filename.includes(".") &&
+      filename.lastIndexOf(".") > filename.lastIndexOf("/");
     if (!hasExtension && languageValue) {
       filename += `.${languageValue}`;
     }
     if (!hasExtension && !languageValue) {
-      filename += '.txt';
+      filename += ".txt";
     }
-    
-    const blob = new Blob([content], { type: 'text/plain' });
+
+    const blob = new Blob([content], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
     a.download = filename;
     document.body.appendChild(a);
@@ -97,125 +87,86 @@ export default function CodeBlockView(props: NodeViewProps) {
 
   return (
     <NodeViewWrapper className="codeBlock">
-      {!hideHeader && (
-        <Group
-          justify="space-between"
-          contentEditable={false}
-          className={classes.headerGroup}
-          mb={4}
-        >
-          <div className={classes.titleContainer}>
-            {editor.isEditable ? (
-              <TextInput
-                placeholder={t("Title")}
-                value={titleValue}
-                onChange={(e) => changeTitle(e.target.value)}
-                variant="unstyled"
-                size="xs"
-                className={classes.titleInput}
-              />
-            ) : (
-              titleValue && (
-                <div className={classes.titleDisplay}>
-                  {titleValue}
-                </div>
-              )
-            )}
-          </div>
-          
-          <Group gap="xs" className={classes.actionsGroup}>
-            <Tooltip label={hideHeader ? t("Show header") : t("Hide header")} withArrow position="top">
-              <ActionIcon
-                variant="subtle"
-                color="gray"
-                size="sm"
-                onClick={toggleHeaderVisibility}
-              >
-                {hideHeader ? <IconEye size={14} /> : <IconEyeOff size={14} />}
-              </ActionIcon>
-            </Tooltip>
-
-            <Tooltip label={wrapLines ? t("Disable line wrap") : t("Enable line wrap")} withArrow position="top">
-              <ActionIcon
-                variant="subtle"
-                color="gray"
-                size="sm"
-                onClick={toggleWrapLines}
-              >
-                {wrapLines ? <IconTextWrapDisabled size={14} /> : <IconTextWrap size={14} />}
-              </ActionIcon>
-            </Tooltip>
-
-            <Select
-              placeholder="auto"
-              checkIconPosition="right"
-              data={extension.options.lowlight.listLanguages().sort()}
-              value={languageValue}
-              onChange={changeLanguage}
-              searchable
-              size="xs"
-              style={{ minWidth: "100px" }}
-              classNames={{ input: classes.selectInput }}
-              disabled={!editor.isEditable}
-            />
-
-            <Tooltip label={t("Download code")} withArrow position="top">
-              <ActionIcon
-                variant="subtle"
-                color="gray"
-                size="sm"
-                onClick={downloadCode}
-              >
-                <IconDownload size={14} />
-              </ActionIcon>
-            </Tooltip>
-
-            <CopyButton value={node?.textContent} timeout={2000}>
-              {({ copied, copy }) => (
-                <Tooltip
-                  label={copied ? t("Copied") : t("Copy")}
-                  withArrow
-                  position="top"
-                >
-                  <ActionIcon
-                    color={copied ? "teal" : "gray"}
-                    variant="subtle"
-                    size="sm"
-                    onClick={copy}
-                  >
-                    {copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
-                  </ActionIcon>
-                </Tooltip>
+      <Group
+        justify="space-between"
+        contentEditable={false}
+        className={classes.headerGroup}
+        mb={0}
+      >
+        <Group gap="xs" className={classes.actionsGroup}>
+          <Tooltip
+            label={wrap ? t("Disable line wrap") : t("Enable line wrap")}
+            withArrow
+            position="top"
+          >
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size="sm"
+              onClick={toggleWrapLines}
+            >
+              {wrap ? (
+                <IconTextWrapDisabled size={14} />
+              ) : (
+                <IconTextWrap size={14} />
               )}
-            </CopyButton>
-          </Group>
+            </ActionIcon>
+          </Tooltip>
+
+          <Select
+            placeholder="auto"
+            checkIconPosition="right"
+            data={extension.options.lowlight.listLanguages().sort()}
+            value={languageValue}
+            onChange={changeLanguage}
+            searchable
+            size="sm"
+            style={{ maxWidth: "130px" }}
+            classNames={{ input: classes.selectInput }}
+            disabled={!editor.isEditable}
+          />
+
+          <Tooltip label={t("Download code")} withArrow position="top">
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size="sm"
+              onClick={downloadCode}
+            >
+              <IconDownload size={14} />
+            </ActionIcon>
+          </Tooltip>
+
+          <CopyButton value={node?.textContent} timeout={2000}>
+            {({ copied, copy }) => (
+              <Tooltip
+                label={copied ? t("Copied") : t("Copy")}
+                withArrow
+                position="top"
+              >
+                <ActionIcon
+                  color={copied ? "teal" : "gray"}
+                  variant="subtle"
+                  size="sm"
+                  onClick={copy}
+                >
+                  {copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
+                </ActionIcon>
+              </Tooltip>
+            )}
+          </CopyButton>
         </Group>
-      )}
+      </Group>
 
       <pre
         spellCheck="false"
-        className={wrapLines ? classes.wrapLines : classes.noWrapLines}
+        className={wrap ? classes.lineWrap : classes.noLineWrap}
         hidden={
           ((language === "mermaid" && !editor.isEditable) ||
             (language === "mermaid" && !isSelected)) &&
           node.textContent.length > 0
         }
       >
-        {hideHeader && (
-          <div className={classes.hiddenHeaderActions}>
-            <Tooltip label={t("Show header")} withArrow position="top">
-              <ActionIcon
-                variant="subtle"
-                color="gray"
-                size="sm"
-                onClick={toggleHeaderVisibility}
-                className={classes.showHeaderButton}
-              >
-                <IconEye size={14} />
-              </ActionIcon>
-            </Tooltip>
-          </div>
-        )}
         <NodeViewContent as="code" className={`language-${language}`} />
       </pre>
 

--- a/apps/client/src/features/editor/components/code-block/code-block.module.css
+++ b/apps/client/src/features/editor/components/code-block/code-block.module.css
@@ -1,151 +1,105 @@
 .codeBlock {
-    position: relative;
+  position: relative;
 }
 
 .headerGroup {
-    align-items: center;
-    min-height: 32px;
-    padding: 6px 12px;
-    background: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
-    display: flex;
-    justify-content: space-between;
-}
+  align-items: center;
+  min-height: 32px;
+  padding: 6px 12px;
+  background: light-dark(
+    var(--mantine-color-gray-0),
+    var(--mantine-color-dark-8)
+  );
+  display: flex;
+  justify-content: space-between;
 
-.titleContainer {
-    flex: 1;
-    max-width: 300px;
-    min-width: 0;
+  @media print {
+    display: none;
+  }
 }
 
 .actionsGroup {
-    flex-shrink: 0;
-    margin-left: auto;
-}
-
-.hiddenHeaderActions {
-    position: absolute;
-    top: 8px;
-    right: 8px;
-    z-index: 10;
-    background: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
-    border-radius: var(--mantine-radius-sm);
-    padding: 4px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.showHeaderButton {
-    opacity: 0.7;
-    transition: opacity 0.2s ease;
-    width: 24px !important;
-    height: 24px !important;
-    min-width: 24px !important;
-    min-height: 24px !important;
-    padding: 0 !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-}
-
-.showHeaderButton:hover {
-    opacity: 1;
-}
-
-.titleInput {
-    font-size: 13px;
-    font-weight: 500;
-    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-3));
-    width: 100%;
-}
-
-.titleInput input {
-    background: transparent !important;
-    border: none !important;
-    font-size: 13px !important;
-    font-weight: 500 !important;
-    padding: 0 !important;
-    min-height: 20px !important;
-    height: 20px !important;
-}
-
-.titleInput input::placeholder {
-    color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-gray-6));
-    font-style: italic;
-}
-
-.titleDisplay {
-    font-size: 13px;
-    font-weight: 500;
-    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-gray-3));
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .selectInput {
-    font-size: 12px;
-    height: 24px;
-    min-height: 24px;
-    background: transparent;
+  font-size: 12px;
+  height: 24px;
+  min-height: 24px;
+  background: transparent;
 }
 
-pre.wrapLines {
-    position: relative;
-    white-space: pre-wrap !important;
-    word-wrap: break-word !important;
-    overflow-wrap: break-word !important;
-    overflow-x: visible !important;
+pre.lineWrap {
+  position: relative;
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
+  overflow-wrap: break-word !important;
+  overflow-x: visible !important;
 }
 
-pre.wrapLines code {
-    white-space: pre-wrap !important;
-    word-wrap: break-word !important;
-    overflow-wrap: break-word !important;
+pre.lineWrap code {
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
+  overflow-wrap: break-word !important;
 }
 
-pre.noWrapLines {
-    position: relative;
-    white-space: pre !important;
-    word-wrap: normal !important;
-    overflow-x: auto !important;
-    overflow-wrap: normal !important;
+pre.noLineWrap {
+  position: relative;
+  white-space: pre !important;
+  word-wrap: normal !important;
+  overflow-x: auto !important;
+  overflow-wrap: normal !important;
 }
 
-pre.noWrapLines code {
-    white-space: pre !important;
-    word-wrap: normal !important;
-    overflow-wrap: normal !important;
+pre.noLineWrap code {
+  white-space: pre !important;
+  word-wrap: normal !important;
+  overflow-wrap: normal !important;
 }
 
 /* Custom scrollbar styling for no-wrap mode */
-pre.noWrapLines::-webkit-scrollbar {
-    height: 6px;
+pre.noLineWrap::-webkit-scrollbar {
+  height: 6px;
 }
 
-pre.noWrapLines::-webkit-scrollbar-track {
-    background: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-6));
-    border-radius: 3px;
+pre.noLineWrap::-webkit-scrollbar-track {
+  background: light-dark(
+    var(--mantine-color-gray-2),
+    var(--mantine-color-dark-6)
+  );
+  border-radius: 3px;
 }
 
-pre.noWrapLines::-webkit-scrollbar-thumb {
-    background: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-4));
-    border-radius: 3px;
+pre.noLineWrap::-webkit-scrollbar-thumb {
+  background: light-dark(
+    var(--mantine-color-gray-5),
+    var(--mantine-color-dark-4)
+  );
+  border-radius: 3px;
 }
 
-pre.noWrapLines::-webkit-scrollbar-thumb:hover {
-    background: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-3));
-    cursor: default;
+pre.noLineWrap::-webkit-scrollbar-thumb:hover {
+  background: light-dark(
+    var(--mantine-color-gray-6),
+    var(--mantine-color-dark-3)
+  );
+  cursor: default;
 }
 
 .error {
-    color: light-dark(var(--mantine-color-red-8), var(--mantine-color-red-7));
-    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-gray-8));
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  color: light-dark(var(--mantine-color-red-8), var(--mantine-color-red-7));
+  background-color: light-dark(
+    var(--mantine-color-gray-0),
+    var(--mantine-color-gray-8)
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .mermaid {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/apps/client/src/features/editor/styles/code.css
+++ b/apps/client/src/features/editor/styles/code.css
@@ -6,7 +6,7 @@
     }
 
   pre {
-    padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+    padding: 5px var(--mantine-spacing-sm);
     margin: 4px;
     font-family: "JetBrainsMono", var(--mantine-font-family-monospace);
     border-radius: var(--mantine-radius-default);

--- a/apps/client/src/features/editor/styles/core.css
+++ b/apps/client/src/features/editor/styles/core.css
@@ -81,8 +81,8 @@
   }
 
   blockquote {
-    padding-left: 25px;
-    padding-right: 25px;
+    padding-left: var(--mantine-spacing-sm);
+    padding-right: var(--mantine-spacing-sm);
     border-left: 2px solid var(--mantine-color-gray-6);
     background-color: light-dark(
       var(--mantine-color-gray-0),

--- a/packages/editor-ext/src/lib/custom-code-block.ts
+++ b/packages/editor-ext/src/lib/custom-code-block.ts
@@ -23,39 +23,15 @@ export const CustomCodeBlock = CodeBlockLowlight.extend<CustomCodeBlockOptions>(
     addAttributes() {
       return {
         ...this.parent?.(),
-        title: {
-          default: null,
-          parseHTML: element => element.getAttribute('data-title'),
-          renderHTML: attributes => {
-            if (!attributes.title) {
-              return {};
-            }
-            return {
-              'data-title': attributes.title,
-            };
-          },
-        },
-        wrapLines: {
-          default: true,
-          parseHTML: element => {
-            const value = element.getAttribute('data-wrap-lines');
-            return value === null || value === 'true';
-          },
-          renderHTML: attributes => {
-            return {
-              'data-wrap-lines': attributes.wrapLines.toString(),
-            };
-          },
-        },
-        hideHeader: {
+        wrap: {
           default: false,
-          parseHTML: element => {
-            const value = element.getAttribute('data-hide-header');
-            return value === 'true';
+          parseHTML: (element) => {
+            const value = element.getAttribute("data-wrap");
+            return value === null || value === "true";
           },
-          renderHTML: attributes => {
+          renderHTML: (attributes) => {
             return {
-              'data-hide-header': attributes.hideHeader.toString(),
+              "data-wrap": attributes.wrap.toString(),
             };
           },
         },
@@ -83,5 +59,5 @@ export const CustomCodeBlock = CodeBlockLowlight.extend<CustomCodeBlockOptions>(
     addNodeView() {
       return ReactNodeViewRenderer(this.options.view);
     },
-  }
+  },
 );


### PR DESCRIPTION
Fixes #1297 

Adds the ability to download, adds titles (e.g. for downloads or as a label), includes a toggle for line wrapping, and allows the header to be hidden.

For mermaid this completely hides the header which make them look better imo

Images:
![grafik](https://github.com/user-attachments/assets/2854d1c1-d3ff-4204-92a7-724628b024df)
![grafik](https://github.com/user-attachments/assets/944aa3a2-a519-45f5-82da-e99e8a9bc798)
![grafik](https://github.com/user-attachments/assets/3ae9a7aa-3740-4495-b99c-ec54cc29b650)
