### PR TITLE
fix: prevent unlicensed user from accessing /security

### DIFF
--- a/apps/client/src/ee/security/pages/security.tsx
+++ b/apps/client/src/ee/security/pages/security.tsx
@@ -19,7 +19,7 @@ export default function Security() {
   const { hasLicenseKey } = useLicense();
   const { isBusiness } = usePlan();
 
-  if (!isAdmin) {
+  if (!isAdmin || !hasLicenseKey) {
     return null;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access control for the Security page to require both admin privileges and a valid license key. Previously, the page was accessible to admins without an active license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->