### PR TITLE
feat: add IPv6 support via configurable HOST binding

### DIFF
--- a/apps/server/src/collaboration/server/collab-main.ts
+++ b/apps/server/src/collaboration/server/collab-main.ts
@@ -37,7 +37,8 @@ async function bootstrap() {
   const logger = new Logger('CollabServer');
 
   const port = process.env.COLLAB_PORT || 3001;
-  await app.listen(port, '0.0.0.0', () => {
+  const host = process.env.HOST || '0.0.0.0';
+  await app.listen(port, host, () => {
     logger.log(`Listening on http://127.0.0.1:${port}`);
   });
 }

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -104,7 +104,8 @@ async function bootstrap() {
   });
 
   const port = process.env.PORT || 3000;
-  await app.listen(port, '0.0.0.0', () => {
+  const host = process.env.HOST || '0.0.0.0';
+  await app.listen(port, host, () => {
     logger.log(
       `Listening on http://127.0.0.1:${port} / ${process.env.APP_URL}`,
     );


### PR DESCRIPTION
- Adds `HOST` environment variable to configure server bind address
- Defaults to `0.0.0.0`                                                                                                                                       
                                                                                                                                                                                                                   
  ### Usage                                                                                                                                                                                                                                                                                                                                                                                                                            
  | Value | Description |                                                                                                                                                                                          
  |-------|-------------|                                                                                                                                                                                          
  | `0.0.0.0` | All IPv4 interfaces (default) |                                                                                                                                                                    
  | `::` | All IPv6 interfaces (+ IPv4 on most systems via dual-stack) |                                                                                                                                           
  | `127.0.0.1` | Localhost IPv4 only |                                                                                                                                                                            
  | `::1` | Localhost IPv6 only |    