### PR TITLE
fix: pin jose@4 for openid-client to prevent OIDC breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
       "@tiptap/core": "patches/@tiptap__core.patch"
     },
     "overrides": {
+      "openid-client>jose": "4.15.9",
       "jsdom": "25.0.1",
       "jsonwebtoken": "9.0.3",
       "prosemirror-changeset": "2.3.1",


### PR DESCRIPTION
## Summary

`openid-client@5` requires `jose@^4.15.5 || ^5.0.0`, but `@modelcontextprotocol/sdk` (added in #1976) depends on `jose@6`. With `shamefully-hoist = true` in `.npmrc`, pnpm hoists `jose@6` to the root `node_modules/`, which `openid-client` then resolves at runtime.

`jose@6` has breaking API changes that cause OIDC token exchange to fail silently.

## Fix

Scoped pnpm override in `package.json`:

```json
"openid-client>jose": "4.15.9"
```

This ensures `openid-client` always resolves `jose@4` regardless of hoisting, without affecting other packages that legitimately use `jose@6`.

## Why not upgrade openid-client to v6?

The proper long-term fix is upgrading `openid-client` from v5 to v6 (which uses `jose@6` natively), but v5→v6 is a full API rewrite (class-based → functional). Since the OIDC usage lives in the EE submodule, this override is the safe interim fix. It can be removed once `openid-client` is upgraded to v6+.