### PR TITLE
fix: handle empty replace term in search and replace functionality

### DIFF
--- a/packages/editor-ext/src/lib/search-and-replace/search-and-replace.ts
+++ b/packages/editor-ext/src/lib/search-and-replace/search-and-replace.ts
@@ -195,9 +195,13 @@ const replace = (
     
     const marks = Array.from(marksSet);
     
-    // Delete the old text and insert new text with preserved marks
+    // Delete the old text
     tr.delete(from, to);
-    tr.insert(from, state.schema.text(replaceTerm, marks));
+
+    // Only insert new text if replaceTerm is not empty (allows for deletion when replaceTerm is empty)
+    if (replaceTerm) {
+      tr.insert(from, state.schema.text(replaceTerm, marks));
+    }
     
     dispatch(tr);
   }
@@ -226,9 +230,13 @@ const replaceAll = (
     
     const marks = Array.from(marksSet);
     
-    // Delete and insert with preserved marks
+    // Delete the old text
     tr.delete(from, to);
-    tr.insert(from, tr.doc.type.schema.text(replaceTerm, marks));
+
+    // Only insert new text if replaceTerm is not empty (allows for deletion when replaceTerm is empty)
+    if (replaceTerm) {
+      tr.insert(from, tr.doc.type.schema.text(replaceTerm, marks));
+    }
   }
 
   dispatch(tr);


### PR DESCRIPTION
Fix #1537 

- Fix 'Empty text nodes are not allowed' error when replace field is empty
- Allow empty replace term to perform batch deletion of matched text
- Update both replace() and replaceAll() functions to check for empty replaceTerm