### PR TITLE
fix(editor): disable slash and emoji menus inside code blocks

### DIFF
--- a/apps/client/src/features/editor/extensions/emoji-command.ts
+++ b/apps/client/src/features/editor/extensions/emoji-command.ts
@@ -15,6 +15,14 @@ const Command = Extension.create({
         command: ({ editor, range, props }) => {
           props.command({ editor, range, props });
         },
+        allow: ({ state, range }) => {
+          const $from = state.doc.resolve(range.from);
+          // Disable emoji menu inside code blocks
+          if ($from.parent.type.name === "codeBlock") {
+            return false;
+          }
+          return true;
+        },
       } as Partial<SuggestionOptions>,
     };
   },

--- a/apps/client/src/features/editor/extensions/slash-command.ts
+++ b/apps/client/src/features/editor/extensions/slash-command.ts
@@ -17,6 +17,14 @@ const Command = Extension.create({
         command: ({ editor, range, props }) => {
           props.command({ editor, range, props });
         },
+        allow: ({ state, range }) => {
+          const $from = state.doc.resolve(range.from);
+          // Disable slash menu inside code blocks
+          if ($from.parent.type.name === 'codeBlock') {
+            return false;
+          }
+          return true;
+        },
       } as Partial<SuggestionOptions>,
     };
   },


### PR DESCRIPTION
## Summary

- Disable slash command menu (`/`) when cursor is inside a code block
- Disable emoji menu (`:`) when cursor is inside a code block
- Fixes keyboard navigation being captured by menus in code blocks

## Problem

When typing inside code blocks, characters like `/` (for paths like `/work`) and `:` (for symbols like `:=`) incorrectly trigger the slash command and emoji menus. This:
- Breaks arrow key navigation (up/down keys navigate the menu instead of code)
- Confuses users who are writing actual code

## Solution

Added an `allow` function to both `SlashCommand` and `EmojiCommand` extensions that checks if the cursor is inside a code block using `$from.parent.type.name === 'codeBlock'` and returns `false` to disable the menu.

This follows the same pattern used in:
- The `Mention` extension's `allow` function
- PR #1336 for codeblock keyboard handling

## Test plan

- [x] Create a code block and type `/work` - slash menu does NOT appear
- [x] Type `:=` in code block - emoji menu does NOT appear
- [x] Arrow keys navigate code normally inside code blocks
- [x] Slash and emoji menus still work correctly outside code blocks

Closes #1730