### PR TITLE
feat: allow process in docker to run as different uid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+# IDE - Intellij
+*.iml
 
 .nx
 .nx/installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,17 +34,21 @@ COPY --from=builder /app/pnpm*.yaml /app/
 COPY --from=builder /app/patches /app/patches
 
 RUN npm install -g pnpm@10.4.0
-
-RUN chown -R node:node /app
-
-USER node
-
 RUN pnpm install --frozen-lockfile --prod
-
 RUN mkdir -p /app/data/storage
 
 VOLUME ["/app/data/storage"]
 
+COPY ./entrypoint.sh /app/run.sh
+RUN chown -R node:node /app && \
+    find /app -type d -exec chmod 770 {} + && \
+    find /app -type f -exec chmod 660 {} + && \
+    find /app/node_modules/.bin/ -type f -exec chmod 770 {} + && \
+    chmod +x /app/run.sh \
+
 EXPOSE 3000
 
-CMD ["pnpm", "start"]
+ENTRYPOINT ["/app/run.sh"]
+
+
+#CMD ["pnpm", "start"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Get PUID/PGID
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+# Change user if needed
+if [ "$(id -u)" != "1000" ]; then
+    echo "using user ID: $PUID"
+    # If container is started as as non root
+    addgroup -g "$PGID" skywalker
+    adduser -D -u "$PUID" -G skywalker skywalker
+    addgroup skywalker node
+    echo "Switching to custom user (UID: $PUID)"
+fi
+
+su -s /bin/sh -c "pnpm start" skywalker


### PR DESCRIPTION
This PR modifies the docker entrypoint to allow starting docmost as a dynamically configured PUID/PGID.

The motivation behind this is to use a mapped local folder instead of a volume for `/app/data/storage` by setting the environment vars PUID and PGID and adjusting the volume mount

example docker compose

```
services:
  docmost:
    container_name: docmost_server
    image: docmost/docmost:latest
    environment:
      APP_URL: 'http://localhost:3000'
      APP_SECRET: 'REPLACE_WITH_LONG_SECRET'
      DATABASE_URL: 'postgresql://docmost:STRONG_DB_PASSWORD@db:5432/docmost?schema=public'
      REDIS_URL: 'redis://redis:6379'
      PUID: 1002
      PGID: 1002
    ports:
      - "127.0.0.1:3000:3000"
    restart: unless-stopped
    volumes:
      - /tmp/DATA/:/app/data/storage

```