### PR TITLE
Fixing extra page bug on print

### DIFF
--- a/apps/client/src/features/editor/styles/print.css
+++ b/apps/client/src/features/editor/styles/print.css
@@ -7,5 +7,6 @@
 
     .mantine-AppShell-main {
         padding-top: 0 !important;
+        min-height: auto !important;
     }
 }


### PR DESCRIPTION
This issue fixes #1464

The extra blank page was caused by Mantine’s <AppShell.Main> applying min-height: 100vh in print mode. In Chrome, 100vh maps to the full page box (~1056px) while the printable area is slightly smaller (~982px), which forced an overflow onto a second empty page.

 I added min-height: auto to the existing class in 'print.css, so the container shrink-wraps to its content. This removes the phantom page without affecting normal screen layout.

https://github.com/user-attachments/assets/61b0798a-51f2-4028-94f2-d8107389f9ff
