### PR TITLE
feat: add persistent block type toolbar in page header

### DIFF
--- a/apps/client/src/features/editor/components/fixed-toolbar/fixed-toolbar.tsx
+++ b/apps/client/src/features/editor/components/fixed-toolbar/fixed-toolbar.tsx
@@ -1,0 +1,43 @@
+import { FC, useState } from "react";
+import { useEditorState } from "@tiptap/react";
+import { useAtomValue } from "jotai";
+import { pageEditorAtom } from "@/features/editor/atoms/editor-atoms";
+import { NodeSelector } from "../bubble-menu/node-selector";
+import { TextAlignmentSelector } from "../bubble-menu/text-alignment-selector";
+
+export const FixedToolbar: FC = () => {
+  const editor = useAtomValue(pageEditorAtom);
+  const [isNodeSelectorOpen, setIsNodeSelectorOpen] = useState(false);
+  const [isTextAlignmentOpen, setIsTextAlignmentOpen] = useState(false);
+
+  const editorIsEditable = useEditorState({
+    editor,
+    selector: (ctx) => ctx.editor?.isEditable ?? false,
+  });
+
+  if (!editor || !editorIsEditable) {
+    return null;
+  }
+
+  return (
+    <>
+      <NodeSelector
+        editor={editor}
+        isOpen={isNodeSelectorOpen}
+        setIsOpen={() => {
+          setIsNodeSelectorOpen(!isNodeSelectorOpen);
+          setIsTextAlignmentOpen(false);
+        }}
+      />
+
+      <TextAlignmentSelector
+        editor={editor}
+        isOpen={isTextAlignmentOpen}
+        setIsOpen={() => {
+          setIsTextAlignmentOpen(!isTextAlignmentOpen);
+          setIsNodeSelectorOpen(false);
+        }}
+      />
+    </>
+  );
+};

--- a/apps/client/src/features/page/components/header/page-header-menu.tsx
+++ b/apps/client/src/features/page/components/header/page-header-menu.tsx
@@ -39,6 +39,7 @@ import { PageStateSegmentedControl } from "@/features/user/components/page-state
 import MovePageModal from "@/features/page/components/move-page-modal.tsx";
 import { useTimeAgo } from "@/hooks/use-time-ago.tsx";
 import ShareModal from "@/features/share/components/share-modal.tsx";
+import { FixedToolbar } from "@/features/editor/components/fixed-toolbar/fixed-toolbar";
 
 interface PageHeaderMenuProps {
   readOnly?: boolean;
@@ -71,6 +72,8 @@ export default function PageHeaderMenu({ readOnly }: PageHeaderMenuProps) {
   return (
     <>
       <ConnectionWarning />
+
+      {!readOnly && <FixedToolbar />}
 
       {!readOnly && <PageStateSegmentedControl size="xs" />}
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                   

- Add a block type selector and text alignment dropdown to the page header bar, positioned next to the Edit/Read toggle
- Allows changing block types (text, headings, lists, blockquote, code) and text alignment **without selecting text first**
- Only visible in edit mode; reuses existing `NodeSelector` and `TextAlignmentSelector` components

## Rationale

Currently, changing a block's type (e.g. paragraph to heading, or text to bullet list) requires either selecting text to trigger the bubble menu, or using the `/` slash command on an empty line. This creates unnecessary friction for a very common editing action.

With this change, the block type and alignment controls are always accessible in the page header, making it faster and more discoverable to transform blocks, especially for users unfamiliar with slash commands.

<img width="1480" height="587" alt="feature" src="https://github.com/user-attachments/assets/81bc3170-4731-4246-aa96-39e40a94be58" />


