### PR TITLE
Listen on HOST environment variable

### DIFF
--- a/apps/server/src/collaboration/server/collab-main.ts
+++ b/apps/server/src/collaboration/server/collab-main.ts
@@ -33,8 +33,9 @@ async function bootstrap() {
 
   const port = process.env.COLLAB_PORT || 3001;
   const host = process.env.HOST || '0.0.0.0';
+  const displayHost = host.includes(':') ? `[${host}]` : host;
   await app.listen(port, host, () => {
-    logger.log(`Listening on http://${host}:${port}`);
+    logger.log(`Listening on http://${displayHost}:${port}`);
   });
 }
 

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -99,9 +99,10 @@ async function bootstrap() {
 
   const port = process.env.PORT || 3000;
   const host = process.env.HOST || '0.0.0.0';
+  const displayHost = host.includes(':') ? `[${host}]` : host;
   await app.listen(port, host, () => {
     logger.log(
-      `Listening on http://${host}:${port} / ${process.env.APP_URL}`,
+      `Listening on http://${displayHost}:${port} and ${process.env.APP_URL}`,
     );
   });
 }


### PR DESCRIPTION
Use .env HOST defaulting to 0.0.0.0
Also update the logline to reflect the listen address (not localhost).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Server host is now configurable via the HOST environment variable (defaults to '0.0.0.0'), allowing flexible deployment.
  * Startup logs now reflect the chosen host (including IPv6-friendly formatting) and configured URL.
  * Port behavior remains unchanged (uses existing port configuration/default).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->