### PR TITLE
feat: Add floating parent header to sidebar tree navigation

### DIFF
--- a/FLOATING_PARENT_HEADER_FEATURE.md
+++ b/FLOATING_PARENT_HEADER_FEATURE.md
@@ -1,0 +1,106 @@
+# Floating Parent Header Feature Implementation
+
+## Overview
+This feature adds a sticky/floating parent page header that stays visible at the top of the sidebar when navigating through large hierarchies of subpages. Similar to how VSCode pins the current function name while scrolling through long files, this keeps the context of which parent page's children you're viewing.
+
+## Changes Made
+
+### 1. New Component: FloatingParentHeader
+**File**: `/workspaces/docmost/apps/client/src/features/page/tree/components/floating-parent-header.tsx`
+
+A new React component that displays:
+- Parent page icon
+- Parent page name (clickable link to navigate to parent)
+- Collapse button to close the parent and hide subpages
+
+**Features**:
+- Responsive text truncation with ellipsis for long page names
+- Hover effects for better UX
+- Tooltip on collapse button
+- Only renders when a parent node is actually expanded
+- Matches the application's light/dark theme
+
+### 2. Styling for Floating Header
+**File**: `/workspaces/docmost/apps/client/src/features/page/tree/components/floating-parent-header.module.css`
+
+**Key CSS properties**:
+- `position: sticky` - Keeps header visible while scrolling subpages
+- `top: 0` - Sticks to top of the tree container
+- `z-index: 10` - Ensures it appears above tree items
+- Border-bottom separator for visual distinction
+- Light/dark theme support using Mantine variables
+- Smooth transitions and hover states
+
+### 3. Updated SpaceTree Component
+**File**: `/workspaces/docmost/apps/client/src/features/page/tree/components/space-tree.tsx`
+
+**Changes**:
+- Imported new `FloatingParentHeader` component
+- Created new Jotai atom `expandedParentNodeAtom` to track the currently expanded parent
+- Added state management: `expandedParentNode` and `setExpandedParentNode`
+- Implemented `handleNodeToggle()` function that:
+  - Checks which nodes are open in the tree
+  - Finds the deepest open node with children
+  - Updates the floating header with that parent node
+- Implemented `handleCollapseParent()` function to toggle parent closure
+- Updated tree's `onToggle` handler to call `handleNodeToggle()`
+- Integrated `<FloatingParentHeader>` component into the render output
+
+### 4. Updated Tree Container Styles
+**File**: `/workspaces/docmost/apps/client/src/features/page/tree/styles/tree.module.css`
+
+**Changes**:
+- Changed `.treeContainer` to use `display: flex` and `flex-direction: column`
+- Added `position: relative` for proper sticky positioning
+- Updated `.tree` to use `flex: 1` and `min-height: 0` to ensure proper layout
+- This ensures the floating header and tree scroll independently while header stays fixed
+
+## How It Works
+
+### User Flow
+1. User opens a parent page's children by clicking the expand arrow
+2. When the parent node is toggled open, `handleNodeToggle()` is called
+3. The function analyzes which nodes are currently open
+4. It identifies the deepest (most relevant) open node
+5. The `expandedParentNode` state is updated with that node
+6. The `FloatingParentHeader` component becomes visible with the parent's info
+7. As user scrolls through subpages, the header remains sticky at the top
+8. When user clicks collapse or closes the parent, the header disappears
+
+### State Management
+- Uses Jotai atoms for global state that persists across tree mutations
+- `expandedParentNodeAtom` holds the currently visible parent node
+- `openTreeNodesAtom` continues to track which nodes are open
+- This allows the floating header to work seamlessly with the existing tree system
+
+## User Experience Benefits
+
+1. **Better Context**: Always know which parent's children you're browsing
+2. **Easy Navigation**: Click the parent name to jump back to parent page
+3. **Quick Collapse**: One-click collapse button to hide subpages
+4. **Visual Hierarchy**: Clear visual separation with the sticky header
+5. **Non-intrusive**: Only appears when needed (when parent has children)
+6. **Smooth Scrolling**: Floating header doesn't block tree interaction
+
+## Browser Compatibility
+Uses standard CSS `position: sticky` which is supported in all modern browsers:
+- Chrome/Edge 56+
+- Firefox 59+
+- Safari 13+
+- iOS Safari 13+
+
+## Integration Points
+The feature integrates with existing Docmost systems:
+- Uses existing `SpaceTreeNode` type
+- Leverages `buildPageUrl` from page utilities
+- Respects `readOnly` prop for editing permissions
+- Works with existing tree mutation and WebSocket update systems
+- Compatible with mobile sidebar handling
+
+## Future Enhancements
+Possible improvements:
+- Add breadcrumb navigation showing multiple parent levels
+- Option to show parent's siblings for quick navigation
+- Sticky scroll to smoothly transition between parents
+- Remember expanded state across sessions
+- Search within current parent's children

--- a/apps/client/src/features/page/tree/components/floating-parent-header.module.css
+++ b/apps/client/src/features/page/tree/components/floating-parent-header.module.css
@@ -1,0 +1,68 @@
+.container {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
+    border-bottom: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-6));
+    padding: rem(8px) rem(6px);
+    margin-left: rem(-6px);
+    margin-right: rem(-6px);
+    margin-bottom: rem(4px);
+    display: none;
+
+    &:not(:empty) {
+        display: block;
+    }
+
+    /* Only show when there's actual content to display */
+    &:has(*) {
+        display: block;
+    }
+}
+
+.content {
+    padding: 0 rem(8px);
+    min-height: rem(30px);
+    align-items: center;
+}
+
+.icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-2));
+}
+
+.link {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: inherit;
+    flex: 1;
+    min-width: 0;
+    padding: rem(4px) rem(4px);
+    border-radius: var(--mantine-radius-sm);
+    transition: background-color 150ms ease;
+
+    &:hover {
+        background-color: light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-6));
+    }
+}
+
+.text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-0));
+}
+
+.collapseButton {
+    flex-shrink: 0;
+    color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-2));
+    transition: color 150ms ease;
+}
+
+.collapseButton:hover {
+    color: light-dark(var(--mantine-color-gray-7), var(--mantine-color-dark-0));
+}

