### PR TITLE
fix: reset AppShell padding in print styles for Safari compatibility 

### DIFF
--- a/apps/client/src/features/editor/styles/print.css
+++ b/apps/client/src/features/editor/styles/print.css
@@ -8,7 +8,7 @@
   }
 
   .mantine-AppShell-main {
-    padding-top: 0 !important;
+    padding: 0 !important;
     min-height: auto !important;
   }
 


### PR DESCRIPTION
Fix print layout in Safari where the sidebar was hidden but still occupied horizontal space as a white gap.

Closes https://github.com/docmost/docmost/issues/1501.