### PR TITLE
feat: Add Markdown Endpoint for easier AI Retrieval

### DIFF
--- a/apps/server/src/integrations/export/export.service.ts
+++ b/apps/server/src/integrations/export/export.service.ts
@@ -89,6 +89,18 @@ export class ExportService {
     return;
   }
 
+  async exportPageAsMarkdown(pageId: string): Promise<string> {
+    const page = await this.pageRepo.findById(pageId, {
+      includeContent: true,
+    });
+
+    if (!page) {
+      throw new NotFoundException('Page not found');
+    }
+
+    return this.exportPage(ExportFormat.Markdown, page, true);
+  }
+
   async exportPages(
     pageId: string,
     format: string,


### PR DESCRIPTION
Adds an Endpoint to direktly get the Markdown Format as content and not as ZIP.

Resolves #1463 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an authenticated API endpoint to export a single page as Markdown.
  - Returns Markdown as plain text for easy download or integration with external tools.
  - Provides clear responses: 404 if the page doesn’t exist, 403 if access is denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->