### PR TITLE
feat: 添加隐藏分享页面导航栏的自定义构建指南

### DIFF
--- a/CUSTOM_BUILD_GUIDE.md
+++ b/CUSTOM_BUILD_GUIDE.md
@@ -1,0 +1,137 @@
+# Docmost 自定义构建指南
+
+本指南将帮助你构建一个隐藏了分享页面导航栏的 Docmost 自定义版本。
+
+## 修改内容
+
+### 1. 分享页面导航栏隐藏
+- **文件**: `apps/client/src/features/share/components/share-shell.tsx`
+- **修改**: 注释掉了 `AppShell.Header` 组件和相关的 header 配置
+- **效果**: 分享页面将不再显示顶部导航栏
+
+### 2. CSS 样式支持
+- **文件**: `apps/client/src/features/share/components/share.module.css`
+- **新增**: `.hideHeader` 类用于备用的隐藏方案
+
+## 构建步骤
+
+### 方法一：使用构建脚本（推荐）
+
+1. 确保你在 docmost 项目根目录下：
+   ```bash
+   cd /root/cms/docmost/docmost
+   ```
+
+2. 运行构建脚本：
+   ```bash
+   ./build-docker.sh
+   ```
+
+3. 等待构建完成，镜像名称为 `docmost-custom:latest`
+
+### 方法二：手动构建
+
+1. 在项目根目录下运行：
+   ```bash
+   docker build -t docmost-custom:latest .
+   ```
+
+## 部署方式
+
+### 方法一：使用自定义 docker-compose 文件
+
+1. 使用提供的自定义配置文件：
+   ```bash
+   docker-compose -f docker-compose.custom.yml up -d
+   ```
+
+### 方法二：修改现有 docker-compose.yml
+
+将 `docker-compose.yml` 中的：
+```yaml
+image: docmost/docmost:latest
+```
+
+修改为：
+```yaml
+image: docmost-custom:latest
+```
+
+然后运行：
+```bash
+docker-compose up -d
+```
+
+### 方法三：直接运行容器
+
+```bash
+# 启动数据库和 Redis
+docker run -d --name docmost-db \
+  -e POSTGRES_DB=docmost \
+  -e POSTGRES_USER=docmost \
+  -e POSTGRES_PASSWORD=STRONG_DB_PASSWORD \
+  -v docmost_db:/var/lib/postgresql/data \
+  postgres:16-alpine
+
+docker run -d --name docmost-redis \
+  -v docmost_redis:/data \
+  redis:7.2-alpine
+
+# 启动 Docmost
+docker run -d --name docmost-custom \
+  -p 3000:3000 \
+  -e APP_URL='http://localhost:3000' \
+  -e APP_SECRET='REPLACE_WITH_LONG_SECRET' \
+  -e DATABASE_URL='postgresql://docmost:STRONG_DB_PASSWORD@docmost-db:5432/docmost?schema=public' \
+  -e REDIS_URL='redis://docmost-redis:6379' \
+  -v docmost_storage:/app/data/storage \
+  --link docmost-db:db \
+  --link docmost-redis:redis \
+  docmost-custom:latest
+```
+
+## 验证部署
+
+1. 访问 `http://localhost:3000` 确认 Docmost 正常运行
+2. 创建一个页面并生成分享链接
+3. 访问分享链接，确认导航栏已被隐藏
+
+## 恢复导航栏
+
+如果需要恢复导航栏功能，请编辑 `apps/client/src/features/share/components/share-shell.tsx` 文件：
+
+1. 取消注释 `header={{ height: 50 }}` 行
+2. 取消注释整个 `AppShell.Header` 组件
+3. 重新构建镜像
+
+## 注意事项
+
+1. **数据安全**: 请确保修改默认密码和密钥
+2. **端口配置**: 根据需要修改端口映射
+3. **数据持久化**: 确保正确配置 Docker 卷以保存数据
+4. **网络配置**: 如果部署在服务器上，请修改 `APP_URL` 环境变量
+
+## 故障排除
+
+### 构建失败
+- 检查 Docker 是否正确安装
+- 确保有足够的磁盘空间
+- 检查网络连接是否正常
+
+### 容器启动失败
+- 检查环境变量配置
+- 确认数据库和 Redis 容器正常运行
+- 查看容器日志：`docker logs docmost-custom`
+
+### 分享页面仍显示导航栏
+- 确认使用的是自定义构建的镜像
+- 清除浏览器缓存
+- 检查修改是否正确应用
+
+## 技术支持
+
+如果遇到问题，请检查：
+1. Docker 和 docker-compose 版本
+2. 系统资源使用情况
+3. 网络端口是否被占用
+4. 日志文件中的错误信息

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ LABEL org.opencontainers.image.source="https://github.com/docmost/docmost"
 
 FROM base AS builder
 
+# 安装构建依赖
+RUN apk add --no-cache python3 make g++ py3-pip
+
 WORKDIR /app
 
 COPY . .

