### PR TITLE
fix: fix .env file not loaded in docmost container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       APP_SECRET: 'REPLACE_WITH_LONG_SECRET'
       DATABASE_URL: 'postgresql://docmost:STRONG_DB_PASSWORD@db:5432/docmost?schema=public'
       REDIS_URL: 'redis://redis:6379'
+    env_file: ".env"
     ports:
       - "3000:3000"
     restart: unless-stopped


### PR DESCRIPTION
I'm using Coolify to use docmost and environment variables are not loaded into docmost container (all other env variables that aren't in the docker-compose file, including mail configuration). This PR just adds the loading of the `.env` file contained in the `docker-compose.yml` directory.

Close #1566
