### PR TITLE
Revert "feat: set mermaid theme based on computed color scheme"

### DIFF
--- a/apps/client/src/features/editor/components/code-block/mermaid-view.tsx
+++ b/apps/client/src/features/editor/components/code-block/mermaid-view.tsx
@@ -4,14 +4,10 @@ import mermaid from "mermaid";
 import { v4 as uuidv4 } from "uuid";
 import classes from "./code-block.module.css";
 import { useTranslation } from "react-i18next";
-import { useComputedColorScheme } from "@mantine/core";
-
-const computedColorScheme = useComputedColorScheme();
 
 mermaid.initialize({
   startOnLoad: false,
   suppressErrorRendering: true,
-  theme: computedColorScheme === "light" ? "default" : "dark",
 });
 
 interface MermaidViewProps {


### PR DESCRIPTION
Reverts docmost/docmost#1397.
Leads to: Uncaught Error: Invalid hook call. Hooks can only be called inside of the body of a function component.
Will revisit this again.
