### PR TITLE
Fix PDF print table overflow and missing borders

### DIFF
--- a/apps/client/src/features/editor/styles/print.css
+++ b/apps/client/src/features/editor/styles/print.css
@@ -18,6 +18,26 @@
   }
 
   .tableWrapper {
-    overflow: hidden !important;
+    width: 100% !important;
+    overflow: visible !important;
+  }
+  .tableWrapper table {
+    width: 100% !important;
+    max-width: 100% !important;
+    border-collapse: collapse !important;
+    table-layout: fixed;
+  }
+
+  .tableWrapper col,
+  .tableWrapper th,
+  .tableWrapper td {
+    width: auto !important;
+    min-width: 0 !important;
+    max-width: 100% !important;
+    border: 0.5px solid #000 !important;
+    outline: 0.5px solid #000;
+    outline-offset: -0.5px;
+    word-break: break-word;
+    overflow-wrap: break-word;
   }
 }


### PR DESCRIPTION
## Problem
Tables overflow page width and sometimes lose borders when printing to PDF.

## Solution
Added print-specific CSS using `@media print` to:
- Ensure tables fit within the PDF page
- Enable proper word wrapping
- Render table borders consistently

## Notes
Local UI could not be fully tested due to backend dependency.
Implementation follows the tested CSS provided in the issue discussion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table layout and formatting in print views with enhanced overflow handling and better border styling for table elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->