### PR TITLE
Fix public attachment URL issue

### DIFF
--- a/apps/server/src/core/share/share.util.ts
+++ b/apps/server/src/core/share/share.util.ts
@@ -32,5 +32,5 @@ function updateAttachmentUrl(src: string, jwtToken: string) {
   const updatedSrc = src.replace('/files/', '/files/public/');
   const encodedSrc = encodePathsInUrl(updatedSrc);
   const separator = updatedSrc.includes('?') ? '&' : '?';
-  return `${encodedSrc}${separator}jwt=${jwtToken}`;
+  return `${encodedSrc}${separator}jwt=${encodeURIComponents(jwtToken)}`;
 }


### PR DESCRIPTION
When there's a '#' in the file name, the public attachment url will be incorrectly parsed by the browser.

This PR fixes this problem by encoding URI components in URL paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL encoding for file paths to ensure proper handling of special characters in URLs.
  * Enhanced URL processing to preserve query parameters while encoding path segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->