--- a/apps/client/src/features/share/components/share-shell.tsx
+++ b/apps/client/src/features/share/components/share-shell.tsx
@@ -62,7 +62,7 @@ export default function ShareShell({
 
   return (
     <AppShell
-      header={{ height: 50 }}
+      // header={{ height: 50 }} // 隐藏导航栏
       {...(data?.pageTree?.length > 1 && {
         navbar: {
           width: 300,
@@ -83,6 +83,7 @@ export default function ShareShell({
       }}
       padding="md"
     >
+      {/* 导航栏已隐藏 - 如需恢复请取消注释
       <AppShell.Header>
         <Group wrap="nowrap" justify="space-between" py="sm" px="xl">
           <Group wrap="nowrap">
@@ -154,6 +155,7 @@ export default function ShareShell({
           </Group>
         </Group>
       </AppShell.Header>
+      */}
 
       {data?.pageTree?.length > 1 && (
         <AppShell.Navbar p="md" className={classes.navbar}>

--- a/apps/client/src/features/share/components/share.module.css
+++ b/apps/client/src/features/share/components/share.module.css
@@ -2,6 +2,7 @@
   @mixin light {
     border-bottom: 0.05em solid var(--mantine-color-dark-0);
   }
+
   @mixin dark {
     border-bottom: 0.05em solid var(--mantine-color-dark-2);
   }
@@ -17,4 +18,9 @@
   @media (max-width: $mantine-breakpoint-sm) {
     width: 350px;
   }
+}
+
+/* 隐藏分享页面导航栏的备用方案 */
+.hideHeader {
+  display: none !important;
 }

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Docmost Docker 构建脚本
+# 用于构建隐藏导航栏的自定义 Docmost 镜像
+
+set -e
+
+# 配置变量
+IMAGE_NAME="docmost-custom"
+IMAGE_TAG="latest"
+FULL_IMAGE_NAME="${IMAGE_NAME}:${IMAGE_TAG}"
+
+echo "🚀 开始构建 Docmost 自定义镜像..."
+echo "镜像名称: ${FULL_IMAGE_NAME}"
+echo "构建时间: $(date)"
+echo ""
+
+# 检查 Docker 是否安装
+if ! command -v docker &> /dev/null; then
+    echo "❌ 错误: Docker 未安装或不在 PATH 中"
+    exit 1
+fi
+
+# 检查是否在正确的目录
+if [ ! -f "Dockerfile" ]; then
+    echo "❌ 错误: 未找到 Dockerfile，请确保在 docmost 项目根目录下运行此脚本"
+    exit 1
+fi
+
+# 构建 Docker 镜像
+echo "📦 正在构建 Docker 镜像..."
+docker build -t "${FULL_IMAGE_NAME}" .
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✅ Docker 镜像构建成功!"
+    echo "镜像名称: ${FULL_IMAGE_NAME}"
+    echo ""
+    echo "🔧 使用方法:"
+    echo "1. 直接运行:"
+    echo "   docker run -d -p 3000:3000 --name docmost-custom ${FULL_IMAGE_NAME}"
+    echo ""
+    echo "2. 使用 docker-compose (推荐):"
+    echo "   修改 docker-compose.yml 中的 image 字段为: ${FULL_IMAGE_NAME}"
+    echo "   然后运行: docker-compose up -d"
+    echo ""
+    echo "📝 注意事项:"
+    echo "- 分享页面的导航栏已被隐藏"
+    echo "- 如需恢复导航栏，请编辑 apps/client/src/features/share/components/share-shell.tsx"
+    echo "- 数据将保存在 Docker 卷中，请确保正确配置数据库和 Redis"
+else
+    echo ""
+    echo "❌ Docker 镜像构建失败!"
+    exit 1
+fi

--- a/docker-compose.custom.yml
+++ b/docker-compose.custom.yml
@@ -1,0 +1,44 @@
+version: '3'
+
+services:
+  docmost:
+    # 使用自定义构建的镜像（隐藏了分享页面导航栏）
+    image: docmost-custom:latest
+    # 如果需要从源码构建，可以取消注释下面的 build 配置
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    depends_on:
+      - db
+      - redis
+    environment:
+      APP_URL: 'http://localhost:3000'
+      APP_SECRET: 'c1905985497168325b59bc6f2a4459f61ed9d4acb54c80439d92d4a0e32fc4ba'
+      DATABASE_URL: 'postgresql://docmost:STRONG_DB_PASSWORD@db:5432/docmost?schema=public'
+      REDIS_URL: 'redis://redis:6379'
+    ports:
+      - "3200:3000"
+    restart: unless-stopped
+    volumes:
+      - docmost:/app/data/storage
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: docmost
+      POSTGRES_USER: docmost
+      POSTGRES_PASSWORD: STRONG_DB_PASSWORD
+    restart: unless-stopped
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7.2-alpine
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+
+volumes:
+  docmost:
+  db_data:
+  redis_data:


### PR DESCRIPTION
- 注释掉了 `apps/client/src/features/share/components/share-shell.tsx` 文件中的 `AppShell.Header` 组件和相关的 header 配置，实现了分享页面导航栏的隐藏
- 在 `apps/client/src/features/share/components/share.module.css` 文件中新增了 `.hideHeader` 类，作为备用的隐藏方案
- 添加了 `build-docker.sh` 构建脚本，简化了自定义镜像的构建过程
- 新增了 `docker-compose.custom.yml` 文件，提供了使用自定义构建镜像的部署方式
- 更新了 `Dockerfile`，增加了构建依赖的安装步骤，确保构建过程顺利进行