### PR TITLE
feat: implement OIDC SSO support

### DIFF
--- a/apps/server/src/core/core.module.ts
+++ b/apps/server/src/core/core.module.ts
@@ -16,6 +16,7 @@ import { GroupModule } from './group/group.module';
 import { CaslModule } from './casl/casl.module';
 import { DomainMiddleware } from '../common/middlewares/domain.middleware';
 import { ShareModule } from './share/share.module';
+import { SsoModule } from './sso/sso.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { ShareModule } from './share/share.module';
     GroupModule,
     CaslModule,
     ShareModule,
+    SsoModule,
   ],
 })
 export class CoreModule implements NestModule {

--- a/apps/server/src/core/sso/dto/sso.dto.ts
+++ b/apps/server/src/core/sso/dto/sso.dto.ts
@@ -1,0 +1,102 @@
+import {
+  IsBoolean,
+  IsIn,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
+
+export class CreateSsoProviderDto {
+  @IsString()
+  @IsIn(['oidc', 'saml', 'google', 'ldap'])
+  type: string;
+
+  @IsString()
+  name: string;
+}
+
+export class UpdateSsoProviderDto {
+  @IsUUID()
+  providerId: string;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  // OIDC fields
+  @IsOptional()
+  @IsString()
+  oidcIssuer?: string;
+
+  @IsOptional()
+  @IsString()
+  oidcClientId?: string;
+
+  @IsOptional()
+  @IsString()
+  oidcClientSecret?: string;
+
+  // SAML fields
+  @IsOptional()
+  @IsString()
+  samlUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  samlCertificate?: string;
+
+  // LDAP fields
+  @IsOptional()
+  @IsString()
+  ldapUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  ldapBindDn?: string;
+
+  @IsOptional()
+  @IsString()
+  ldapBindPassword?: string;
+
+  @IsOptional()
+  @IsString()
+  ldapBaseDn?: string;
+
+  @IsOptional()
+  @IsString()
+  ldapUserSearchFilter?: string;
+
+  @IsOptional()
+  ldapUserAttributes?: any;
+
+  @IsOptional()
+  @IsBoolean()
+  ldapTlsEnabled?: boolean;
+
+  @IsOptional()
+  @IsString()
+  ldapTlsCaCert?: string;
+
+  // Common fields
+  @IsOptional()
+  @IsBoolean()
+  isEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  allowSignup?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  groupSync?: boolean;
+}
+
+export class DeleteSsoProviderDto {
+  @IsUUID()
+  providerId: string;
+}
+
+export class GetSsoProviderDto {
+  @IsUUID()
+  providerId: string;
+}

--- a/apps/server/src/core/sso/services/sso.service.ts
+++ b/apps/server/src/core/sso/services/sso.service.ts
@@ -1,0 +1,226 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthProviderRepo } from '@docmost/db/repos/auth-provider/auth-provider.repo';
+import { AuthAccountRepo } from '@docmost/db/repos/auth-provider/auth-account.repo';
+import { UserRepo } from '@docmost/db/repos/user/user.repo';
+import { TokenService } from '../../auth/services/token.service';
+import { SignupService } from '../../auth/services/signup.service';
+import { EnvironmentService } from '../../../integrations/environment/environment.service';
+import { nanoIdGen } from '../../../common/helpers';
+import {
+  AuthProvider,
+  User,
+  Workspace,
+} from '@docmost/db/types/entity.types';
+import {
+  CreateSsoProviderDto,
+  DeleteSsoProviderDto,
+  GetSsoProviderDto,
+  UpdateSsoProviderDto,
+} from '../dto/sso.dto';
+import { Issuer } from 'openid-client';
+import { IncomingMessage } from 'http';
+
+@Injectable()
+export class SsoService {
+  constructor(
+    private authProviderRepo: AuthProviderRepo,
+    private authAccountRepo: AuthAccountRepo,
+    private userRepo: UserRepo,
+    private tokenService: TokenService,
+    private signupService: SignupService,
+    private environmentService: EnvironmentService,
+  ) {}
+
+  async getProviders(workspaceId: string): Promise<AuthProvider[]> {
+    return this.authProviderRepo.findByWorkspaceId(workspaceId);
+  }
+
+  async getProviderById(dto: GetSsoProviderDto, workspaceId: string) {
+    const provider = await this.authProviderRepo.findById(dto.providerId);
+    if (!provider || provider.workspaceId !== workspaceId) {
+      throw new NotFoundException('SSO provider not found');
+    }
+    return provider;
+  }
+
+  async createProvider(
+    dto: CreateSsoProviderDto,
+    user: User,
+    workspace: Workspace,
+  ): Promise<AuthProvider> {
+    return this.authProviderRepo.insert({
+      type: dto.type,
+      name: dto.name,
+      workspaceId: workspace.id,
+      creatorId: user.id,
+    });
+  }
+
+  async updateProvider(
+    dto: UpdateSsoProviderDto,
+    workspaceId: string,
+  ): Promise<AuthProvider> {
+    const provider = await this.authProviderRepo.findById(dto.providerId);
+    if (!provider || provider.workspaceId !== workspaceId) {
+      throw new NotFoundException('SSO provider not found');
+    }
+
+    const { providerId, ...updateData } = dto;
+
+    return this.authProviderRepo.update(providerId, updateData as any);
+  }
+
+  async deleteProvider(
+    dto: DeleteSsoProviderDto,
+    workspaceId: string,
+  ): Promise<void> {
+    const provider = await this.authProviderRepo.findById(dto.providerId);
+    if (!provider || provider.workspaceId !== workspaceId) {
+      throw new NotFoundException('SSO provider not found');
+    }
+
+    await this.authProviderRepo.delete(dto.providerId, workspaceId);
+  }
+
+  getOidcCallbackUrl(providerId: string): string {
+    return `${this.environmentService.getAppUrl()}/api/sso/oidc/${providerId}/callback`;
+  }
+
+  async getOidcLoginUrl(providerId: string): Promise<string> {
+    const provider = await this.authProviderRepo.findById(providerId);
+    if (
+      !provider ||
+      provider.type !== 'oidc' ||
+      !provider.isEnabled
+    ) {
+      throw new NotFoundException('OIDC provider not found or not enabled');
+    }
+
+    if (!provider.oidcIssuer || !provider.oidcClientId) {
+      throw new BadRequestException('OIDC provider is not properly configured');
+    }
+
+    const issuer = await Issuer.discover(provider.oidcIssuer);
+
+    if (!issuer.metadata.authorization_endpoint) {
+      throw new BadRequestException('OIDC issuer has no authorization endpoint');
+    }
+
+    const redirectUri = this.getOidcCallbackUrl(providerId);
+
+    return (
+      `${issuer.metadata.authorization_endpoint}` +
+      `?response_type=code` +
+      `&client_id=${provider.oidcClientId}` +
+      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      `&scope=openid profile email` +
+      `&state=${providerId}`
+    );
+  }
+
+  async handleOidcCallback(
+    providerId: string,
+    req: IncomingMessage,
+  ): Promise<string> {
+    const provider = await this.authProviderRepo.findById(providerId);
+    if (
+      !provider ||
+      provider.type !== 'oidc' ||
+      !provider.isEnabled
+    ) {
+      throw new UnauthorizedException('OIDC provider not found or not enabled');
+    }
+
+    if (
+      !provider.oidcIssuer ||
+      !provider.oidcClientId ||
+      !provider.oidcClientSecret
+    ) {
+      throw new UnauthorizedException('OIDC provider is not properly configured');
+    }
+
+    const issuer = await Issuer.discover(provider.oidcIssuer);
+    const client = new issuer.Client({
+      client_id: provider.oidcClientId,
+      client_secret: provider.oidcClientSecret,
+    });
+
+    const redirectUri = this.getOidcCallbackUrl(providerId);
+    const params = client.callbackParams(req);
+
+    const tokenSet = await client.callback(redirectUri, params, {
+      state: providerId,
+    });
+
+    const claims = tokenSet.claims();
+    const email = claims.email as string;
+    const name = (claims.name as string) || (claims.preferred_username as string);
+    const providerUserId = claims.sub;
+
+    if (!email) {
+      throw new UnauthorizedException('Email not provided by OIDC provider');
+    }
+
+    // Check if auth account already exists
+    const existingAccount = await this.authAccountRepo.findByProviderUserId(
+      providerUserId,
+      provider.id,
+    );
+
+    if (existingAccount) {
+      const user = await this.userRepo.findById(
+        existingAccount.userId,
+        provider.workspaceId,
+      );
+      if (!user || user.deactivatedAt) {
+        throw new UnauthorizedException('User account is deactivated');
+      }
+      return this.tokenService.generateAccessToken(user);
+    }
+
+    // Find user by email
+    let user = await this.userRepo.findByEmail(email, provider.workspaceId);
+
+    if (user) {
+      // Link the OIDC account to existing user
+      await this.authAccountRepo.upsert({
+        userId: user.id,
+        providerUserId,
+        authProviderId: provider.id,
+        workspaceId: provider.workspaceId,
+      });
+      return this.tokenService.generateAccessToken(user);
+    }
+
+    // JIT provisioning: create user if allowSignup is enabled
+    if (provider.allowSignup) {
+      user = await this.signupService.signup(
+        {
+          email,
+          name: name || email.split('@')[0],
+          password: nanoIdGen() + nanoIdGen(),
+          emailVerifiedAt: new Date(),
+        } as any,
+        provider.workspaceId,
+      );
+
+      await this.authAccountRepo.insert({
+        userId: user.id,
+        providerUserId,
+        authProviderId: provider.id,
+        workspaceId: provider.workspaceId,
+      });
+
+      return this.tokenService.generateAccessToken(user);
+    }
+
+    throw new UnauthorizedException(
+      'No account found for this email. Contact your workspace administrator.',
+    );
+  }
+}

--- a/apps/server/src/core/sso/sso.controller.ts
+++ b/apps/server/src/core/sso/sso.controller.ts
@@ -1,0 +1,133 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { SsoService } from './services/sso.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { AuthUser } from '../../common/decorators/auth-user.decorator';
+import { AuthWorkspace } from '../../common/decorators/auth-workspace.decorator';
+import { User, Workspace } from '@docmost/db/types/entity.types';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { EnvironmentService } from '../../integrations/environment/environment.service';
+import {
+  CreateSsoProviderDto,
+  DeleteSsoProviderDto,
+  GetSsoProviderDto,
+  UpdateSsoProviderDto,
+} from './dto/sso.dto';
+
+@Controller('sso')
+export class SsoController {
+  private readonly logger = new Logger(SsoController.name);
+
+  constructor(
+    private ssoService: SsoService,
+    private environmentService: EnvironmentService,
+  ) {}
+
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @Post('providers')
+  async getProviders(@AuthWorkspace() workspace: Workspace) {
+    const providers = await this.ssoService.getProviders(workspace.id);
+    return { items: providers, limit: providers.length, page: 1 };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @Post('info')
+  async getProviderById(
+    @Body() dto: GetSsoProviderDto,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    return this.ssoService.getProviderById(dto, workspace.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @Post('create')
+  async createProvider(
+    @Body() dto: CreateSsoProviderDto,
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    return this.ssoService.createProvider(dto, user, workspace);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @Post('update')
+  async updateProvider(
+    @Body() dto: UpdateSsoProviderDto,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    return this.ssoService.updateProvider(dto, workspace.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @Post('delete')
+  async deleteProvider(
+    @Body() dto: DeleteSsoProviderDto,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    return this.ssoService.deleteProvider(dto, workspace.id);
+  }
+
+  // OIDC Login: redirects user to OIDC provider
+  @Get('oidc/:providerId/login')
+  @HttpCode(HttpStatus.TEMPORARY_REDIRECT)
+  async oidcLogin(
+    @Param('providerId') providerId: string,
+    @Res() reply: FastifyReply,
+  ) {
+    try {
+      const loginUrl = await this.ssoService.getOidcLoginUrl(providerId);
+      return reply.redirect(loginUrl);
+    } catch (err) {
+      this.logger.error('OIDC login error', err);
+      return reply.redirect(
+        `${this.environmentService.getAppUrl()}/login`,
+      );
+    }
+  }
+
+  // OIDC Callback: handles the OIDC provider response
+  @Get('oidc/:providerId/callback')
+  @HttpCode(HttpStatus.TEMPORARY_REDIRECT)
+  async oidcCallback(
+    @Param('providerId') providerId: string,
+    @Req() req: FastifyRequest,
+    @Res() reply: FastifyReply,
+  ) {
+    const appUrl = this.environmentService.getAppUrl();
+
+    try {
+      const authToken = await this.ssoService.handleOidcCallback(
+        providerId,
+        req.raw,
+      );
+
+      reply.setCookie('authToken', authToken, {
+        httpOnly: true,
+        path: '/',
+        expires: this.environmentService.getCookieExpiresIn(),
+        secure: this.environmentService.isHttps(),
+      });
+
+      return reply.redirect(`${appUrl}/home`);
+    } catch (err) {
+      this.logger.error('OIDC callback error', err);
+      return reply.redirect(`${appUrl}/login?error=oidc_failed`);
+    }
+  }
+}

--- a/apps/server/src/core/sso/sso.module.ts
+++ b/apps/server/src/core/sso/sso.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { SsoController } from './sso.controller';
+import { SsoService } from './services/sso.service';
+import { TokenModule } from '../auth/token.module';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [TokenModule, AuthModule],
+  controllers: [SsoController],
+  providers: [SsoService],
+  exports: [SsoService],
+})
+export class SsoModule {}

--- a/apps/server/src/database/database.module.ts
+++ b/apps/server/src/database/database.module.ts
@@ -25,6 +25,8 @@ import { UserTokenRepo } from './repos/user-token/user-token.repo';
 import { BacklinkRepo } from '@docmost/db/repos/backlink/backlink.repo';
 import { ShareRepo } from '@docmost/db/repos/share/share.repo';
 import { PageListener } from '@docmost/db/listeners/page.listener';
+import { AuthProviderRepo } from '@docmost/db/repos/auth-provider/auth-provider.repo';
+import { AuthAccountRepo } from '@docmost/db/repos/auth-provider/auth-account.repo';
 import { PostgresJSDialect } from 'kysely-postgres-js';
 import * as postgres from 'postgres';
 import { normalizePostgresUrl } from '../common/helpers';
@@ -81,6 +83,8 @@ import { normalizePostgresUrl } from '../common/helpers';
     BacklinkRepo,
     ShareRepo,
     PageListener,
+    AuthProviderRepo,
+    AuthAccountRepo,
   ],
   exports: [
     WorkspaceRepo,
@@ -96,6 +100,8 @@ import { normalizePostgresUrl } from '../common/helpers';
     UserTokenRepo,
     BacklinkRepo,
     ShareRepo,
+    AuthProviderRepo,
+    AuthAccountRepo,
   ],
 })
 export class DatabaseModule

--- a/apps/server/src/database/repos/auth-provider/auth-account.repo.ts
+++ b/apps/server/src/database/repos/auth-provider/auth-account.repo.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { InjectKysely } from 'nestjs-kysely';
+import { KyselyDB, KyselyTransaction } from '@docmost/db/types/kysely.types';
+import { dbOrTx } from '@docmost/db/utils';
+import {
+  AuthAccount,
+  InsertableAuthAccount,
+} from '@docmost/db/types/entity.types';
+
+@Injectable()
+export class AuthAccountRepo {
+  constructor(@InjectKysely() private readonly db: KyselyDB) {}
+
+  async findByProviderUserId(
+    providerUserId: string,
+    authProviderId: string,
+    trx?: KyselyTransaction,
+  ): Promise<AuthAccount> {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .selectFrom('authAccounts')
+      .selectAll()
+      .where('providerUserId', '=', providerUserId)
+      .where('authProviderId', '=', authProviderId)
+      .executeTakeFirst();
+  }
+
+  async findByUserId(
+    userId: string,
+    authProviderId: string,
+    trx?: KyselyTransaction,
+  ): Promise<AuthAccount> {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .selectFrom('authAccounts')
+      .selectAll()
+      .where('userId', '=', userId)
+      .where('authProviderId', '=', authProviderId)
+      .executeTakeFirst();
+  }
+
+  async insert(
+    insertable: InsertableAuthAccount,
+    trx?: KyselyTransaction,
+  ): Promise<AuthAccount> {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .insertInto('authAccounts')
+      .values(insertable)
+      .returningAll()
+      .executeTakeFirst();
+  }
+
+  async upsert(
+    insertable: InsertableAuthAccount,
+    trx?: KyselyTransaction,
+  ): Promise<AuthAccount> {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .insertInto('authAccounts')
+      .values(insertable)
+      .onConflict((oc) =>
+        oc
+          .columns(['userId', 'authProviderId'])
+          .doUpdateSet({ updatedAt: new Date() }),
+      )
+      .returningAll()
+      .executeTakeFirst();
+  }
+}

--- a/apps/server/src/database/repos/auth-provider/auth-provider.repo.ts
+++ b/apps/server/src/database/repos/auth-provider/auth-provider.repo.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@nestjs/common';
+import { InjectKysely } from 'nestjs-kysely';
+import { KyselyDB, KyselyTransaction } from '@docmost/db/types/kysely.types';
+import { dbOrTx } from '@docmost/db/utils';
+import {
+  AuthProvider,
+  InsertableAuthProvider,
+  UpdatableAuthProvider,
+} from '@docmost/db/types/entity.types';
+
+@Injectable()
+export class AuthProviderRepo {
+  constructor(@InjectKysely() private readonly db: KyselyDB) {}
+
+  async findById(
+    providerId: string,
+    trx?: KyselyTransaction,
+  ): Promise<AuthProvider> {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .selectFrom('authProviders')
+      .selectAll()
+      .where('id', '=', providerId)
+      .executeTakeFirst();
+  }
+
+  async findByWorkspaceId(workspaceId: string): Promise<AuthProvider[]> {
+    return this.db
+      .selectFrom('authProviders')
+      .selectAll()
+      .where('workspaceId', '=', workspaceId)
+      .orderBy('createdAt', 'asc')
+      .execute();
+  }
+
+  async findEnabledByWorkspaceId(workspaceId: string): Promise<AuthProvider[]> {
+    return this.db
+      .selectFrom('authProviders')
+      .selectAll()
+      .where('workspaceId', '=', workspaceId)
+      .where('isEnabled', '=', true)
+      .execute();
+  }
+
+  async insert(
+    insertable: InsertableAuthProvider,
+    trx?: KyselyTransaction,
+  ): Promise<AuthProvider> {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .insertInto('authProviders')
+      .values(insertable)
+      .returningAll()
+      .executeTakeFirst();
+  }
+
+  async update(
+    providerId: string,
+    updatable: UpdatableAuthProvider,
+    trx?: KyselyTransaction,
+  ): Promise<AuthProvider> {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .updateTable('authProviders')
+      .set({ ...updatable, updatedAt: new Date() })
+      .where('id', '=', providerId)
+      .returningAll()
+      .executeTakeFirst();
+  }
+
+  async delete(
+    providerId: string,
+    workspaceId: string,
+    trx?: KyselyTransaction,
+  ): Promise<void> {
+    const db = dbOrTx(this.db, trx);
+    await db
+      .deleteFrom('authProviders')
+      .where('id', '=', providerId)
+      .where('workspaceId', '=', workspaceId)
+      .execute();
+  }
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -64,6 +64,7 @@ async function bootstrap() {
         '/api/billing/stripe/webhook',
         '/api/workspace/check-hostname',
         '/api/sso/google',
+        '/api/sso/oidc',
         '/api/workspace/create',
         '/api/workspace/joined',
       ];


### PR DESCRIPTION
Adds OIDC (OpenID Connect) authentication support using the existing auth_providers and auth_accounts database infrastructure. Implements:

- AuthProviderRepo and AuthAccountRepo for database operations on SSO provider configurations and user account links
- SsoService with full auth provider CRUD and OIDC authentication flow including JIT (Just-in-Time) user provisioning when allowSignup is enabled
- SsoController exposing management endpoints (providers, create, update, delete, info) and OIDC flow endpoints (login redirect, callback handler)
- SsoModule registered in CoreModule
- OIDC callback routes excluded from workspace requirement in main.ts

The OIDC flow: user clicks SSO button → redirected to OIDC provider → provider redirects to callback URL → token exchanged → user logged in via httpOnly cookie. Existing users are linked by email; new users are provisioned when allowSignup is enabled on the provider.

https://claude.ai/code/session_01F7WU8YwRUEhuLiGfrZofAj