### PR TITLE
fix: enforce C collation for page position ordering to ensure consistent behavior in Postgres 16+

### DIFF
--- a/apps/server/src/core/page/services/page.service.ts
+++ b/apps/server/src/core/page/services/page.service.ts
@@ -110,7 +110,7 @@ export class PageService {
       .select(['position'])
       .where('spaceId', '=', spaceId)
       .where('deletedAt', 'is', null)
-      .orderBy('position', 'desc')
+      .orderBy('position', (ob) => ob.collate('C').desc())
       .limit(1);
 
     if (parentPageId) {
@@ -191,7 +191,7 @@ export class PageService {
         'deletedAt',
       ])
       .select((eb) => this.pageRepo.withHasChildren(eb))
-      .orderBy('position', 'asc')
+      .orderBy('position', (ob) => ob.collate('C').asc())
       .where('deletedAt', 'is', null)
       .where('spaceId', '=', spaceId);
 

--- a/apps/server/src/integrations/import/services/import.service.ts
+++ b/apps/server/src/integrations/import/services/import.service.ts
@@ -178,7 +178,7 @@ export class ImportService {
       .selectFrom('pages')
       .select(['id', 'position'])
       .where('spaceId', '=', spaceId)
-      .orderBy('position', 'desc')
+      .orderBy('position', (ob) => ob.collate('C').desc())
       .limit(1)
       .where('parentPageId', 'is', null)
       .executeTakeFirst();


### PR DESCRIPTION
- Add explicit C collation to position ordering queries to fix incorrect page placement in PostgreSQL 16+
- Ensures consistent ASCII-based ordering regardless of database locale settings
- Fixes issue where new pages were incorrectly placed at random positions instead of at the bottom

i. https://stackoverflow.com/a/68728603/8299075
ii. https://stackoverflow.com/a/77979710/8299075
iii. https://www.postgresql.org/docs/current/collation.html#COLLATION-MANAGING-STANDARD