### PR TITLE
fix: toggle content are fully imported (not partially)

### DIFF
--- a/apps/server/src/integrations/import/utils/import-formatter.ts
+++ b/apps/server/src/integrations/import/utils/import-formatter.ts
@@ -175,11 +175,39 @@ export function notionFormatter($: CheerioAPI, $root: Cheerio<any>) {
 
   // toggle blocks
   $root
-    .find('ul.toggle details')
+    .find('details')
     .get()
     .reverse()
     .forEach((det) => {
       const $det = $(det);
+
+      const hasDetailsContent =
+        $det.children('div[data-type="detailsContent"]').length > 0;
+      if (!hasDetailsContent) {
+        let $summary: Cheerio<any> = $det.children('summary').first();
+
+        if (!$summary.length) {
+          $summary = $('<summary>').text('Toggle');
+          $det.prepend($summary);
+        } else {
+          $det.prepend($summary);
+        }
+
+        const $contentWrapper = $('<div>').attr('data-type', 'detailsContent');
+        $det
+          .children()
+          .filter((_, child) => child.tagName?.toLowerCase() !== 'summary')
+          .each((_, child) => {
+            $contentWrapper.append($(child));
+          });
+
+        if ($contentWrapper.children().length === 0) {
+          $contentWrapper.append($('<p>'));
+        }
+
+        $det.append($contentWrapper);
+      }
+
       const $li = $det.closest('li');
       if ($li.length) {
         $li.before($det);
@@ -191,6 +219,7 @@ export function notionFormatter($: CheerioAPI, $root: Cheerio<any>) {
         if (!$ul.children().length) $ul.remove();
       }
     });
+
 
   // bookmarks
   $root


### PR DESCRIPTION
This pull request updates the `notionFormatter` function in `import-formatter.ts` to improve how toggle (details) blocks are handled during import.

**Key Improvements:**

* **Fixes content truncation:** Previously, only the **first element** inside a toggle block was being correctly placed into the content wrapper. I have fixed this logic to ensure **all** subsequent elements/siblings are correctly moved inside the toggle.
* **Expanded scope:** Changed the selector to target all `details` elements (not just those inside `ul.toggle`) for more comprehensive processing.
* **Structure normalization:**
    * Ensures every `details` block has a `summary` element (creating one with the text "Toggle" if missing).
    * Wraps all non-`summary` children in a `div` with `data-type="detailsContent"`, ensuring this wrapper always contains at least one child (an empty paragraph if needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced toggle block import processing from Notion to ensure proper content structure and reliable display of toggle blocks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->