### PR TITLE
feat(editor): add Alt+Arrow keyboard shortcuts to move blocks up/down

### DIFF
--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -43,6 +43,7 @@ import {
   Highlight,
   UniqueID,
   SharedStorage,
+  MoveBlock,
 } from "@docmost/editor-ext";
 import {
   randomElement,
@@ -216,6 +217,7 @@ export const mainExtensions = [
     },
   }),
   Selection,
+  MoveBlock,
   Attachment.configure({
     view: AttachmentView,
   }),

--- a/packages/editor-ext/src/index.ts
+++ b/packages/editor-ext/src/index.ts
@@ -25,3 +25,4 @@ export * from "./lib/heading/heading";
 export * from "./lib/unique-id";
 export * from "./lib/shared-storage";
 export * from "./lib/recreate-transform";
+export * from "./lib/move-block";

--- a/packages/editor-ext/src/lib/move-block.ts
+++ b/packages/editor-ext/src/lib/move-block.ts
@@ -1,0 +1,115 @@
+import { Extension } from "@tiptap/core";
+import { Fragment } from "@tiptap/pm/model";
+import { TextSelection } from "@tiptap/pm/state";
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    moveBlock: {
+      moveBlockUp: () => ReturnType;
+      moveBlockDown: () => ReturnType;
+    };
+  }
+}
+
+export const MoveBlock = Extension.create({
+  name: "moveBlock",
+
+  addCommands() {
+    return {
+      moveBlockUp:
+        () =>
+        ({ state, dispatch }) => {
+          const { doc, selection, tr } = state;
+          const $from = selection.$from;
+
+          // Find the top-level block containing the selection
+          if ($from.depth < 1) return false;
+
+          const blockIndex = $from.index(0);
+          if (blockIndex === 0) return false; // Already at top
+
+          const currentBlock = doc.child(blockIndex);
+          const prevBlock = doc.child(blockIndex - 1);
+
+          // Calculate positions
+          let pos = 0;
+          for (let i = 0; i < blockIndex - 1; i++) {
+            pos += doc.child(i).nodeSize;
+          }
+          const prevBlockStart = pos;
+          const prevBlockEnd = prevBlockStart + prevBlock.nodeSize;
+          const currentBlockStart = prevBlockEnd;
+          const currentBlockEnd = currentBlockStart + currentBlock.nodeSize;
+
+          if (dispatch) {
+            // Calculate the offset of the selection within the current block
+            const selFromOffset = selection.from - currentBlockStart;
+            const selToOffset = selection.to - currentBlockStart;
+
+            // Replace the range [prevBlockStart, currentBlockEnd] with [currentBlock, prevBlock]
+            const newContent = Fragment.from([currentBlock, prevBlock]);
+            tr.replaceWith(prevBlockStart, currentBlockEnd, newContent);
+
+            // Restore selection at new position (current block is now at prevBlockStart)
+            const newFrom = prevBlockStart + selFromOffset;
+            const newTo = prevBlockStart + selToOffset;
+            tr.setSelection(TextSelection.create(tr.doc, newFrom, newTo));
+
+            dispatch(tr);
+          }
+
+          return true;
+        },
+
+      moveBlockDown:
+        () =>
+        ({ state, dispatch }) => {
+          const { doc, selection, tr } = state;
+          const $from = selection.$from;
+
+          if ($from.depth < 1) return false;
+
+          const blockIndex = $from.index(0);
+          if (blockIndex >= doc.childCount - 1) return false; // Already at bottom
+
+          const currentBlock = doc.child(blockIndex);
+          const nextBlock = doc.child(blockIndex + 1);
+
+          // Calculate positions
+          let pos = 0;
+          for (let i = 0; i < blockIndex; i++) {
+            pos += doc.child(i).nodeSize;
+          }
+          const currentBlockStart = pos;
+          const currentBlockEnd = currentBlockStart + currentBlock.nodeSize;
+          const nextBlockEnd = currentBlockEnd + nextBlock.nodeSize;
+
+          if (dispatch) {
+            const selFromOffset = selection.from - currentBlockStart;
+            const selToOffset = selection.to - currentBlockStart;
+
+            // Replace [currentBlockStart, nextBlockEnd] with [nextBlock, currentBlock]
+            const newContent = Fragment.from([nextBlock, currentBlock]);
+            tr.replaceWith(currentBlockStart, nextBlockEnd, newContent);
+
+            // Current block is now after nextBlock
+            const newBlockStart = currentBlockStart + nextBlock.nodeSize;
+            const newFrom = newBlockStart + selFromOffset;
+            const newTo = newBlockStart + selToOffset;
+            tr.setSelection(TextSelection.create(tr.doc, newFrom, newTo));
+
+            dispatch(tr);
+          }
+
+          return true;
+        },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      "Alt-ArrowUp": () => this.editor.commands.moveBlockUp(),
+      "Alt-ArrowDown": () => this.editor.commands.moveBlockDown(),
+    };
+  },
+});


### PR DESCRIPTION
## Summary

Adds a `MoveBlock` Tiptap extension that lets users reorder top-level blocks using keyboard shortcuts:

- **Alt+ArrowUp** — move the current block up
- **Alt+ArrowDown** — move the current block down

The cursor selection is preserved at its new position after the move. This follows the same convention used by VS Code and other editors.

## Demo

![Move block shortcuts demo](https://github.com/BowTiedRaccoon/docmost/releases/download/demo-assets/moveblock_demo.gif)

## Changes

- `packages/editor-ext/src/lib/move-block.ts` — new Tiptap extension using ProseMirror transactions (`Fragment`, `TextSelection`, `replaceWith`)
- `packages/editor-ext/src/index.ts` — export the new extension
- `apps/client/src/features/editor/extensions/extensions.ts` — register `MoveBlock` in `mainExtensions`

## Test plan

- [x] Place cursor in a paragraph, press Alt+ArrowUp — block moves up
- [x] Press Alt+ArrowDown — block moves back down
- [x] Works with headings, lists, code blocks, and other top-level nodes
- [x] First block ignores Alt+ArrowUp, last block ignores Alt+ArrowDown
- [x] Text selection is preserved after the move
- [x] Undo (Ctrl+Z) reverses the move

🤖 Generated with [Claude Code](https://claude.ai/claude-code)