### PR TITLE
fix: allow deleting last character in headings

### DIFF
--- a/packages/editor-ext/src/lib/heading/heading.ts
+++ b/packages/editor-ext/src/lib/heading/heading.ts
@@ -20,7 +20,7 @@ export const Heading = TiptapHeading.extend<TiptapHeadingOptions>({
             const { doc } = state;
 
             doc.descendants((node, pos) => {
-              if (node.type.name === "heading" && node.content.size > 0) {
+              if (node.type.name === "heading" && node.content.size > 1) {
                 const deco = Decoration.widget(
                   pos + node.nodeSize - 1,
                   () => {


### PR DESCRIPTION
## Summary

- The copy-link decoration widget (`contentEditable="false"`) injected inside headings prevented browsers from deleting the last remaining character via Backspace or Delete keys
- Fix: only render the widget when the heading has more than one character of content (`node.content.size > 1` instead of `> 0`)

## Test plan

- [ ] Create a heading (e.g. type `# A`)
- [ ] Place cursor after the single character and press Backspace — should delete it
- [ ] Create a heading, place cursor before the single character and press Delete — should delete it
- [ ] Verify the copy-link button still appears on headings with 2+ characters