### PR TITLE
Add landing page functionality to workspace settings

### DIFF
--- a/apps/client/src/features/page/services/page-service.ts
+++ b/apps/client/src/features/page/services/page-service.ts
@@ -101,8 +101,9 @@ export async function getPageBreadcrumbs(
 
 export async function getRecentChanges(
   spaceId?: string,
+  params?: QueryParams,
 ): Promise<IPagination<IPage>> {
-  const req = await api.post("/pages/recent", { spaceId });
+  const req = await api.post("/pages/recent", { spaceId, ...(params ?? {}) });
   return req.data;
 }
 

--- a/apps/client/src/features/search/types/search.types.ts
+++ b/apps/client/src/features/search/types/search.types.ts
@@ -36,6 +36,8 @@ export interface IPageSearchParams {
   query: string;
   spaceId?: string;
   shareId?: string;
+  limit?: number;
+  offset?: number;
 }
 
 export interface IAttachmentSearch {

--- a/apps/client/src/features/workspace/components/settings/components/workspace-landing-page-form.tsx
+++ b/apps/client/src/features/workspace/components/settings/components/workspace-landing-page-form.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useState } from "react";
+import { useAtom } from "jotai";
+import { Button, Select, Text } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
+import { useDebouncedValue } from "@mantine/hooks";
+import { useTranslation } from "react-i18next";
+import { workspaceAtom } from "@/features/user/atoms/current-user-atom.ts";
+import useUserRole from "@/hooks/use-user-role.tsx";
+import { searchSuggestions } from "@/features/search/services/search-service.ts";
+import { updateWorkspace } from "@/features/workspace/services/workspace-service.ts";
+import { usePageQuery } from "@/features/page/queries/page-query.ts";
+import { getRecentChanges } from "@/features/page/services/page-service.ts";
+
+type LandingPageSelectItem = {
+  value: string;
+  label: string;
+  pageId: string;
+  spaceName?: string;
+};
+
+export default function WorkspaceLandingPageForm() {
+  const { t } = useTranslation();
+  const [workspace, setWorkspace] = useAtom(workspaceAtom);
+  const { isAdmin } = useUserRole();
+
+  const [value, setValue] = useState<string | null>(workspace?.landingPageId ?? null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedQuery] = useDebouncedValue(searchQuery, 250);
+  const [options, setOptions] = useState<any[]>([]);
+  const [recentOptions, setRecentOptions] = useState<any[]>([]);
+  const [selectedOption, setSelectedOption] = useState<LandingPageSelectItem | null>(
+    null,
+  );
+
+  const landingPageId = workspace?.landingPageId ?? null;
+  const { data: landingPage } = usePageQuery({
+    pageId: landingPageId ?? undefined,
+  });
+
+  useEffect(() => {
+    setValue(workspace?.landingPageId ?? null);
+  }, [workspace?.landingPageId]);
+
+  useEffect(() => {
+    if (landingPage && landingPage.id) {
+      setSelectedOption({
+        value: landingPage.id,
+        pageId: landingPage.id,
+        label: `${landingPage.icon || ""} ${landingPage.title || t("untitled")}`.trim(),
+        spaceName: landingPage.space?.name,
+      });
+    } else if (!landingPageId) {
+      setSelectedOption(null);
+    }
+  }, [landingPageId, landingPage, t]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      const q = debouncedQuery.trim();
+      if (q.length < 1) {
+        setOptions([]);
+        return;
+      }
+      try {
+        const results = await searchSuggestions({
+          query: q,
+          includePages: true,
+          limit: 15,
+        });
+        if (!cancelled) setOptions(results?.pages || []);
+      } catch {
+        if (!cancelled) setOptions([]);
+      }
+    }
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedQuery]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      try {
+        const recent = await getRecentChanges(undefined, { page: 1, limit: 10 });
+        if (!cancelled) setRecentOptions(recent?.items ?? []);
+      } catch {
+        if (!cancelled) setRecentOptions([]);
+      }
+    }
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const { data, itemsByValue } = useMemo(() => {
+    const showRecent = searchQuery.trim().length === 0;
+    const raw = showRecent
+      ? Array.isArray(recentOptions)
+        ? recentOptions
+        : []
+      : Array.isArray(options)
+        ? options
+        : [];
+
+    const items: LandingPageSelectItem[] = raw.map((p) => ({
+      value: p.id,
+      pageId: p.id,
+      label: `${p.icon || ""} ${p.title || t("untitled")}`.trim(),
+      spaceName: p.space?.name,
+    }));
+
+    if (selectedOption && !items.find((i) => i.value === selectedOption.value)) {
+      items.unshift(selectedOption);
+    }
+
+    const groupedData = showRecent
+      ? [
+          {
+            group: t("Recent pages"),
+            items: items.map(({ value, label, spaceName }) => ({
+              value,
+              label: spaceName ? `${label} — ${spaceName}` : label,
+            })),
+          },
+        ]
+      : (() => {
+          const grouped = new Map<string, LandingPageSelectItem[]>();
+          for (const item of items) {
+            const groupName = item.spaceName || t("Unknown space");
+            const bucket = grouped.get(groupName) ?? [];
+            bucket.push(item);
+            grouped.set(groupName, bucket);
+          }
+          return Array.from(grouped.entries()).map(([group, groupItems]) => ({
+            group,
+            items: groupItems.map(({ value, label }) => ({ value, label })),
+          }));
+        })();
+
+    const byValue = new Map<string, LandingPageSelectItem>();
+    for (const item of items) byValue.set(item.value, item);
+
+    return { data: groupedData, itemsByValue: byValue };
+  }, [options, recentOptions, searchQuery, selectedOption, t]);
+
+  async function handleSave() {
+    setIsLoading(true);
+    try {
+      const updated = await updateWorkspace({ landingPageId: value || null });
+      setWorkspace(updated);
+      notifications.show({ message: t("Updated successfully") });
+    } catch (err) {
+      console.log(err);
+      notifications.show({ message: t("Failed to update data"), color: "red" });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  const isDirty = (workspace?.landingPageId ?? null) !== value;
+
+  const nothingFoundMessage =
+    searchQuery.trim().length === 0 ? t("Type to search pages...") : t("No results found...");
+
+  return (
+    <div style={{ marginTop: 24 }}>
+      <Text size="sm" fw={500} mb="xs">
+        {t("Landing page")}
+      </Text>
+      <Select
+        placeholder={t("Optional")}
+        searchable
+        clearable
+        nothingFoundMessage={nothingFoundMessage}
+        variant="filled"
+        value={value}
+        onChange={(next) => {
+          setValue(next);
+          if (!next) {
+            setSelectedOption(null);
+            return;
+          }
+          const found = itemsByValue.get(next);
+          if (found) setSelectedOption(found);
+        }}
+        onSearchChange={setSearchQuery}
+        data={data}
+        disabled={!isAdmin}
+        description={t(
+          "If set, members will be redirected here when opening the workspace.",
+        )}
+      />
+
+      {isAdmin && (
+        <Button
+          mt="sm"
+          type="button"
+          disabled={isLoading || !isDirty}
+          loading={isLoading}
+          onClick={handleSave}
+        >
+          {t("Save")}
+        </Button>
+      )}
+    </div>
+  );
+}
+

--- a/apps/client/src/features/workspace/types/workspace.types.ts
+++ b/apps/client/src/features/workspace/types/workspace.types.ts
@@ -7,6 +7,7 @@ export interface IWorkspace {
   logo: string;
   hostname: string;
   defaultSpaceId: string;
+  landingPageId?: string | null;
   customDomain: string;
   enableInvite: boolean;
   settings: IWorkspaceSettings;

--- a/apps/client/src/pages/dashboard/home.tsx
+++ b/apps/client/src/pages/dashboard/home.tsx
@@ -4,9 +4,35 @@ import SpaceGrid from "@/features/space/components/space-grid.tsx";
 import { getAppName } from "@/lib/config.ts";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
+import { useAtom } from "jotai";
+import { workspaceAtom } from "@/features/user/atoms/current-user-atom.ts";
+import { useEffect } from "react";
+import { usePageQuery } from "@/features/page/queries/page-query.ts";
+import { buildPageUrl } from "@/features/page/page.utils.ts";
+import { useNavigate } from "react-router-dom";
 
 export default function Home() {
   const { t } = useTranslation();
+  const [workspace] = useAtom(workspaceAtom);
+  const navigate = useNavigate();
+
+  const landingPageId = workspace?.landingPageId ?? null;
+  const { data: landingPage, isLoading: landingIsLoading } = usePageQuery(
+    { pageId: landingPageId ?? undefined },
+  );
+
+  useEffect(() => {
+    if (landingPage && landingPage.space?.slug) {
+      navigate(
+        buildPageUrl(landingPage.space.slug, landingPage.slugId, landingPage.title),
+        { replace: true },
+      );
+    }
+  }, [landingPage, navigate]);
+
+  if (landingPageId && landingIsLoading) {
+    return <></>;
+  }
 
   return (
     <>

--- a/apps/client/src/pages/settings/workspace/workspace-settings.tsx
+++ b/apps/client/src/pages/settings/workspace/workspace-settings.tsx
@@ -1,6 +1,7 @@
 import SettingsTitle from "@/components/settings/settings-title.tsx";
 import WorkspaceNameForm from "@/features/workspace/components/settings/components/workspace-name-form";
 import WorkspaceIcon from "@/features/workspace/components/settings/components/workspace-icon.tsx";
+import WorkspaceLandingPageForm from "@/features/workspace/components/settings/components/workspace-landing-page-form.tsx";
 import { useTranslation } from "react-i18next";
 import { getAppName, isCloud } from "@/lib/config.ts";
 import { Helmet } from "react-helmet-async";
@@ -17,6 +18,7 @@ export default function WorkspaceSettings() {
       <SettingsTitle title={t("General")} />
       <WorkspaceIcon />
       <WorkspaceNameForm />
+      <WorkspaceLandingPageForm />
 
       {isCloud() && (
         <>

--- a/apps/server/src/core/search/search.service.ts
+++ b/apps/server/src/core/search/search.service.ts
@@ -198,6 +198,7 @@ export class SearchService {
       let pageSearch = this.db
         .selectFrom('pages')
         .select(['id', 'slugId', 'title', 'icon', 'spaceId'])
+        .select((eb) => this.pageRepo.withSpace(eb))
         .where((eb) =>
           eb(
             sql`LOWER(f_unaccent(pages.title))`,

--- a/apps/server/src/core/workspace/dto/update-workspace.dto.ts
+++ b/apps/server/src/core/workspace/dto/update-workspace.dto.ts
@@ -1,11 +1,15 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateWorkspaceDto } from './create-workspace.dto';
-import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+import { IsArray, IsBoolean, IsOptional, IsString, IsUUID } from 'class-validator';
 
 export class UpdateWorkspaceDto extends PartialType(CreateWorkspaceDto) {
   @IsOptional()
   @IsString()
   logo: string;
+
+  @IsOptional()
+  @IsUUID('all')
+  landingPageId?: string | null;
 
   @IsOptional()
   @IsArray()

--- a/apps/server/src/core/workspace/services/workspace.service.ts
+++ b/apps/server/src/core/workspace/services/workspace.service.ts
@@ -313,6 +313,23 @@ export class WorkspaceService {
       }
     }
 
+    if (typeof updateWorkspaceDto.landingPageId !== 'undefined') {
+      // allow explicit clearing via `null`
+      if (updateWorkspaceDto.landingPageId) {
+        const page = await this.db
+          .selectFrom('pages')
+          .select(['id'])
+          .where('id', '=', updateWorkspaceDto.landingPageId)
+          .where('workspaceId', '=', workspaceId)
+          .where('deletedAt', 'is', null)
+          .executeTakeFirst();
+
+        if (!page) {
+          throw new BadRequestException('Landing page not found');
+        }
+      }
+    }
+
     if (typeof updateWorkspaceDto.restrictApiToAdmins !== 'undefined') {
       await this.workspaceRepo.updateApiSettings(
         workspaceId,

--- a/apps/server/src/database/migrations/20260120T120000-workspace-landing-page.ts
+++ b/apps/server/src/database/migrations/20260120T120000-workspace-landing-page.ts
@@ -1,0 +1,32 @@
+import { Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('workspaces')
+    .addColumn('landing_page_id', 'uuid', (col) => col)
+    .execute();
+
+  await db.schema
+    .alterTable('workspaces')
+    .addForeignKeyConstraint(
+      'workspaces_landing_page_id_fkey',
+      ['landing_page_id'],
+      'pages',
+      ['id'],
+    )
+    .onDelete('set null')
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable('workspaces')
+    .dropConstraint('workspaces_landing_page_id_fkey')
+    .execute();
+
+  await db.schema
+    .alterTable('workspaces')
+    .dropColumn('landing_page_id')
+    .execute();
+}
+

--- a/apps/server/src/database/repos/workspace/workspace.repo.ts
+++ b/apps/server/src/database/repos/workspace/workspace.repo.ts
@@ -23,6 +23,7 @@ export class WorkspaceRepo {
     'defaultRole',
     'emailDomains',
     'defaultSpaceId',
+    'landingPageId',
     'createdAt',
     'updatedAt',
     'deletedAt',

--- a/apps/server/src/database/types/db.d.ts
+++ b/apps/server/src/database/types/db.d.ts
@@ -351,6 +351,7 @@ export interface Workspaces {
   enforceSso: Generated<boolean>;
   hostname: string | null;
   id: Generated<string>;
+  landingPageId: string | null;
   licenseKey: string | null;
   logo: string | null;
   name: string | null;


### PR DESCRIPTION
In Workspace Settings > General, present a "Landing page" dropdown that allows an admin to select a page that members will see when opening the workspace. 
- Features a typeahead
- Features ability to remove selection to return to default functionality