### PR TITLE
Support cross-page attachment sharing with sharedPageId

### DIFF
--- a/apps/server/src/core/auth/dto/jwt-payload.ts
+++ b/apps/server/src/core/auth/dto/jwt-payload.ts
@@ -29,6 +29,7 @@ export type JwtAttachmentPayload = {
   pageId: string;
   workspaceId: string;
   type: 'attachment';
+  sharedPageId?: string;
 };
 
 export interface JwtMfaTokenPayload {

--- a/apps/server/src/core/auth/services/token.service.ts
+++ b/apps/server/src/core/auth/services/token.service.ts
@@ -66,13 +66,15 @@ export class TokenService {
     attachmentId: string;
     pageId: string;
     workspaceId: string;
+    sharedPageId?: string;
   }): Promise<string> {
-    const { attachmentId, pageId, workspaceId } = opts;
+    const { attachmentId, pageId, workspaceId, sharedPageId } = opts;
     const payload: JwtAttachmentPayload = {
       attachmentId: attachmentId,
       pageId: pageId,
       workspaceId: workspaceId,
       type: JwtType.ATTACHMENT,
+      sharedPageId: sharedPageId,
     };
     return this.jwtService.sign(payload, { expiresIn: '1h' });
   }

--- a/apps/server/src/core/share/share.service.ts
+++ b/apps/server/src/core/share/share.service.ts
@@ -273,6 +273,7 @@ export class ShareService {
           attachmentId,
           pageId: page.id,
           workspaceId: page.workspaceId,
+          sharedPageId: page.id,
         });
         attachmentMap.set(attachmentId, token);
       }),


### PR DESCRIPTION
Adds support for sharing attachments across pages by introducing an optional sharedPageId in the JWT payload. Updates attachment controller validation logic to handle cross-page access, modifies token generation to include sharedPageId, and updates the share service to set this field when generating tokens for shared attachments.

This should fix the issue where copy/pasted images don't work on public (shared) pages.
See issue #1194 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for accessing attachments shared across different pages, with strict checks to ensure workspace and space consistency.
* **Improvements**
  * Enhanced attachment sharing tokens to include optional cross-page access information for more flexible sharing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->