### PR TITLE
Removed line that caused the bug

### DIFF
--- a/apps/client/src/features/editor/components/bubble-menu/color-selector.tsx
+++ b/apps/client/src/features/editor/components/bubble-menu/color-selector.tsx
@@ -156,11 +156,7 @@ export const ColorSelector: FC<ColorSelectorProps> = ({
                   )
                 }
                 onClick={() => {
-                  if (name === "Default") {
-                    editor.commands.unsetColor();
-                  } else {
-                    editor.chain().focus().setColor(color || "").run();
-                  }
+                  editor.chain().focus().setColor(color || "").run();
                   setIsOpen(false);
                 }}
                 style={{ border: "none" }}


### PR DESCRIPTION
FIxes #1526

The original code made every cell default when you change the color of only one cell to be default. I agree with the guy who created the ticket and I feel like this makes no sense because every cell should only control the color of one specific cell, so I fixed the code to get rid of that statement.