### PR TITLE
feat: implement SSO group sync for SAML and OIDC

### DIFF
--- a/apps/client/src/ee/security/components/sso-oidc-form.tsx
+++ b/apps/client/src/ee/security/components/sso-oidc-form.tsx
@@ -16,6 +16,7 @@ const ssoSchema = z.object({
   oidcClientSecret: z.string().min(1, "Client secret is required"),
   isEnabled: z.boolean(),
   allowSignup: z.boolean(),
+  isGroupSyncEnabled: z.boolean(),
 });
 
 type SSOFormValues = z.infer<typeof ssoSchema>;
@@ -36,6 +37,7 @@ export function SsoOIDCForm({ provider, onClose }: SsoFormProps) {
       oidcClientSecret: provider.oidcClientSecret || "",
       isEnabled: provider.isEnabled,
       allowSignup: provider.allowSignup,
+      isGroupSyncEnabled: provider.isGroupSyncEnabled || false,
     },
     validate: zodResolver(ssoSchema),
   });
@@ -66,6 +68,9 @@ export function SsoOIDCForm({ provider, onClose }: SsoFormProps) {
     }
     if (form.isDirty("allowSignup")) {
       ssoData.allowSignup = values.allowSignup;
+    }
+    if (form.isDirty("isGroupSyncEnabled")) {
+      ssoData.isGroupSyncEnabled = values.isGroupSyncEnabled;
     }
 
     await updateSsoProviderMutation.mutateAsync(ssoData);
@@ -116,6 +121,15 @@ export function SsoOIDCForm({ provider, onClose }: SsoFormProps) {
               className={classes.switch}
               checked={form.values.allowSignup}
               {...form.getInputProps("allowSignup")}
+            />
+          </Group>
+
+          <Group justify="space-between">
+            <div>{t("Group sync")}</div>
+            <Switch
+              className={classes.switch}
+              checked={form.values.isGroupSyncEnabled}
+              {...form.getInputProps("isGroupSyncEnabled")}
             />
           </Group>
 

--- a/apps/client/src/ee/security/components/sso-saml-form.tsx
+++ b/apps/client/src/ee/security/components/sso-saml-form.tsx
@@ -26,6 +26,7 @@ const ssoSchema = z.object({
   samlCertificate: z.string().min(1, "SAML Idp Certificate is required"),
   isEnabled: z.boolean(),
   allowSignup: z.boolean(),
+  isGroupSyncEnabled: z.boolean(),
 });
 
 type SSOFormValues = z.infer<typeof ssoSchema>;
@@ -45,6 +46,7 @@ export function SsoSamlForm({ provider, onClose }: SsoFormProps) {
       samlCertificate: provider.samlCertificate || "",
       isEnabled: provider.isEnabled,
       allowSignup: provider.allowSignup,
+      isGroupSyncEnabled: provider.isGroupSyncEnabled || false,
     },
     validate: zodResolver(ssoSchema),
   });
@@ -74,6 +76,9 @@ export function SsoSamlForm({ provider, onClose }: SsoFormProps) {
     }
     if (form.isDirty("allowSignup")) {
       ssoData.allowSignup = values.allowSignup;
+    }
+    if (form.isDirty("isGroupSyncEnabled")) {
+      ssoData.isGroupSyncEnabled = values.isGroupSyncEnabled;
     }
 
     await updateSsoProviderMutation.mutateAsync(ssoData);
@@ -129,6 +134,15 @@ export function SsoSamlForm({ provider, onClose }: SsoFormProps) {
               className={classes.switch}
               checked={form.values.allowSignup}
               {...form.getInputProps("allowSignup")}
+            />
+          </Group>
+
+          <Group justify="space-between">
+            <div>{t("Group sync")}</div>
+            <Switch
+              className={classes.switch}
+              checked={form.values.isGroupSyncEnabled}
+              {...form.getInputProps("isGroupSyncEnabled")}
             />
           </Group>
 

--- a/apps/client/src/ee/security/types/security.types.ts
+++ b/apps/client/src/ee/security/types/security.types.ts
@@ -11,6 +11,7 @@ export interface IAuthProvider {
   oidcClientSecret: string;
   allowSignup: boolean;
   isEnabled: boolean;
+  isGroupSyncEnabled: boolean;
   creatorId: string;
   workspaceId: string;
   createdAt: Date;

--- a/apps/server/src/database/migrations/20250710T120000-add-group-sync-to-auth-providers.ts
+++ b/apps/server/src/database/migrations/20250710T120000-add-group-sync-to-auth-providers.ts
@@ -1,0 +1,17 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('auth_providers')
+    .addColumn('is_group_sync_enabled', 'boolean', (col) =>
+      col.defaultTo(false).notNull(),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('auth_providers')
+    .dropColumn('is_group_sync_enabled')
+    .execute();
+}

--- a/apps/server/src/database/types/db.d.ts
+++ b/apps/server/src/database/types/db.d.ts
@@ -62,6 +62,7 @@ export interface AuthProviders {
   deletedAt: Timestamp | null;
   id: Generated<string>;
   isEnabled: Generated<boolean>;
+  isGroupSyncEnabled: Generated<boolean>;
   name: string;
   oidcClientId: string | null;
   oidcClientSecret: string | null;
@@ -122,6 +123,7 @@ export interface Comments {
   pageId: string;
   parentCommentId: string | null;
   resolvedAt: Timestamp | null;
+  resolvedById: string | null;
   selection: string | null;
   type: string | null;
   workspaceId: string;


### PR DESCRIPTION
- Add is_group_sync_enabled column to auth_providers table
- Extract groups from SAML attributes (memberOf, groups, roles)
- Extract groups from OIDC claims (groups, roles)
- Implement case-insensitive group matching with auto-creation
- Sync user groups on each SSO login
- Ensure only one provider can have group sync enabled at a time
- Add group sync toggle to SAML and OIDC configuration forms