### PR TITLE
fix: handle empty password, missing port, and TLS in Redis URL parsing

### DIFF
--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -22,7 +22,8 @@ import { TelemetryModule } from './integrations/telemetry/telemetry.module';
 import { RedisModule } from '@nestjs-labs/nestjs-ioredis';
 import { RedisConfigService } from './integrations/redis/redis-config.service';
 import { CacheModule } from '@nestjs/cache-manager';
-import KeyvRedis from '@keyv/redis';
+import KeyvRedis, { defaultReconnectStrategy } from '@keyv/redis';
+import { parseRedisUrl } from './common/helpers';
 import { LoggerModule } from './common/logger/logger.module';
 import { ClsModule } from 'nestjs-cls';
 import { NoopAuditModule } from './integrations/audit/audit.module';
@@ -59,10 +60,16 @@ try {
       isGlobal: true,
       useFactory: async (environmentService: EnvironmentService) => {
         const redisUrl = environmentService.getRedisUrl();
+        const { family } = parseRedisUrl(redisUrl);
 
         return {
           ttl: 5 * 1000,
-          stores: [new KeyvRedis(redisUrl)],
+          stores: [
+            new KeyvRedis({
+              url: redisUrl,
+              socket: { family, reconnectStrategy: defaultReconnectStrategy },
+            }),
+          ],
         };
       },
       inject: [EnvironmentService],

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -60,14 +60,18 @@ try {
       isGlobal: true,
       useFactory: async (environmentService: EnvironmentService) => {
         const redisUrl = environmentService.getRedisUrl();
-        const { family } = parseRedisUrl(redisUrl);
+        const { family, tls } = parseRedisUrl(redisUrl);
 
         return {
           ttl: 5 * 1000,
           stores: [
             new KeyvRedis({
               url: redisUrl,
-              socket: { family, reconnectStrategy: defaultReconnectStrategy },
+              socket: {
+                family,
+                reconnectStrategy: defaultReconnectStrategy,
+                ...tls,
+              },
             }),
           ],
         };

--- a/apps/server/src/collaboration/collaboration.gateway.ts
+++ b/apps/server/src/collaboration/collaboration.gateway.ts
@@ -65,6 +65,7 @@ export class CollaborationGateway {
           password: this.redisConfig.password,
           db: this.redisConfig.db,
           family: this.redisConfig.family,
+          tls: this.redisConfig.tls,
           retryStrategy: createRetryStrategy(),
         }),
         serverId: `collab-${os?.hostname()}-${nanoid(10)}`,

--- a/apps/server/src/common/helpers/utils.ts
+++ b/apps/server/src/common/helpers/utils.ts
@@ -30,13 +30,14 @@ export type RedisConfig = {
   db: number;
   password?: string;
   family?: number;
+  tls?: object;
 };
 
 export function parseRedisUrl(redisUrl: string): RedisConfig {
   // format - redis[s]://[[username][:password]@][host][:port][/db-number][?family=4|6]
   const url = new URL(redisUrl);
-  const { hostname, port, password, pathname, searchParams } = url;
-  const portInt = parseInt(port, 10);
+  const { hostname, port, password, pathname, protocol, searchParams } = url;
+  const portInt = port ? parseInt(port, 10) : 6379;
 
   let db: number = 0;
   // extract db value if present
@@ -54,7 +55,9 @@ export function parseRedisUrl(redisUrl: string): RedisConfig {
     family = parseInt(familyParam, 10);
   }
 
-  return { host: hostname, port: portInt, password, db, family };
+  const tls = protocol === 'rediss:' ? {} : undefined;
+
+  return { host: hostname, port: portInt, password: password || undefined, db, family, tls };
 }
 
 export function createRetryStrategy() {

--- a/apps/server/src/common/helpers/utils.ts
+++ b/apps/server/src/common/helpers/utils.ts
@@ -30,11 +30,11 @@ export type RedisConfig = {
   db: number;
   password?: string;
   family?: number;
-  tls?: object;
+  tls?: { rejectUnauthorized?: boolean };
 };
 
 export function parseRedisUrl(redisUrl: string): RedisConfig {
-  // format - redis[s]://[[username][:password]@][host][:port][/db-number][?family=4|6]
+  // format - redis[s]://[[username][:password]@][host][:port][/db-number][?family=4|6][&rejectUnauthorized=false]
   const url = new URL(redisUrl);
   const { hostname, port, password, pathname, protocol, searchParams } = url;
   const portInt = port ? parseInt(port, 10) : 6379;
@@ -55,7 +55,12 @@ export function parseRedisUrl(redisUrl: string): RedisConfig {
     family = parseInt(familyParam, 10);
   }
 
-  const tls = protocol === 'rediss:' ? {} : undefined;
+  const tls =
+    protocol === 'rediss:'
+      ? searchParams.get('rejectUnauthorized') === 'false'
+        ? { rejectUnauthorized: false }
+        : {}
+      : undefined;
 
   return { host: hostname, port: portInt, password: password || undefined, db, family, tls };
 }

--- a/apps/server/src/integrations/health/redis.health.ts
+++ b/apps/server/src/integrations/health/redis.health.ts
@@ -5,6 +5,7 @@ import {
 import { Injectable, Logger } from '@nestjs/common';
 import { EnvironmentService } from '../environment/environment.service';
 import { Redis } from 'ioredis';
+import { parseRedisUrl } from '../../common/helpers';
 
 @Injectable()
 export class RedisHealthIndicator {
@@ -19,8 +20,10 @@ export class RedisHealthIndicator {
     const indicator = this.healthIndicatorService.check(key);
 
     try {
-      const redis = new Redis(this.environmentService.getRedisUrl(), {
+      const redisUrl = this.environmentService.getRedisUrl();
+      const redis = new Redis(redisUrl, {
         maxRetriesPerRequest: 15,
+        tls: parseRedisUrl(redisUrl).tls,
       });
 
       await redis.ping();

--- a/apps/server/src/integrations/queue/queue.module.ts
+++ b/apps/server/src/integrations/queue/queue.module.ts
@@ -18,6 +18,7 @@ import { GeneralQueueProcessor } from './processors/general-queue.processor';
             password: redisConfig.password,
             db: redisConfig.db,
             family: redisConfig.family,
+            tls: redisConfig.tls,
             retryStrategy: createRetryStrategy(),
           },
           defaultJobOptions: {

--- a/apps/server/src/integrations/redis/redis-config.service.ts
+++ b/apps/server/src/integrations/redis/redis-config.service.ts
@@ -19,6 +19,7 @@ export class RedisConfigService implements RedisOptionsFactory {
         password: redisConfig.password,
         db: redisConfig.db,
         family: redisConfig.family,
+        tls: redisConfig.tls,
         retryStrategy: createRetryStrategy(),
       },
     };

--- a/apps/server/src/ws/adapter/ws-redis.adapter.ts
+++ b/apps/server/src/ws/adapter/ws-redis.adapter.ts
@@ -17,6 +17,7 @@ export class WsRedisIoAdapter extends IoAdapter {
 
     const options: RedisOptions = {
       family: this.redisConfig.family,
+      tls: this.redisConfig.tls,
       retryStrategy: createRetryStrategy(),
     };
 


### PR DESCRIPTION
Fixes three edge cases in `parseRedisUrl()` that cause issues with common Redis URL formats:

### 1. Empty password triggers ioredis warning
`new URL('redis://localhost:6379').password` returns `""` (empty string). ioredis treats any string — including empty — as a supplied password, spamming logs with:
```
[WARN] This Redis server's default user does not require a password, but a password was supplied
```
**Fix:** `password: password || undefined`

### 2. Missing port produces `NaN`
`new URL('redis://localhost/0').port` returns `""` when omitted. `parseInt('', 10)` is `NaN`, which breaks the connection.

**Fix:** `port ? parseInt(port, 10) : 6379`

### 3. `rediss://` TLS silently dropped
For `rediss://` URLs, the protocol indicates TLS should be used, but the parsed config object never included a `tls` field. Any code using the parsed config (instead of the raw URL string) silently drops TLS.

**Fix:** Extract `protocol` from the URL and return `tls: {}` for `rediss://` schemes. Propagated to all Redis consumers (redis-config service, BullMQ queue module, collaboration gateway).