### PR TITLE
fix: decode percent-encoded password in parseRedisUrl

### DIFF
--- a/apps/server/src/common/helpers/utils.ts
+++ b/apps/server/src/common/helpers/utils.ts
@@ -54,7 +54,10 @@ export function parseRedisUrl(redisUrl: string): RedisConfig {
     family = parseInt(familyParam, 10);
   }
 
-  return { host: hostname, port: portInt, password, db, family };
+  // URL.password returns percent-encoded values (e.g. '=' → '%3D'), decode before use
+  const decodedPassword = password ? decodeURIComponent(password) : password;
+
+  return { host: hostname, port: portInt, password: decodedPassword, db, family };
 }
 
 export function createRetryStrategy() {


### PR DESCRIPTION
## Problem

`parseRedisUrl()` returns the password from `new URL().password` without decoding it. The [WHATWG URL spec](https://url.spec.whatwg.org/#concept-url-serializer) mandates that `=` is percent-encoded as `%3D` in the userinfo section.

Cloud Redis providers (Azure Managed Redis, AWS ElastiCache, etc.) use base64 access keys that end with `=`. When these keys are placed in a `redis://` URL, the parser encodes them:

```
redis://:aBjR684eranIt5Ch13YS7aoUFioc4N5CpAzCaJdAF4g=@host:6379
                                                     ^
                                          URL parser encodes this to %3D
```

`url.password` then returns `...4N5CpAzCaJdAF4g%3D`, which ioredis sends verbatim to Redis `AUTH` → `WRONGPASS`.

Verified in Node.js:
```js
const u = new URL('redis://:key=@host:6379');
u.password // => 'key%3D'  (not 'key=')
```

## Fix

Add `decodeURIComponent()` to the parsed password before returning `RedisConfig`. This is safe for passwords that don't contain percent-encoded characters (decoding a string without `%XX` sequences is a no-op).

## Testing

Tested against Azure Managed Redis with a base64 access key ending in `=`. Before fix: `WRONGPASS`. After fix: connects successfully.