### PR TITLE
feat: add button to highlight selected text

### DIFF
--- a/apps/client/src/features/editor/components/bubble-menu/bubble-menu.tsx
+++ b/apps/client/src/features/editor/components/bubble-menu/bubble-menu.tsx
@@ -17,7 +17,7 @@ import {
 import clsx from "clsx";
 import classes from "./bubble-menu.module.css";
 import { ActionIcon, rem, Tooltip } from "@mantine/core";
-import { ColorSelector } from "./color-selector";
+import { ColorSelector, HighlightSelector } from "./color-selector";
 import { NodeSelector } from "./node-selector";
 import { TextAlignmentSelector } from "./text-alignment-selector";
 import {
@@ -145,6 +145,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
         setIsNodeSelectorOpen(false);
         setIsTextAlignmentOpen(false);
         setIsColorSelectorOpen(false);
+        setIsHighlightSelectorOpen(false);
         setIsLinkSelectorOpen(false);
       },
     },
@@ -153,6 +154,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
   const [isNodeSelectorOpen, setIsNodeSelectorOpen] = useState(false);
   const [isTextAlignmentSelectorOpen, setIsTextAlignmentOpen] = useState(false);
   const [isColorSelectorOpen, setIsColorSelectorOpen] = useState(false);
+  const [isHighlightSelectorOpen, setIsHighlightSelectorOpen] = useState(false);
   const [isLinkSelectorOpen, setIsLinkSelectorOpen] = useState(false);
 
   return (
@@ -165,6 +167,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
             setIsNodeSelectorOpen(!isNodeSelectorOpen);
             setIsTextAlignmentOpen(false);
             setIsColorSelectorOpen(false);
+            setIsHighlightSelectorOpen(false);
             setIsLinkSelectorOpen(false);
           }}
         />
@@ -176,6 +179,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
             setIsTextAlignmentOpen(!isTextAlignmentSelectorOpen);
             setIsNodeSelectorOpen(false);
             setIsColorSelectorOpen(false);
+            setIsHighlightSelectorOpen(false);
             setIsLinkSelectorOpen(false);
           }}
         />
@@ -207,6 +211,7 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
             setIsNodeSelectorOpen(false);
             setIsTextAlignmentOpen(false);
             setIsColorSelectorOpen(false);
+            setIsHighlightSelectorOpen(false);
           }}
         />
 
@@ -217,6 +222,19 @@ export const EditorBubbleMenu: FC<EditorBubbleMenuProps> = (props) => {
             setIsColorSelectorOpen(!isColorSelectorOpen);
             setIsNodeSelectorOpen(false);
             setIsTextAlignmentOpen(false);
+            setIsHighlightSelectorOpen(false);
+            setIsLinkSelectorOpen(false);
+          }}
+        />
+
+        <HighlightSelector
+          editor={props.editor}
+          isOpen={isHighlightSelectorOpen}
+          setIsOpen={() => {
+            setIsHighlightSelectorOpen(!isHighlightSelectorOpen);
+            setIsNodeSelectorOpen(false);
+            setIsTextAlignmentOpen(false);
+            setIsColorSelectorOpen(false);
             setIsLinkSelectorOpen(false);
           }}
         />

--- a/apps/client/src/features/editor/components/bubble-menu/color-selector.tsx
+++ b/apps/client/src/features/editor/components/bubble-menu/color-selector.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, FC, SetStateAction } from "react";
-import { IconCheck, IconPalette } from "@tabler/icons-react";
+import { IconCheck, IconPalette, IconHighlight } from "@tabler/icons-react";
 import {
   ActionIcon,
   Button,
@@ -121,10 +121,6 @@ export const ColorSelector: FC<ColorSelectorProps> = ({
       TEXT_COLORS.forEach(({ color }) => {
         activeColors[`text_${color}`] = ctx.editor.isActive("textStyle", { color });
       });
-      HIGHLIGHT_COLORS.forEach(({ color }) => {
-        activeColors[`highlight_${color}`] = ctx.editor.isActive("highlight", { color });
-      });
-
       return activeColors;
     },
   });
