### PR TITLE
feat: add Gravatar fallback for user avatars

### DIFF
--- a/apps/client/src/components/common/user-info.tsx
+++ b/apps/client/src/components/common/user-info.tsx
@@ -10,7 +10,7 @@ interface UserInfoProps {
 export function UserInfo({ user, size }: UserInfoProps) {
   return (
     <Group gap="sm" wrap="nowrap">
-      <CustomAvatar avatarUrl={user?.avatarUrl} name={user?.name} size={size} />
+      <CustomAvatar avatarUrl={user?.avatarUrl} name={user?.name} email={user?.email} size={size} />
       <div>
         <Text fz="sm" fw={500} lineClamp={1}>
           {user?.name}

--- a/apps/client/src/components/layouts/global/top-menu.tsx
+++ b/apps/client/src/components/layouts/global/top-menu.tsx
@@ -87,6 +87,7 @@ export default function TopMenu() {
               size={"sm"}
               avatarUrl={user.avatarUrl}
               name={user.name}
+              email={user.email}
             />
 
             <div style={{ width: 190 }}>

--- a/apps/client/src/components/ui/custom-avatar.tsx
+++ b/apps/client/src/components/ui/custom-avatar.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { Avatar } from "@mantine/core";
 import { getAvatarUrl } from "@/lib/config.ts";
+import { getGravatarUrl } from "@/lib/gravatar.ts";
 import { AvatarIconType } from "@/features/attachments/types/attachment.types.ts";
 
 interface CustomAvatarProps {
   avatarUrl?: string;
   name: string;
+  email?: string;
   color?: string;
   size?: string | number;
   radius?: string | number;
@@ -19,8 +21,8 @@ interface CustomAvatarProps {
 export const CustomAvatar = React.forwardRef<
   HTMLInputElement,
   CustomAvatarProps
->(({ avatarUrl, name, type, ...props }: CustomAvatarProps, ref) => {
-  const avatarLink = getAvatarUrl(avatarUrl, type);
+>(({ avatarUrl, name, email, type, ...props }: CustomAvatarProps, ref) => {
+  const avatarLink = getAvatarUrl(avatarUrl, type) ?? getGravatarUrl(email);
 
   return (
     <Avatar

--- a/apps/client/src/features/comment/components/comment-dialog.tsx
+++ b/apps/client/src/features/comment/components/comment-dialog.tsx
@@ -109,6 +109,7 @@ function CommentDialog({ editor, pageId }: CommentDialogProps) {
             size="sm"
             avatarUrl={currentUser.user.avatarUrl}
             name={currentUser.user.name}
+            email={currentUser.user.email}
           />
           <div style={{ flex: 1 }}>
             <Group justify="space-between" wrap="nowrap">

--- a/apps/client/src/features/comment/components/comment-list-item.tsx
+++ b/apps/client/src/features/comment/components/comment-list-item.tsx
@@ -128,6 +128,7 @@ function CommentListItem({
           size="sm"
           avatarUrl={comment.creator.avatarUrl}
           name={comment.creator.name}
+          email={comment.creator.email}
         />
 
         <div style={{ flex: 1 }}>

--- a/apps/client/src/features/group/components/group-members.tsx
+++ b/apps/client/src/features/group/components/group-members.tsx
@@ -63,7 +63,7 @@ export default function GroupMembersList() {
               <Table.Tr key={index}>
                 <Table.Td>
                   <Group gap="sm" wrap="nowrap">
-                    <CustomAvatar avatarUrl={user.avatarUrl} name={user.name} />
+                    <CustomAvatar avatarUrl={user.avatarUrl} name={user.name} email={user.email} />
                     <div>
                       <Text fz="sm" fw={500} lineClamp={1}>
                         {user.name}

--- a/apps/client/src/features/group/components/multi-user-select.tsx
+++ b/apps/client/src/features/group/components/multi-user-select.tsx
@@ -18,6 +18,7 @@ const renderMultiSelectOption: MultiSelectProps["renderOption"] = ({
     <CustomAvatar
       avatarUrl={option?.["avatarUrl"]}
       name={option.label}
+      email={option?.["email"]}
       size={36}
     />
     <div>

--- a/apps/client/src/features/space/components/multi-member-select.tsx
+++ b/apps/client/src/features/space/components/multi-member-select.tsx
@@ -22,6 +22,7 @@ const renderMultiSelectOption: MultiSelectProps["renderOption"] = ({
         avatarUrl={option["avatarUrl"]}
         size={20}
         name={option.label}
+        email={option["email"]}
       />
     )}
     {option["type"] === "group" && <IconGroupCircle />}

--- a/apps/client/src/features/space/components/space-members.tsx
+++ b/apps/client/src/features/space/components/space-members.tsx
@@ -156,6 +156,7 @@ export default function SpaceMembersList({
                         <CustomAvatar
                           avatarUrl={member?.avatarUrl}
                           name={member.name}
+                          email={member?.email}
                         />
                       )}
 

--- a/apps/client/src/features/workspace/components/members/components/workspace-members-table.tsx
+++ b/apps/client/src/features/workspace/components/members/components/workspace-members-table.tsx
@@ -73,6 +73,7 @@ export default function WorkspaceMembersTable() {
                       <CustomAvatar
                         avatarUrl={user.avatarUrl}
                         name={user.name}
+                        email={user.email}
                       />
                       <div>
                         <Text fz="sm" fw={500} lineClamp={1}>

--- a/apps/client/src/lib/gravatar.ts
+++ b/apps/client/src/lib/gravatar.ts
@@ -1,0 +1,229 @@
+/**
+ * Gravatar support utilities.
+ * Generates Gravatar URLs from email addresses using MD5 hashing.
+ */
+
+// Compact MD5 implementation (RFC 1321)
+function md5(input: string): string {
+  function safeAdd(x: number, y: number): number {
+    const lsw = (x & 0xffff) + (y & 0xffff);
+    const msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+    return (msw << 16) | (lsw & 0xffff);
+  }
+
+  function bitRotateLeft(num: number, cnt: number): number {
+    return (num << cnt) | (num >>> (32 - cnt));
+  }
+
+  function md5cmn(
+    q: number,
+    a: number,
+    b: number,
+    x: number,
+    s: number,
+    t: number,
+  ): number {
+    return safeAdd(bitRotateLeft(safeAdd(safeAdd(a, q), safeAdd(x, t)), s), b);
+  }
+
+  function md5ff(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    x: number,
+    s: number,
+    t: number,
+  ): number {
+    return md5cmn((b & c) | (~b & d), a, b, x, s, t);
+  }
+
+  function md5gg(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    x: number,
+    s: number,
+    t: number,
+  ): number {
+    return md5cmn((b & d) | (c & ~d), a, b, x, s, t);
+  }
+
+  function md5hh(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    x: number,
+    s: number,
+    t: number,
+  ): number {
+    return md5cmn(b ^ c ^ d, a, b, x, s, t);
+  }
+
+  function md5ii(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    x: number,
+    s: number,
+    t: number,
+  ): number {
+    return md5cmn(c ^ (b | ~d), a, b, x, s, t);
+  }
+
+  function binlMD5(x: number[], len: number): number[] {
+    x[len >> 5] |= 0x80 << len % 32;
+    x[(((len + 64) >>> 9) << 4) + 14] = len;
+
+    let i: number;
+    let olda: number;
+    let oldb: number;
+    let oldc: number;
+    let oldd: number;
+    let a = 1732584193;
+    let b = -271733879;
+    let c = -1732584194;
+    let d = 271733878;
+
+    for (i = 0; i < x.length; i += 16) {
+      olda = a;
+      oldb = b;
+      oldc = c;
+      oldd = d;
+
+      a = md5ff(a, b, c, d, x[i], 7, -680876936);
+      d = md5ff(d, a, b, c, x[i + 1], 12, -389564586);
+      c = md5ff(c, d, a, b, x[i + 2], 17, 606105819);
+      b = md5ff(b, c, d, a, x[i + 3], 22, -1044525330);
+      a = md5ff(a, b, c, d, x[i + 4], 7, -176418897);
+      d = md5ff(d, a, b, c, x[i + 5], 12, 1200080426);
+      c = md5ff(c, d, a, b, x[i + 6], 17, -1473231341);
+      b = md5ff(b, c, d, a, x[i + 7], 22, -45705983);
+      a = md5ff(a, b, c, d, x[i + 8], 7, 1770035416);
+      d = md5ff(d, a, b, c, x[i + 9], 12, -1958414417);
+      c = md5ff(c, d, a, b, x[i + 10], 17, -42063);
+      b = md5ff(b, c, d, a, x[i + 11], 22, -1990404162);
+      a = md5ff(a, b, c, d, x[i + 12], 7, 1804603682);
+      d = md5ff(d, a, b, c, x[i + 13], 12, -40341101);
+      c = md5ff(c, d, a, b, x[i + 14], 17, -1502002290);
+      b = md5ff(b, c, d, a, x[i + 15], 22, 1236535329);
+
+      a = md5gg(a, b, c, d, x[i + 1], 5, -165796510);
+      d = md5gg(d, a, b, c, x[i + 6], 9, -1069501632);
+      c = md5gg(c, d, a, b, x[i + 11], 14, 643717713);
+      b = md5gg(b, c, d, a, x[i], 20, -373897302);
+      a = md5gg(a, b, c, d, x[i + 5], 5, -701558691);
+      d = md5gg(d, a, b, c, x[i + 10], 9, 38016083);
+      c = md5gg(c, d, a, b, x[i + 15], 14, -660478335);
+      b = md5gg(b, c, d, a, x[i + 4], 20, -405537848);
+      a = md5gg(a, b, c, d, x[i + 9], 5, 568446438);
+      d = md5gg(d, a, b, c, x[i + 14], 9, -1019803690);
+      c = md5gg(c, d, a, b, x[i + 3], 14, -187363961);
+      b = md5gg(b, c, d, a, x[i + 8], 20, 1163531501);
+      a = md5gg(a, b, c, d, x[i + 13], 5, -1444681467);
+      d = md5gg(d, a, b, c, x[i + 2], 9, -51403784);
+      c = md5gg(c, d, a, b, x[i + 7], 14, 1735328473);
+      b = md5gg(b, c, d, a, x[i + 12], 20, -1926607734);
+
+      a = md5hh(a, b, c, d, x[i + 5], 4, -378558);
+      d = md5hh(d, a, b, c, x[i + 8], 11, -2022574463);
+      c = md5hh(c, d, a, b, x[i + 11], 16, 1839030562);
+      b = md5hh(b, c, d, a, x[i + 14], 23, -35309556);
+      a = md5hh(a, b, c, d, x[i + 1], 4, -1530992060);
+      d = md5hh(d, a, b, c, x[i + 4], 11, 1272893353);
+      c = md5hh(c, d, a, b, x[i + 7], 16, -155497632);
+      b = md5hh(b, c, d, a, x[i + 10], 23, -1094730640);
+      a = md5hh(a, b, c, d, x[i + 13], 4, 681279174);
+      d = md5hh(d, a, b, c, x[i], 11, -358537222);
+      c = md5hh(c, d, a, b, x[i + 3], 16, -722521979);
+      b = md5hh(b, c, d, a, x[i + 6], 23, 76029189);
+      a = md5hh(a, b, c, d, x[i + 9], 4, -640364487);
+      d = md5hh(d, a, b, c, x[i + 12], 11, -421815835);
+      c = md5hh(c, d, a, b, x[i + 15], 16, 530742520);
+      b = md5hh(b, c, d, a, x[i + 2], 23, -995338651);
+
+      a = md5ii(a, b, c, d, x[i], 6, -198630844);
+      d = md5ii(d, a, b, c, x[i + 7], 10, 1126891415);
+      c = md5ii(c, d, a, b, x[i + 14], 15, -1416354905);
+      b = md5ii(b, c, d, a, x[i + 5], 21, -57434055);
+      a = md5ii(a, b, c, d, x[i + 12], 6, 1700485571);
+      d = md5ii(d, a, b, c, x[i + 3], 10, -1894986606);
+      c = md5ii(c, d, a, b, x[i + 10], 15, -1051523);
+      b = md5ii(b, c, d, a, x[i + 1], 21, -2054922799);
+      a = md5ii(a, b, c, d, x[i + 8], 6, 1873313359);
+      d = md5ii(d, a, b, c, x[i + 15], 10, -30611744);
+      c = md5ii(c, d, a, b, x[i + 6], 15, -1560198380);
+      b = md5ii(b, c, d, a, x[i + 13], 21, 1309151649);
+      a = md5ii(a, b, c, d, x[i + 4], 6, -145523070);
+      d = md5ii(d, a, b, c, x[i + 11], 10, -1120210379);
+      c = md5ii(c, d, a, b, x[i + 2], 15, 718787259);
+      b = md5ii(b, c, d, a, x[i + 9], 21, -343485551);
+
+      a = safeAdd(a, olda);
+      b = safeAdd(b, oldb);
+      c = safeAdd(c, oldc);
+      d = safeAdd(d, oldd);
+    }
+    return [a, b, c, d];
+  }
+
+  function binl2rstr(input: number[]): string {
+    let i: number;
+    let output = "";
+    const length32 = input.length * 32;
+    for (i = 0; i < length32; i += 8) {
+      output += String.fromCharCode((input[i >> 5] >>> i % 32) & 0xff);
+    }
+    return output;
+  }
+
+  function rstr2binl(input: string): number[] {
+    let i: number;
+    const output: number[] = [];
+    output[(input.length >> 2) - 1] = undefined;
+    for (i = 0; i < output.length; i += 1) {
+      output[i] = 0;
+    }
+    const length8 = input.length * 8;
+    for (i = 0; i < length8; i += 8) {
+      output[i >> 5] |= (input.charCodeAt(i / 8) & 0xff) << i % 32;
+    }
+    return output;
+  }
+
+  function rstr2hex(input: string): string {
+    const hexTab = "0123456789abcdef";
+    let output = "";
+    let x: number;
+    let i: number;
+    for (i = 0; i < input.length; i += 1) {
+      x = input.charCodeAt(i);
+      output += hexTab.charAt((x >>> 4) & 0x0f) + hexTab.charAt(x & 0x0f);
+    }
+    return output;
+  }
+
+  function str2rstrUTF8(input: string): string {
+    return unescape(encodeURIComponent(input));
+  }
+
+  function rstrMD5(s: string): string {
+    return binl2rstr(binlMD5(rstr2binl(s), s.length * 8));
+  }
+
+  return rstr2hex(rstrMD5(str2rstrUTF8(input)));
+}
+
+/**
+ * Returns a Gravatar URL for the given email address.
+ * Uses `d=404` so requests fail when no Gravatar exists,
+ * allowing the Avatar component to fall back to initials.
+ */
+export function getGravatarUrl(email: string, size = 200): string {
+  if (!email) return null;
+  const hash = md5(email.trim().toLowerCase());
+  return `https://www.gravatar.com/avatar/${hash}?s=${size}&d=404`;
+}


### PR DESCRIPTION
Adds Gravatar as a fallback when users have no uploaded avatar. Instead of always showing colored initials, the avatar component now checks Gravatar first using the user's email hash.

## How it works

1. **New utility** (`apps/client/src/lib/gravatar.ts`): `getGravatarUrl(email)` hashes the email with MD5 (pure-JS, no dependencies) and returns a Gravatar URL with `d=404`.

2. **CustomAvatar** (`apps/client/src/components/ui/custom-avatar.tsx`): Accepts an optional `email` prop. When no `avatarUrl` is set, falls back to the Gravatar URL. The `d=404` parameter means Gravatar returns a 404 when no image exists, which lets Mantine's `<Avatar>` fall back to the colored initials as before.

3. **Fallback chain**: Uploaded avatar → Gravatar → Colored initials

## Changes

- **New file**: `apps/client/src/lib/gravatar.ts` — MD5 hash + Gravatar URL builder
- **Modified**: `apps/client/src/components/ui/custom-avatar.tsx` — added `email` prop + Gravatar fallback
- **Modified** (9 files): Threaded `email` prop to `CustomAvatar` in all user-facing components where email is available in the data model (user-info, top-menu, comments, group members, space members, workspace members, multi-select dropdowns)

## Notes

- Some `CustomAvatar` call sites (notifications, share list, page history, audit logs) don't have email in their API response types, so those are left unchanged — they continue to use initials as fallback.
- The MD5 implementation is a compact pure-JS version (~200 lines) to avoid adding a dependency. An alternative would be to use `crypto.subtle` but it doesn't support MD5 (only SHA family), so a JS implementation is necessary for Gravatar compatibility.