### PR TITLE
feat: set mermaid theme based on computed color scheme

### DIFF
--- a/apps/client/src/features/editor/components/code-block/mermaid-view.tsx
+++ b/apps/client/src/features/editor/components/code-block/mermaid-view.tsx
@@ -4,10 +4,14 @@ import mermaid from "mermaid";
 import { v4 as uuidv4 } from "uuid";
 import classes from "./code-block.module.css";
 import { useTranslation } from "react-i18next";
+import { useComputedColorScheme } from "@mantine/core";
+
+const computedColorScheme = useComputedColorScheme();
 
 mermaid.initialize({
   startOnLoad: false,
   suppressErrorRendering: true,
+  theme: computedColorScheme === "light" ? "default" : "dark",
 });
 
 interface MermaidViewProps {


### PR DESCRIPTION
Use Mantine's `useComputedColorScheme` hook to dynamically configure mermaid's theme.
- When the computed color scheme is "light", the theme is set to "default".
- Otherwise, it is set to "dark".

List of [available themes](https://mermaid.js.org/config/theming.html#available-themes):
- `default` - This is the default theme for all diagrams.
- `neutral` - This theme is great for black and white documents that will be printed.
- `dark` - This theme goes well with dark-colored elements or dark-mode.
- `forest` - This theme contains shades of green.
- `base` - This is the only theme that can be modified. Use this theme as the base for customizations.

Closes: #1259