### PR TITLE
fix: unsafe docmost editor-ext constructed from library input

### DIFF
--- a/packages/editor-ext/src/lib/utils.ts
+++ b/packages/editor-ext/src/lib/utils.ts
@@ -377,5 +377,7 @@ export function setAttributes(
 }
 
 export function icon(name: string) {
-  return `<span class="ProseMirror-icon ProseMirror-icon-${name}"></span>`;
+  const span = document.createElement("span");
+  span.classList.add("ProseMirror-icon", `ProseMirror-icon-${name}`);
+  return span.outerHTML;
 }


### PR DESCRIPTION
https://github.com/docmost/docmost/blob/44e592763dc4c5ff2c2c35b0d288cdb759740802/packages/editor-ext/src/lib/utils.ts#L380-L380
When a library function dynamically constructs HTML in a potentially unsafe way, then it's important to document to clients of the library that the function should only be used with trusted inputs. If the function is not documented as being potentially unsafe, then a client may inadvertently use inputs containing unsafe HTML fragments, and thereby leave the client vulnerable to cross-site scripting attacks.


The best way to fix the problem is to ensure that the `name` parameter is sanitized or safely handled before being embedded into the HTML string. This can be achieved by escaping the input to prevent it from being treated as executable code. Alternatively, a safer approach is to use DOM manipulation methods instead of string interpolation to construct the HTML dynamically. In this fix, we will replace the string interpolation approach with a DOM manipulation method. Specifically, we will create a `span` element, set its class list dynamically using a safe API, and then return its outer HTML. This avoids direct use of `innerHTML` for constructing the HTML and ensures the `name` parameter cannot introduce unsafe content.

#### References
[DOM based XSS Prevention Cheat Sheet](https://www.owasp.org/index.php/DOM_based_XSS_Prevention_Cheat_Sheet)
[XSS (Cross Site Scripting) Prevention Cheat Sheet](https://www.owasp.org/index.php/XSS_%28Cross_Site_Scripting%29_Prevention_Cheat_Sheet)
[DOM Based XSS](https://www.owasp.org/index.php/DOM_Based_XSS)