### PR TITLE
Add optional password protection to shared pages

### DIFF
--- a/apps/client/src/features/share/components/share-password-modal.tsx
+++ b/apps/client/src/features/share/components/share-password-modal.tsx
@@ -1,0 +1,103 @@
+import {
+  Modal,
+  Text,
+  PasswordInput,
+  Button,
+  Group,
+  Alert,
+  Stack,
+} from "@mantine/core";
+import { IconLock, IconAlertCircle } from "@tabler/icons-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface SharePasswordModalProps {
+  shareId: string;
+  opened: boolean;
+  onSuccess: (password: string) => void;
+}
+
+export default function SharePasswordModal({
+  shareId,
+  opened,
+  onSuccess,
+}: SharePasswordModalProps) {
+  const { t } = useTranslation();
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!password.trim()) {
+      setError(t("Password is required"));
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      setPassword("");
+      setError(null);
+      onSuccess(password.trim());
+    } catch (err) {
+      setError(t("Failed to validate password"));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleKeyPress = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter") {
+      handleSubmit();
+    }
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={() => {}}
+      title={
+      <Group gap="xs">
+        <IconLock size={20} />
+        <Text fw={500}>{t("Password Required")}</Text>
+      </Group>
+      }
+      centered
+      size="sm"
+      closeOnClickOutside={false}
+      closeOnEscape={false}
+      withCloseButton={false}
+    >
+      <Stack>
+        <Text size="sm" c="dimmed">
+          {t("This page is password protected. Please enter the password to continue.")}
+        </Text>
+
+        {error && (
+          <Alert icon={<IconAlertCircle size={16} />} color="red" variant="light">
+            {error}
+          </Alert>
+        )}
+
+        <PasswordInput
+          label={t("Password")}
+          placeholder={t("Enter password")}
+          value={password}
+          onChange={(event) => setPassword(event.currentTarget.value)}
+          onKeyDown={handleKeyPress}
+          error={error ? true : false}
+          data-autofocus
+        />
+
+        <Group justify="flex-end">
+          <Button
+            onClick={handleSubmit}
+            loading={isLoading}
+            disabled={!password.trim()}
+          >
+            {t("Continue")}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/apps/client/src/features/share/components/share-shell.tsx
+++ b/apps/client/src/features/share/components/share-shell.tsx
@@ -57,7 +57,8 @@ export default function ShareShell({
   const toggleToc = useToggleToc(tableOfContentAsideAtom);
 
   const { shareId } = useParams();
-  const { data } = useGetSharedPageTreeQuery(shareId);
+  const sessionPassword = shareId ? sessionStorage.getItem(`share-password-${shareId}`) : null;
+  const { data } = useGetSharedPageTreeQuery(shareId, sessionPassword || undefined);
   const readOnlyEditor = useAtomValue(readOnlyEditorAtom);
 
   return (

--- a/apps/client/src/features/share/services/share-service.ts
+++ b/apps/client/src/features/share/services/share-service.ts
@@ -9,6 +9,7 @@ import {
   ISharedPageTree,
   IShareForPage,
   IShareInfoInput,
+  ISharePassword,
   IUpdateShare,
 } from "@/features/share/types/share.types.ts";
 import { IPagination, QueryParams } from "@/lib/types.ts";
@@ -25,8 +26,8 @@ export async function createShare(data: ICreateShare): Promise<any> {
   return req.data;
 }
 
-export async function getShareInfo(shareId: string): Promise<IShare> {
-  const req = await api.post<IShare>("/shares/info", { shareId });
+export async function getShareInfo(shareId: string, password?: string): Promise<IShare> {
+  const req = await api.post<IShare>("/shares/info", { shareId, password });
   return req.data;
 }
 
@@ -53,7 +54,16 @@ export async function deleteShare(shareId: string): Promise<void> {
 
 export async function getSharedPageTree(
   shareId: string,
+  password?: string,
 ): Promise<ISharedPageTree> {
-  const req = await api.post<ISharedPageTree>("/shares/tree", { shareId });
+  const req = await api.post<ISharedPageTree>("/shares/tree", { shareId, password });
   return req.data;
+}
+
+export async function setSharePassword(data: ISharePassword): Promise<void> {
+  await api.post("/shares/set-password", data);
+}
+
+export async function removeSharePassword(shareId: string): Promise<void> {
+  await api.post("/shares/remove-password", { shareId });
 }

--- a/apps/client/src/features/share/types/share.types.ts
+++ b/apps/client/src/features/share/types/share.types.ts
@@ -6,6 +6,7 @@ export interface IShare {
   pageId: string;
   includeSubPages: boolean;
   searchIndexing: boolean;
+  passwordHash?: string;
   creatorId: string;
   spaceId: string;
   workspaceId: string;
@@ -60,12 +61,19 @@ export interface ICreateShare {
   pageId?: string;
   includeSubPages?: boolean;
   searchIndexing?: boolean;
+  password?: string;
 }
 
-export type IUpdateShare = ICreateShare & { shareId: string; pageId?: string };
+export type IUpdateShare = ICreateShare & { shareId: string; pageId?: string; password?: string; };
 
 export interface IShareInfoInput {
   pageId: string;
+  password?: string;
+}
+
+export interface ISharePassword {
+  shareId: string;
+  password: string;
 }
 
 export interface ISharedPageTree {

--- a/apps/server/src/core/share/dto/share.dto.ts
+++ b/apps/server/src/core/share/dto/share.dto.ts
@@ -18,6 +18,10 @@ export class CreateShareDto {
   @IsOptional()
   @IsBoolean()
   searchIndexing: boolean;
+
+  @IsString()
+  @IsOptional()
+  password?: string;
 }
 
 export class UpdateShareDto extends CreateShareDto {
@@ -28,12 +32,20 @@ export class UpdateShareDto extends CreateShareDto {
   @IsString()
   @IsOptional()
   pageId: string;
+
+  @IsString()
+  @IsOptional()
+  password?: string;
 }
 
 export class ShareIdDto {
   @IsString()
   @IsNotEmpty()
   shareId: string;
+
+  @IsString()
+  @IsOptional()
+  password?: string;
 }
 
 export class SpaceIdDto {
@@ -49,10 +61,24 @@ export class ShareInfoDto {
   @IsString()
   @IsOptional()
   pageId: string;
+
+  @IsString()
+  @IsOptional()
+  password?: string;
 }
 
 export class SharePageIdDto {
   @IsString()
   @IsNotEmpty()
   pageId: string;
+}
+
+export class SharePasswordDto {
+  @IsString()
+  @IsNotEmpty()
+  shareId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  password: string;
 }

--- a/apps/server/src/core/share/exceptions/share-password-required.exception.ts
+++ b/apps/server/src/core/share/exceptions/share-password-required.exception.ts
@@ -1,0 +1,14 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class SharePasswordRequiredException extends HttpException {
+  constructor(shareId: string) {
+    super(
+      {
+        message: 'Password required for this shared page',
+        error: 'SHARE_PASSWORD_REQUIRED',
+        shareId,
+      },
+      HttpStatus.FORBIDDEN,
+    );
+  }
+}

--- a/apps/server/src/core/share/share.service.ts
+++ b/apps/server/src/core/share/share.service.ts
@@ -3,11 +3,12 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { CreateShareDto, ShareInfoDto, UpdateShareDto } from './dto/share.dto';
 import { InjectKysely } from 'nestjs-kysely';
 import { KyselyDB } from '@docmost/db/types/kysely.types';
-import { nanoIdGen } from '../../common/helpers';
+import { nanoIdGen, hashPassword, comparePasswordHash } from '../../common/helpers';
 import { PageRepo } from '@docmost/db/repos/page/page.repo';
 import { TokenService } from '../auth/services/token.service';
 import { jsonToNode } from '../../collaboration/collaboration.util';
@@ -18,6 +19,7 @@ import {
   removeMarkTypeFromDoc,
 } from '../../common/helpers/prosemirror/utils';
 import { Node } from '@tiptap/pm/model';
+import { SharePasswordRequiredException } from './exceptions/share-password-required.exception';
 import { ShareRepo } from '@docmost/db/repos/share/share.repo';
 import { updateAttachmentAttr } from './share.util';
 import { Page } from '@docmost/db/types/entity.types';
@@ -52,6 +54,26 @@ export class ShareService {
     }
   }
 
+  async getShareTreeWithPassword(shareId: string, password: string | undefined, workspaceId: string) {
+    const share = await this.shareRepo.findById(shareId);
+    if (!share || share.workspaceId !== workspaceId) {
+      throw new NotFoundException('Share not found');
+    }
+
+    if (share.passwordHash) {
+      if (!password) {
+        throw new SharePasswordRequiredException(share.key);
+      }
+
+      const isValidPassword = await comparePasswordHash(password, share.passwordHash);
+      if (!isValidPassword) {
+        throw new SharePasswordRequiredException(share.key);
+      }
+    }
+
+    return this.getShareTree(shareId, workspaceId);
+  }
+
   async createShare(opts: {
     authUserId: string;
     workspaceId: string;
@@ -66,11 +88,17 @@ export class ShareService {
         return shares;
       }
 
+      let passwordHash: string | null = null;
+      if (createShareDto.password) {
+        passwordHash = await hashPassword(createShareDto.password);
+      }
+
       return await this.shareRepo.insertShare({
         key: nanoIdGen().toLowerCase(),
         pageId: page.id,
         includeSubPages: createShareDto.includeSubPages || true,
         searchIndexing: createShareDto.searchIndexing || true,
+        passwordHash,
         creatorId: authUserId,
         spaceId: page.spaceId,
         workspaceId,
@@ -83,13 +111,22 @@ export class ShareService {
 
   async updateShare(shareId: string, updateShareDto: UpdateShareDto) {
     try {
-      return this.shareRepo.updateShare(
-        {
-          includeSubPages: updateShareDto.includeSubPages,
-          searchIndexing: updateShareDto.searchIndexing,
-        },
-        shareId,
-      );
+      const updateData: any = {
+        includeSubPages: updateShareDto.includeSubPages,
+        searchIndexing: updateShareDto.searchIndexing,
+      };
+
+      if (updateShareDto.password !== undefined) {
+        if (updateShareDto.password === null || updateShareDto.password === '') {
+          // Remove password
+          updateData.passwordHash = null;
+        } else {
+          // Set new password
+          updateData.passwordHash = await hashPassword(updateShareDto.password);
+        }
+      }
+
+      return this.shareRepo.updateShare(updateData, shareId);
     } catch (err) {
       this.logger.error(err);
       throw new BadRequestException('Failed to update share');
@@ -101,6 +138,17 @@ export class ShareService {
 
     if (!share) {
       throw new NotFoundException('Shared page not found');
+    }
+
+    if (share.passwordHash) {
+      if (!dto.password) {
+        throw new SharePasswordRequiredException(share.key);
+      }
+
+      const isValidPassword = await comparePasswordHash(dto.password, share.passwordHash);
+      if (!isValidPassword) {
+        throw new SharePasswordRequiredException(share.key);
+      }
     }
 
     const page = await this.pageRepo.findById(dto.pageId, {
@@ -160,6 +208,7 @@ export class ShareService {
         'shares.pageId',
         'shares.includeSubPages',
         'shares.searchIndexing',
+        'shares.passwordHash',
         'shares.creatorId',
         'shares.spaceId',
         'shares.workspaceId',
@@ -184,6 +233,7 @@ export class ShareService {
       key: share.key,
       includeSubPages: share.includeSubPages,
       searchIndexing: share.searchIndexing,
+      passwordHash: share.passwordHash,
       pageId: share.pageId,
       creatorId: share.creatorId,
       spaceId: share.spaceId,
@@ -291,5 +341,14 @@ export class ShareService {
 
     const removeCommentMarks = removeMarkTypeFromDoc(doc, 'comment');
     return removeCommentMarks.toJSON();
+  }
+
+  async setSharePassword(shareId: string, password: string): Promise<void> {
+    const passwordHash = await hashPassword(password);
+    await this.shareRepo.updateShare({ passwordHash }, shareId);
+  }
+
+  async removeSharePassword(shareId: string): Promise<void> {
+    await this.shareRepo.updateShare({ passwordHash: null }, shareId);
   }
 }

--- a/apps/server/src/database/migrations/20250628T170000-add-password-to-shares.ts
+++ b/apps/server/src/database/migrations/20250628T170000-add-password-to-shares.ts
@@ -1,0 +1,15 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('shares')
+    .addColumn('password_hash', 'varchar', (col) => col)
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('shares')
+    .dropColumn('password_hash')
+    .execute();
+}

--- a/apps/server/src/database/repos/share/share.repo.ts
+++ b/apps/server/src/database/repos/share/share.repo.ts
@@ -28,6 +28,7 @@ export class ShareRepo {
     'pageId',
     'includeSubPages',
     'searchIndexing',
+    'passwordHash',
     'creatorId',
     'spaceId',
     'workspaceId',

--- a/apps/server/src/database/types/db.d.ts
+++ b/apps/server/src/database/types/db.d.ts
@@ -214,6 +214,7 @@ export interface Shares {
   includeSubPages: Generated<boolean | null>;
   key: string;
   pageId: string | null;
+  passwordHash: string | null;
   searchIndexing: Generated<boolean | null>;
   spaceId: string;
   updatedAt: Generated<Timestamp>;


### PR DESCRIPTION
This adds password protection to the shared pages. 

This fixes #1098 and it's duplicate fixes #1308

Only users with full access should be able to remove a password to make sure members cannot take it off sensitive files. They can disable the share and enable it again at any time, but this will create a new link.

The password is stored securly in the DB. Thus it cannot be displayed after entering

![grafik](https://github.com/user-attachments/assets/d7471bf3-1392-4f49-a758-7c3b7a5bbe86)
![grafik](https://github.com/user-attachments/assets/cc3bb564-a0cf-48bc-a2cf-f13a6f600100)
![grafik](https://github.com/user-attachments/assets/665e46ca-36c7-42c9-a879-1b8e987cd62a)
