### PR TITLE
fix: local storage copy function

### DIFF
--- a/apps/server/src/integrations/storage/drivers/local.driver.ts
+++ b/apps/server/src/integrations/storage/drivers/local.driver.ts
@@ -40,8 +40,11 @@ export class LocalDriver implements StorageDriver {
 
   async copy(fromFilePath: string, toFilePath: string): Promise<void> {
     try {
+      const fromFullPath = this._fullPath(fromFilePath);
+      const toFullPath = this._fullPath(toFilePath);
+      
       if (await this.exists(fromFilePath)) {
-        await fs.copy(fromFilePath, toFilePath);
+        await fs.copy(fromFullPath, toFullPath);
       }
     } catch (err) {
       throw new Error(`Failed to copy file: ${(err as Error).message}`);


### PR DESCRIPTION
This fixes broken attachment links in copied/duplicated pages for local storage users.