### PR TITLE
fix: centralize redis config and add TLS support

### DIFF
--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -17,6 +17,7 @@ import { ImportModule } from './integrations/import/import.module';
 import { SecurityModule } from './integrations/security/security.module';
 import { TelemetryModule } from './integrations/telemetry/telemetry.module';
 import { RedisModule } from '@nestjs-labs/nestjs-ioredis';
+import { RedisConfigModule } from './integrations/redis/redis-config-module';
 import { RedisConfigService } from './integrations/redis/redis-config.service';
 
 const enterpriseModules = [];
@@ -39,7 +40,12 @@ try {
     DatabaseModule,
     EnvironmentModule,
     RedisModule.forRootAsync({
-      useClass: RedisConfigService,
+      imports: [RedisConfigModule],
+      inject: [RedisConfigService],
+      useFactory: (redisConfig: RedisConfigService) => ({
+        readyLog: true,
+        config: redisConfig.getOptions(),
+      }),
     }),
     CollaborationModule,
     WsModule,

--- a/apps/server/src/collaboration/collaboration.gateway.ts
+++ b/apps/server/src/collaboration/collaboration.gateway.ts
@@ -6,25 +6,21 @@ import { PersistenceExtension } from './extensions/persistence.extension';
 import { Injectable } from '@nestjs/common';
 import { Redis } from '@hocuspocus/extension-redis';
 import { EnvironmentService } from '../integrations/environment/environment.service';
-import {
-  createRetryStrategy,
-  parseRedisUrl,
-  RedisConfig,
-} from '../common/helpers';
 import { LoggerExtension } from './extensions/logger.extension';
+import { RedisConfigService } from '../integrations/redis/redis-config.service';
 
 @Injectable()
 export class CollaborationGateway {
   private hocuspocus: Hocuspocus;
-  private redisConfig: RedisConfig;
 
   constructor(
     private authenticationExtension: AuthenticationExtension,
     private persistenceExtension: PersistenceExtension,
     private loggerExtension: LoggerExtension,
     private environmentService: EnvironmentService,
+    private redisConfigService: RedisConfigService,
   ) {
-    this.redisConfig = parseRedisUrl(this.environmentService.getRedisUrl());
+    const redisOptions = this.redisConfigService.getOptions();
 
     this.hocuspocus = HocuspocusServer.configure({
       debounce: 10000,
@@ -38,14 +34,9 @@ export class CollaborationGateway {
           ? []
           : [
               new Redis({
-                host: this.redisConfig.host,
-                port: this.redisConfig.port,
-                options: {
-                  password: this.redisConfig.password,
-                  db: this.redisConfig.db,
-                  family: this.redisConfig.family,
-                  retryStrategy: createRetryStrategy(),
-                },
+                host: redisOptions.host,
+                port: redisOptions.port,
+                options: redisOptions,
               }),
             ]),
       ],

--- a/apps/server/src/collaboration/collaboration.module.ts
+++ b/apps/server/src/collaboration/collaboration.module.ts
@@ -9,9 +9,11 @@ import { WebSocket } from 'ws';
 import { TokenModule } from '../core/auth/token.module';
 import { HistoryListener } from './listeners/history.listener';
 import { LoggerExtension } from './extensions/logger.extension';
+import { RedisConfigModule } from '../integrations/redis/redis-config-module';
 
 @Module({
   providers: [
+    RedisConfigModule,
     CollaborationGateway,
     AuthenticationExtension,
     PersistenceExtension,
@@ -19,7 +21,7 @@ import { LoggerExtension } from './extensions/logger.extension';
     HistoryListener,
   ],
   exports: [CollaborationGateway],
-  imports: [TokenModule],
+  imports: [TokenModule, RedisConfigModule]
 })
 export class CollaborationModule implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(CollaborationModule.name);

--- a/apps/server/src/common/helpers/utils.ts
+++ b/apps/server/src/common/helpers/utils.ts
@@ -23,45 +23,6 @@ export function generateRandomSuffixNumbers(length: number) {
     .substring(2, 2 + length);
 }
 
-export type RedisConfig = {
-  host: string;
-  port: number;
-  db: number;
-  password?: string;
-  family?: number;
-};
-
-export function parseRedisUrl(redisUrl: string): RedisConfig {
-  // format - redis[s]://[[username][:password]@][host][:port][/db-number][?family=4|6]
-  const url = new URL(redisUrl);
-  const { hostname, port, password, pathname, searchParams } = url;
-  const portInt = parseInt(port, 10);
-
-  let db: number = 0;
-  // extract db value if present
-  if (pathname.length > 1) {
-    const value = pathname.slice(1);
-    if (!isNaN(parseInt(value))) {
-      db = parseInt(value, 10);
-    }
-  }
-
-  // extract family from query parameters
-  let family: number | undefined;
-  const familyParam = searchParams.get('family');
-  if (familyParam && !isNaN(parseInt(familyParam))) {
-    family = parseInt(familyParam, 10);
-  }
-
-  return { host: hostname, port: portInt, password, db, family };
-}
-
-export function createRetryStrategy() {
-  return function (times: number): number {
-    return Math.max(Math.min(Math.exp(times), 20000), 3000);
-  };
-}
-
 export function extractDateFromUuid7(uuid7: string) {
   //https://park.is/blog_posts/20240803_extracting_timestamp_from_uuid_v7/
   const parts = uuid7.split('-');

--- a/apps/server/src/integrations/environment/environment.service.ts
+++ b/apps/server/src/integrations/environment/environment.service.ts
@@ -60,6 +60,30 @@ export class EnvironmentService {
     );
   }
 
+  getRedisTlsRejectUnauthorized(): boolean {
+    const value = this.configService.get<string>('REDIS_TLS_REJECT_UNAUTHORIZED', 'true');
+    return value.toLowerCase() === 'true';
+  }
+
+  getRedisTlsServername(): string | undefined {
+    return this.configService.get<string>('REDIS_TLS_SERVERNAME');
+  }
+
+  getRedisEnableTLS(): boolean {
+    const value = this.configService.get<string>('REDIS_ENABLE_TLS');
+    if (value) {
+      return value.toLowerCase() === 'true';
+    }
+
+    const redisUrl = this.getRedisUrl();
+    try {
+      const url = new URL(redisUrl);
+      return url.protocol === 'rediss:';
+    } catch (error) {
+      return false;
+    }
+  }
+
   getJwtTokenExpiresIn(): string {
     return this.configService.get<string>('JWT_TOKEN_EXPIRES_IN', '90d');
   }

--- a/apps/server/src/integrations/health/health.module.ts
+++ b/apps/server/src/integrations/health/health.module.ts
@@ -3,11 +3,12 @@ import { HealthController } from './health.controller';
 import { TerminusModule } from '@nestjs/terminus';
 import { PostgresHealthIndicator } from './postgres.health';
 import { RedisHealthIndicator } from './redis.health';
+import { RedisConfigModule } from '../redis/redis-config-module';
 
 @Global()
 @Module({
   controllers: [HealthController],
   providers: [PostgresHealthIndicator, RedisHealthIndicator],
-  imports: [TerminusModule],
+  imports: [TerminusModule, RedisConfigModule],
 })
 export class HealthModule {}

--- a/apps/server/src/integrations/health/redis.health.ts
+++ b/apps/server/src/integrations/health/redis.health.ts
@@ -3,8 +3,8 @@ import {
   HealthIndicatorService,
 } from '@nestjs/terminus';
 import { Injectable, Logger } from '@nestjs/common';
-import { EnvironmentService } from '../environment/environment.service';
 import { Redis } from 'ioredis';
+import { RedisConfigService } from '../redis/redis-config.service';
 
 @Injectable()
 export class RedisHealthIndicator {
@@ -12,16 +12,16 @@ export class RedisHealthIndicator {
 
   constructor(
     private readonly healthIndicatorService: HealthIndicatorService,
-    private environmentService: EnvironmentService,
+    private redisConfigService: RedisConfigService,
   ) {}
 
   async pingCheck(key: string): Promise<HealthIndicatorResult> {
     const indicator = this.healthIndicatorService.check(key);
 
     try {
-      const redis = new Redis(this.environmentService.getRedisUrl(), {
-        maxRetriesPerRequest: 15,
-      });
+      const config = this.redisConfigService.getOptions();
+      config.maxRetriesPerRequest = 15;
+      const redis = new Redis(config);
 
       await redis.ping();
       redis.disconnect();

--- a/apps/server/src/integrations/redis/redis-config-module.ts
+++ b/apps/server/src/integrations/redis/redis-config-module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { RedisConfigService } from './redis-config.service';
+
+@Module({
+  providers: [RedisConfigService],
+  exports: [RedisConfigService],
+})
+export class RedisConfigModule {}

--- a/apps/server/src/integrations/redis/redis-config.service.ts
+++ b/apps/server/src/integrations/redis/redis-config.service.ts
@@ -1,26 +1,40 @@
 import { Injectable } from '@nestjs/common';
-import {
-  RedisModuleOptions,
-  RedisOptionsFactory,
-} from '@nestjs-labs/nestjs-ioredis';
-import { createRetryStrategy, parseRedisUrl } from '../../common/helpers';
+import { RedisOptions } from 'ioredis';
 import { EnvironmentService } from '../environment/environment.service';
 
+export type RedisFamily = 4 | 6;
+
 @Injectable()
-export class RedisConfigService implements RedisOptionsFactory {
-  constructor(private readonly environmentService: EnvironmentService) {}
-  createRedisOptions(): RedisModuleOptions {
-    const redisConfig = parseRedisUrl(this.environmentService.getRedisUrl());
+export class RedisConfigService {
+  constructor(private readonly env: EnvironmentService) {}
+
+  getOptions(): RedisOptions {
+    const url = new URL(this.env.getRedisUrl());
+
+    const family: RedisFamily = url.searchParams.get('family') === '6' ? 6 : 4;
+
+    const tlsEnabled = this.env.getRedisEnableTLS();
+
     return {
-      readyLog: true,
-      config: {
-        host: redisConfig.host,
-        port: redisConfig.port,
-        password: redisConfig.password,
-        db: redisConfig.db,
-        family: redisConfig.family,
-        retryStrategy: createRetryStrategy(),
-      },
+      host: url.hostname,
+      port: Number(url.port || 6379),
+      password: url.password || undefined,
+      db: url.pathname ? Number(url.pathname.slice(1)) || 0 : 0,
+      family,
+
+      ...(tlsEnabled
+        ? {
+            tls: {
+              servername: this.env.getRedisTlsServername() ?? url.hostname,
+              rejectUnauthorized: this.env.getRedisTlsRejectUnauthorized(),
+            },
+          }
+        : {}),
+
+      enableReadyCheck: false,
+      maxRetriesPerRequest: null,
+      connectTimeout: 10_000,
+      retryStrategy: (times) => Math.min(times * 100, 3000),
     };
   }
 }

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -10,6 +10,7 @@ import { WsRedisIoAdapter } from './ws/adapter/ws-redis.adapter';
 import { InternalLogFilter } from './common/logger/internal-log-filter';
 import fastifyMultipart from '@fastify/multipart';
 import fastifyCookie from '@fastify/cookie';
+import { RedisConfigService } from './integrations/redis/redis-config.service';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -33,7 +34,11 @@ async function bootstrap() {
   });
 
   const reflector = app.get(Reflector);
-  const redisIoAdapter = new WsRedisIoAdapter(app);
+
+  const redisIoAdapter = new WsRedisIoAdapter(
+    app.get(RedisConfigService),
+    app
+  );
   await redisIoAdapter.connectToRedis();
 
   app.useWebSocketAdapter(redisIoAdapter);


### PR DESCRIPTION
## What was done
- Introduced `RedisConfigService` providing unified `ioredis` options
- Added TLS support via `REDIS_ENABLE_TLS` or `rediss://` URL
- Reused redis config across:
  - Bull queue
  - WebSocket Redis adapter
  - Collaboration (Hocuspocus)
  - Redis health check
- Removed legacy `parseRedisUrl` and retry helpers

## Why
Fixes incorrect / duplicated Redis configuration and allows proper TLS usage.

## How to test
- Configure `REDIS_URL=rediss://...`
- Optionally set:
  - `REDIS_ENABLE_TLS=true`
  - `REDIS_TLS_REJECT_UNAUTHORIZED`
  - `REDIS_TLS_SERVERNAME`
- Verify:
  - app startup
  - queues
  - websocket collaboration
  - `/health` redis check

## Related issue
Closes https://github.com/docmost/docmost/issues/1681
