### PR TITLE
fix: preserve code block language attribute during server-side Markdown import

### DIFF
--- a/packages/editor-ext/src/lib/custom-code-block.ts
+++ b/packages/editor-ext/src/lib/custom-code-block.ts
@@ -20,6 +20,30 @@ export const CustomCodeBlock = CodeBlockLowlight.extend<CustomCodeBlockOptions>(
       };
     },
 
+    addAttributes() {
+      const parentAttrs = this.parent?.() || {};
+      const parentLanguage = (parentAttrs as any).language || {};
+
+      return {
+        ...parentAttrs,
+        language: {
+          ...parentLanguage,
+          parseHTML: (element) => {
+            // Fix for happy-dom compatibility: extract language from class attribute
+            // instead of using classList which may not work correctly in Node.js environment
+            const codeElement = element.firstElementChild;
+            if (!codeElement) {
+              return null;
+            }
+
+            const className = codeElement.getAttribute("class") || "";
+            const match = className.match(/language-(\S+)/);
+            return match ? match[1] : null;
+          },
+        },
+      };
+    },
+
     addKeyboardShortcuts() {
       return {
         ...this.parent?.(),


### PR DESCRIPTION
Fixes #1668 
## Problem

  Code blocks imported from Markdown files lose their language attributes, resulting in `language: null` in the database. This breaks:
  - Mermaid diagram rendering
  - Syntax highlighting for all code blocks

  ## Root Cause

  The parent `CodeBlockLowlight` extension uses `[...(element.firstElementChild?.classList || [])]` to extract language from HTML class names. This approach fails in
  happy-dom (server-side DOM parser) because the spread operator on `classList` doesn't work correctly in Node.js environment.

  **Import pipeline**: Markdown → marked.js → HTML → happy-dom → TipTap parseHTML → Database

  ## Solution

  Override `parseHTML` in `CustomCodeBlock` to use `getAttribute('class')` with regex matching instead of `classList`:

  ```typescript
  const className = codeElement.getAttribute("class") || "";
  const match = className.match(/language-(\S+)/);
  return match ? match[1] : null;
  ```
  Testing

Before Fix
All code blocks have language: null in database
<img width="628" height="368" alt="image" src="https://github.com/user-attachments/assets/fb965a42-01e8-4498-b374-0b27d1110239" />
After Fix
Language attributes correctly preserved (mermaid, sql, javascript, etc.)
<img width="713" height="399" alt="image" src="https://github.com/user-attachments/assets/7afa830a-155d-4d2a-bbd9-c0818c864c36" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code blocks now expose a language attribute to improve detection and rendering of programming languages.
* **Bug Fixes**
  * Resolved inconsistent language recognition in code blocks that could cause missing or incorrect syntax highlighting, especially in server-side/Node environments.
  * Language parsing is now more robustly derived from the code element’s class, improving compatibility across browsers and SSR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->