### PR TITLE
fix: sanitize page titles in export utils

### DIFF
--- a/apps/server/src/integrations/export/utils.ts
+++ b/apps/server/src/integrations/export/utils.ts
@@ -5,6 +5,7 @@ import { validate as isValidUUID } from 'uuid';
 import * as path from 'path';
 import { Page } from '@docmost/db/types/entity.types';
 import { isAttachmentNode } from '../../common/helpers/prosemirror/utils';
+import { sanitizeFileName } from '../../common/helpers';
 
 export type PageExportTree = Record<string, Page[]>;
 
@@ -23,7 +24,7 @@ export function getExportExtension(format: string) {
 }
 
 export function getPageTitle(title: string) {
-  return title ? title : 'untitled';
+  return title ? sanitizeFileName(title) : 'untitled';
 }
 
 export function updateAttachmentUrlsToLocalPaths(prosemirrorJson: any) {


### PR DESCRIPTION
Fix #1552 

Replaces raw page titles with sanitized versions using the sanitizeFileName helper in getPageTitle to ensure safe filenames during export.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exported file names are now automatically sanitized to remove or replace invalid characters, improving compatibility across operating systems and file storage services.
  * Reduces failures when downloading, syncing, or sharing exports due to problematic characters in titles.
  * Exports for pages without titles continue to use “untitled,” ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->