### PR TITLE
Added database migration for search feature and function change

### DIFF
--- a/apps/server/src/database/migrations/20250914T-add-simple-tsvector.ts
+++ b/apps/server/src/database/migrations/20250914T-add-simple-tsvector.ts
@@ -1,0 +1,31 @@
+import { type Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // Add a new column for the simple tsvector
+  await sql`ALTER TABLE pages ADD COLUMN IF NOT EXISTS tsv_simple tsvector`.execute(db);
+
+  // Create trigger function for simple config
+  await sql`
+    CREATE OR REPLACE FUNCTION pages_tsvector_simple_trigger() RETURNS trigger AS $$
+    begin
+        new.tsv_simple :=
+                  setweight(to_tsvector('simple', f_unaccent(coalesce(new.title, ''))), 'A') ||
+                  setweight(to_tsvector('simple', f_unaccent(substring(coalesce(new.text_content, ''), 1, 1000000))), 'B');
+        return new;
+    end;
+    $$ LANGUAGE plpgsql;
+  `.execute(db);
+
+  // Attach trigger to run before insert/update
+  await sql`
+    CREATE TRIGGER tsvectorupdate_simple
+    BEFORE INSERT OR UPDATE ON pages
+    FOR EACH ROW EXECUTE FUNCTION pages_tsvector_simple_trigger();
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`DROP TRIGGER IF EXISTS tsvectorupdate_simple ON pages`.execute(db);
+  await sql`DROP FUNCTION IF EXISTS pages_tsvector_simple_trigger()`.execute(db);
+  await sql`ALTER TABLE pages DROP COLUMN IF EXISTS tsv_simple`.execute(db);
+}


### PR DESCRIPTION
This issue fixes 'Search - not always working when search word is the last in the sentence #1382' where if you search for a stopword like "up" or "down" nothing comes up. 

The current search function has this limitation because it uses the 'english' configuration for tsv queries, where stop words are not included, this makes the querying faster, which is why I assume it was built this way. 

How i fixed it:

-I created a new database migration for the pages table to add a field called tsv-simple. This field is similar to the tsv field except it includes stopwords in its full text search with the 'simple' configuration instead of the 'english' one. 

-In the searchPage function, where the search endpoint is hit in the backend, I only run the fallback simple search query if the original query fails(the one that uses the 'english' configuration). 

So this implementation shouldn't reduce performance at all, the tsv-simple field is only scanned if the original one comes up empty. 

I will attach a photo of how this looks. I understand, configurations like this can be complex, so if @Philipinho wants another implementation I will understand. But I think this type of issue should be fixed because applications like Notion let you search for all types of words, including stop words.