@@ -135,10 +131,6 @@ export const ColorSelector: FC<ColorSelectorProps> = ({
 
   const activeColorItem = TEXT_COLORS.find(({ color }) =>
     editorState[`text_${color}`]
-  );
-
-  const activeHighlightItem = HIGHLIGHT_COLORS.find(({ color }) =>
-    editorState[`highlight_${color}`]
   );
 
   return (
@@ -185,6 +177,105 @@ export const ColorSelector: FC<ColorSelectorProps> = ({
                     editor.commands.unsetColor();
                   } else {
                     editor.chain().focus().setColor(color || "").run();
+                  }
+                  setIsOpen(false);
+                }}
+                style={{ border: "none" }}
+              >
+                {t(name)}
+              </Button>
+            ))}
+          </Button.Group>
+        </ScrollArea.Autosize>
+      </Popover.Dropdown>
+    </Popover>
+  );
+};
+
+export const HighlightSelector: FC<ColorSelectorProps> = ({
+  editor,
+  isOpen,
+  setIsOpen,
+}) => {
+  const { t } = useTranslation();
+
+  const editorState = useEditorState({
+    editor,
+    selector: ctx => {
+      if (!ctx.editor) {
+        return null;
+      }
+
+      const activeColors: Record<string, boolean> = {};
+      HIGHLIGHT_COLORS.forEach(({ color }) => {
+        activeColors[`highlight_${color}`] = ctx.editor.isActive("highlight", { color });
+      });
+
+      return activeColors;
+    },
+  });
+
+  if (!editor || !editorState) {
+    return null;
+  }
+
+  const activeHighlightItem = HIGHLIGHT_COLORS.find(({ color }) =>
+    editorState[`highlight_${color}`]
+  );
+
+  return (
+    <Popover width={200} opened={isOpen} withArrow>
+      <Popover.Target>
+        <Tooltip label={t("Highlight color")} withArrow>
+          <ActionIcon
+            variant="default"
+            size="lg"
+            radius="0"
+            style={{
+              border: "none",
+              backgroundColor: activeHighlightItem?.color,
+            }}
+            onClick={() => setIsOpen(!isOpen)}
+          >
+            <IconHighlight size={16} stroke={2} />
+          </ActionIcon>
+        </Tooltip>
+      </Popover.Target>
+
+      <Popover.Dropdown>
+        <ScrollArea.Autosize type="scroll" mah="400">
+          <Text span c="dimmed" tt="uppercase" inherit>
+            {t("Highlight")}
+          </Text>
+
+          <Button.Group orientation="vertical">
+            {HIGHLIGHT_COLORS.map(({ name, color }, index) => (
+              <Button
+                key={index}
+                variant="default"
+                leftSection={
+                  <span
+                    style={{
+                      display: "inline-block",
+                      backgroundColor: color || "transparent",
+                      width: rem(16),
+                      height: rem(16),
+                      borderRadius: rem(2),
+                    }}
+                  />
+                }
+                justify="left"
+                fullWidth
+                rightSection={
+                  editorState[`highlight_${color}`] && (
+                    <IconCheck style={{ width: rem(16) }} />
+                  )
+                }
+                onClick={() => {
+                  if (name === "Default") {
+                    editor.commands.unsetHighlight();
+                  } else {
+                    editor.chain().focus().setHighlight({ color: color || "" }).run();
                   }
                   setIsOpen(false);
                 }}


### PR DESCRIPTION
# Summary

This pull request adds a new button in the editor toolbar that allows users to highlight selected text with color.

# Motivation

Many users requested a simple way to emphasize important parts of their notes or documents.
This feature makes it easier to visually organize content, improving readability and focus inside the editor.

# Changes

- Added a Highlight button in the editor toolbar
- Integrated color selection into the existing bubble menu
- Updated related components (bubble-menu.tsx and color-selector.tsx)
- Added styling and event handling to apply highlight color on text selection

# Demo

A short demo video is available here :

https://github.com/user-attachments/assets/a0d89016-1d06-4363-8cd3-e763e224d7a9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added text highlight color selection to the editor's formatting menu, allowing users to apply highlight colors to selected text.
* Highlight selector integrates seamlessly with existing formatting options and automatically closes when switching between other formatting tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->