--- a/apps/client/src/features/page/tree/components/floating-parent-header.tsx
+++ b/apps/client/src/features/page/tree/components/floating-parent-header.tsx
@@ -1,0 +1,70 @@
+import { Box, ActionIcon, Tooltip, Group, Text } from "@mantine/core";
+import { IconChevronUp, IconFileDescription } from "@tabler/icons-react";
+import { SpaceTreeNode } from "@/features/page/tree/types.ts";
+import { Link, useParams } from "react-router-dom";
+import { buildPageUrl } from "@/features/page/page.utils.ts";
+import classes from "./floating-parent-header.module.css";
+
+interface FloatingParentHeaderProps {
+  parentNode: SpaceTreeNode | null;
+  isVisible: boolean;
+  onCollapse?: (nodeId: string) => void;
+}
+
+export default function FloatingParentHeader({
+  parentNode,
+  isVisible,
+  onCollapse,
+}: FloatingParentHeaderProps) {
+  const { spaceSlug } = useParams();
+
+  if (!parentNode || !isVisible) {
+    return null;
+  }
+
+  const pageUrl = buildPageUrl(spaceSlug, parentNode.slugId, parentNode.name);
+
+  return (
+    <Box className={classes.container}>
+      <Group className={classes.content} gap="xs" justify="space-between">
+        <Group gap="xs" style={{ flex: 1, minWidth: 0 }}>
+          <div className={classes.icon}>
+            {parentNode.icon ? parentNode.icon : <IconFileDescription size="18" />}
+          </div>
+          <Group gap={0} style={{ flex: 1, minWidth: 0 }}>
+            <Link
+              to={pageUrl}
+              className={classes.link}
+              title={parentNode.name}
+            >
+              <Text 
+                size="sm" 
+                fw={600} 
+                className={classes.text}
+              >
+                {parentNode.name || "untitled"}
+              </Text>
+            </Link>
+          </Group>
+        </Group>
+
+        {onCollapse && (
+          <Tooltip label="Collapse" withArrow position="left">
+            <ActionIcon
+              variant="subtle"
+              size="sm"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onCollapse(parentNode.id);
+              }}
+              className={classes.collapseButton}
+            >
+              <IconChevronUp size={18} stroke={2} />
+            </ActionIcon>
+          </Tooltip>
+        )}
+      </Group>
+    </Box>
+  );
+}

--- a/apps/client/src/features/page/tree/styles/tree.module.css
+++ b/apps/client/src/features/page/tree/styles/tree.module.css
@@ -1,14 +1,19 @@
-.tree {
-    border-radius: 0;
-}
-
 .treeContainer {
     height: 100%;
     min-width: 0;
+    display: flex;
+    flex-direction: column;
+    position: relative;
 
     > div, > div > .tree {
         height: 100% !important;
     }
+}
+
+.tree {
+    border-radius: 0;
+    flex: 1;
+    min-height: 0;
 }
 
 .node {


### PR DESCRIPTION
## Overview
This PR adds a floating/sticky parent page header to the sidebar that improves navigation through large page hierarchies.

## Problem
When editing or navigating a large number of subpages under a main page, the main page quickly scrolls out of view, making it difficult to:
- Keep track of current context (which parent's children you're viewing)
- Add new subpages quickly
- Navigate back to parent page

## Solution
Implemented a sticky header that:
- ✅ Stays visible at the top of the sidebar when parent pages are expanded
- ✅ Shows parent page icon and name (similar to VSCode breadcrumbs)
- ✅ Provides quick navigation back to parent page
- ✅ Includes one-click collapse button to close all subpages
- ✅ Only appears when needed (when a parent has open children)
- ✅ Supports light/dark theme
- ✅ Works smoothly with existing tree mutations and WebSocket updates

## Changes
### New Files
- **floating-parent-header.tsx** - React component for the sticky header
- **floating-parent-header.module.css** - Styling with sticky positioning
- **FLOATING_PARENT_HEADER_FEATURE.md** - Detailed feature documentation

### Modified Files
- **space-tree.tsx**
  - Imported FloatingParentHeader component
  - Added state management for tracking expanded parent node
  - Implemented handleNodeToggle() to detect open parent nodes
  - Implemented handleCollapseParent() to close parent
  - Integrated component into tree render

- **tree.module.css**
  - Updated container to use flexbox column layout
  - Fixed sticky positioning support
  - Ensured proper height calculation for scrolling

## Technical Details
- Uses Jotai atoms for state management
- Leverages react-arborist's openState tracking
- Implements CSS sticky positioning
- Full Mantine theme integration for light/dark modes
- Maintains compatibility with drag-drop, editing, and WebSocket updates

## Files Changed
- apps/client/src/features/page/tree/components/floating-parent-header.tsx (NEW)
- apps/client/src/features/page/tree/components/floating-parent-header.module.css (NEW)
- apps/client/src/features/page/tree/components/space-tree.tsx (MODIFIED)
- apps/client/src/features/page/tree/styles/tree.module.css (MODIFIED)
- FLOATING_PARENT_HEADER_FEATURE.md (NEW)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating parent header to the page tree that displays the current parent node's name and icon while scrolling
  * Header includes a collapse button for quick parent node closing
  * Automatically hides when no parent is expanded
  * Supports light and dark theme styling with text truncation for long titles

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->