### PR TITLE
feat: add HTML source editor mode

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -55,6 +55,8 @@
     "semver": "^7.7.3",
     "socket.io-client": "^4.8.3",
     "tiptap-extension-global-drag-handle": "^0.1.18",
+    "@codemirror/lang-html": "^6.4.11",
+    "@uiw/react-codemirror": "^4.25.8",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/client/src/features/editor/atoms/editor-atoms.ts
+++ b/apps/client/src/features/editor/atoms/editor-atoms.ts
@@ -9,4 +9,6 @@ export const readOnlyEditorAtom = atom<Editor | null>(null);
 
 export const yjsConnectionStatusAtom = atom<string>("");
 
+export const sourceModeAtom = atom<boolean>(false);
+
 export const showAiMenuAtom = atom(false);

--- a/apps/client/src/features/editor/full-editor.tsx
+++ b/apps/client/src/features/editor/full-editor.tsx
@@ -1,10 +1,12 @@
 import classes from "@/features/editor/styles/editor.module.css";
-import React from "react";
+import React, { useEffect } from "react";
 import { TitleEditor } from "@/features/editor/title-editor";
 import PageEditor from "@/features/editor/page-editor";
+import SourceEditor from "@/features/editor/source-editor";
 import { Container } from "@mantine/core";
 import { useAtom } from "jotai";
 import { userAtom } from "@/features/user/atoms/current-user-atom.ts";
+import { sourceModeAtom } from "@/features/editor/atoms/editor-atoms";
 
 const MemoizedTitleEditor = React.memo(TitleEditor);
 const MemoizedPageEditor = React.memo(PageEditor);
@@ -28,6 +30,12 @@ export function FullEditor({
 }: FullEditorProps) {
   const [user] = useAtom(userAtom);
   const fullPageWidth = user.settings?.preferences?.fullPageWidth;
+  const [sourceMode, setSourceMode] = useAtom(sourceModeAtom);
+
+  // Reset source mode when navigating to a different page
+  useEffect(() => {
+    setSourceMode(false);
+  }, [pageId]);
 
   return (
     <Container
@@ -42,11 +50,19 @@ export function FullEditor({
         spaceSlug={spaceSlug}
         editable={editable}
       />
-      <MemoizedPageEditor
-        pageId={pageId}
-        editable={editable}
-        content={content}
-      />
+
+      {/* Keep PageEditor always mounted so its Tiptap/Y.js editor instance
+          stays alive. Source mode hides it with CSS so that setContent()
+          called on unmount of SourceEditor actually lands on a live editor. */}
+      <div style={{ display: sourceMode ? "none" : undefined }}>
+        <MemoizedPageEditor
+          pageId={pageId}
+          editable={editable}
+          content={content}
+        />
+      </div>
+
+      {sourceMode && <SourceEditor />}
     </Container>
   );
 }

--- a/apps/client/src/features/editor/source-editor.tsx
+++ b/apps/client/src/features/editor/source-editor.tsx
@@ -1,0 +1,115 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useAtomValue } from "jotai";
+import { pageEditorAtom } from "@/features/editor/atoms/editor-atoms";
+import { htmlToMarkdown, markdownToHtml } from "@docmost/editor-ext";
+import classes from "@/features/editor/styles/source-editor.module.css";
+
+export default function SourceEditor() {
+  const pageEditor = useAtomValue(pageEditorAtom);
+  const [sourceContent, setSourceContent] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const initializedRef = useRef(false);
+  // Refs kept up-to-date synchronously so unmount cleanup never closes over
+  // stale values without needing them in any dep array.
+  const latestContentRef = useRef("");
+  const pageEditorRef = useRef(pageEditor);
+  // Update synchronously on every render (safe for refs)
+  pageEditorRef.current = pageEditor;
+
+  // Initialize source content from the editor's current HTML.
+  // Re-initializes if the editor was empty on first read, which happens when
+  // Y.js hasn't finished loading content yet (e.g. user opens source mode
+  // before the collaborative session has synced).
+  useEffect(() => {
+    if (!pageEditor) return;
+    const prevWasEmpty =
+      !latestContentRef.current || latestContentRef.current.trim() === "";
+    if (!initializedRef.current || prevWasEmpty) {
+      initializedRef.current = true;
+      const html = pageEditor.getHTML();
+      const markdown = htmlToMarkdown(html);
+      setSourceContent(markdown);
+      latestContentRef.current = markdown;
+    }
+  }, [pageEditor]);
+
+  // Keep latestContentRef in sync so the unmount cleanup always sees the
+  // most recent value without requiring it in a dep array.
+  useEffect(() => {
+    latestContentRef.current = sourceContent;
+  }, [sourceContent]);
+
+  // Focus textarea when source mode opens.
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  // Apply content back to the editor on unmount only (empty deps).
+  // Using pageEditorRef instead of pageEditor in the dep array ensures this
+  // cleanup only runs on real unmount, not whenever the editor reference
+  // changes (e.g. editor recreation after Y.js extension loads).
+  useEffect(() => {
+    return () => {
+      const editor = pageEditorRef.current;
+      // Guard: no editor, never initialized, or editor already destroyed
+      // (can happen during page-navigation teardown).
+      if (!editor || !initializedRef.current || editor.isDestroyed) return;
+
+      const result = markdownToHtml(latestContentRef.current);
+
+      const apply = (html: string) => {
+        if (editor.isDestroyed) return;
+        // chain().clearContent().setContent() is the same pattern used by
+        // use-history-restore.tsx and reliably replaces content in a
+        // Y.js-backed editor without leaving orphaned CRDT nodes.
+        editor.chain().clearContent().setContent(html).run();
+      };
+
+      // markdownToHtml returns string | Promise<string>; handle both.
+      if (result instanceof Promise) {
+        result.then(apply);
+      } else {
+        apply(result);
+      }
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Allow Tab key to insert spaces instead of moving focus.
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const target = e.currentTarget;
+        const start = target.selectionStart;
+        const end = target.selectionEnd;
+        const newValue =
+          sourceContent.substring(0, start) +
+          "  " +
+          sourceContent.substring(end);
+        setSourceContent(newValue);
+        // Restore cursor position after state update.
+        requestAnimationFrame(() => {
+          target.selectionStart = start + 2;
+          target.selectionEnd = start + 2;
+        });
+      }
+    },
+    [sourceContent],
+  );
+
+  return (
+    <div className={classes.sourceEditorWrapper}>
+      <textarea
+        ref={textareaRef}
+        className={classes.sourceTextarea}
+        value={sourceContent}
+        onChange={(e) => setSourceContent(e.target.value)}
+        onKeyDown={handleKeyDown}
+        spellCheck={false}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+      />
+    </div>
+  );
+}

--- a/apps/client/src/features/editor/source-editor.tsx
+++ b/apps/client/src/features/editor/source-editor.tsx
@@ -1,114 +1,160 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAtomValue } from "jotai";
+import { useComputedColorScheme } from "@mantine/core";
+import CodeMirror, {
+  type ReactCodeMirrorRef,
+  type ViewUpdate,
+} from "@uiw/react-codemirror";
+import { html } from "@codemirror/lang-html";
+import { EditorView } from "@codemirror/view";
 import { pageEditorAtom } from "@/features/editor/atoms/editor-atoms";
-import { htmlToMarkdown, markdownToHtml } from "@docmost/editor-ext";
 import classes from "@/features/editor/styles/source-editor.module.css";
+
+/**
+ * Lightweight HTML pretty-printer. Adds newlines and indentation around block
+ * elements so the raw HTML from TipTap is human-readable. Does not modify
+ * inline content or text nodes.
+ */
+function formatHtml(raw: string): string {
+  const BLOCK_TAGS =
+    /^(html|head|body|div|p|ul|ol|li|table|thead|tbody|tfoot|tr|th|td|colgroup|col|blockquote|pre|h[1-6]|details|summary|section|article|nav|header|footer|main|form|fieldset|figure|figcaption|hr|br)$/i;
+
+  let result = "";
+  let indent = 0;
+  const pad = () => "  ".repeat(indent);
+
+  // Split into tags and text segments.
+  const tokens = raw.split(/(<\/?[^>]+>)/g).filter(Boolean);
+
+  for (const token of tokens) {
+    // Closing tag
+    const closingMatch = token.match(/^<\/(\w+)/);
+    if (closingMatch) {
+      const tag = closingMatch[1];
+      if (BLOCK_TAGS.test(tag)) {
+        indent = Math.max(0, indent - 1);
+        result += `\n${pad()}${token}`;
+        continue;
+      }
+    }
+    // Opening / self-closing / void tag
+    else {
+      const openingMatch = token.match(/^<(\w+)[^>]*\/?>$/);
+      if (openingMatch) {
+        const tag = openingMatch[1];
+        if (BLOCK_TAGS.test(tag)) {
+          result += `\n${pad()}${token}`;
+          // Only increase indent if not self-closing / void
+          if (!/\/>$/.test(token) && !/^(br|hr|col|img|input|meta|link)$/i.test(tag)) {
+            indent++;
+          }
+          continue;
+        }
+      }
+    }
+    // Text node or inline tag — append as-is.
+    result += token;
+  }
+
+  return result.trim();
+}
 
 export default function SourceEditor() {
   const pageEditor = useAtomValue(pageEditorAtom);
-  const [sourceContent, setSourceContent] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const colorScheme = useComputedColorScheme();
+  const cmRef = useRef<ReactCodeMirrorRef>(null);
   const initializedRef = useRef(false);
-  // Refs kept up-to-date synchronously so unmount cleanup never closes over
-  // stale values without needing them in any dep array.
   const latestContentRef = useRef("");
   const pageEditorRef = useRef(pageEditor);
-  // Update synchronously on every render (safe for refs)
   pageEditorRef.current = pageEditor;
 
-  // Initialize source content from the editor's current HTML.
-  // Re-initializes if the editor was empty on first read, which happens when
-  // Y.js hasn't finished loading content yet (e.g. user opens source mode
-  // before the collaborative session has synced).
+  // Cache the first non-empty HTML so subsequent pageEditor changes (e.g.
+  // editor recreation after Y.js extension loads) don't clobber user edits.
+  const [initialValue] = useState(() => {
+    if (!pageEditor) return "";
+    return formatHtml(pageEditor.getHTML());
+  });
+
+  // If Y.js hasn't synced yet, the first read may be empty. Retry when
+  // the editor atom updates and push new content via dispatch (not the
+  // controlled value prop) so we don't overwrite user edits.
   useEffect(() => {
     if (!pageEditor) return;
     const prevWasEmpty =
       !latestContentRef.current || latestContentRef.current.trim() === "";
     if (!initializedRef.current || prevWasEmpty) {
       initializedRef.current = true;
-      const html = pageEditor.getHTML();
-      const markdown = htmlToMarkdown(html);
-      setSourceContent(markdown);
-      latestContentRef.current = markdown;
+      const formatted = formatHtml(pageEditor.getHTML());
+      latestContentRef.current = formatted;
+
+      if (prevWasEmpty && formatted && cmRef.current?.view) {
+        const view = cmRef.current.view;
+        view.dispatch({
+          changes: { from: 0, to: view.state.doc.length, insert: formatted },
+        });
+      }
     }
   }, [pageEditor]);
 
-  // Keep latestContentRef in sync so the unmount cleanup always sees the
-  // most recent value without requiring it in a dep array.
-  useEffect(() => {
-    latestContentRef.current = sourceContent;
-  }, [sourceContent]);
-
-  // Focus textarea when source mode opens.
-  useEffect(() => {
-    textareaRef.current?.focus();
-  }, []);
-
-  // Apply content back to the editor on unmount only (empty deps).
-  // Using pageEditorRef instead of pageEditor in the dep array ensures this
-  // cleanup only runs on real unmount, not whenever the editor reference
-  // changes (e.g. editor recreation after Y.js extension loads).
+  // Apply content back to the TipTap editor on unmount only.
   useEffect(() => {
     return () => {
       const editor = pageEditorRef.current;
-      // Guard: no editor, never initialized, or editor already destroyed
-      // (can happen during page-navigation teardown).
       if (!editor || !initializedRef.current || editor.isDestroyed) return;
-
-      const result = markdownToHtml(latestContentRef.current);
-
-      const apply = (html: string) => {
-        if (editor.isDestroyed) return;
-        // chain().clearContent().setContent() is the same pattern used by
-        // use-history-restore.tsx and reliably replaces content in a
-        // Y.js-backed editor without leaving orphaned CRDT nodes.
-        editor.chain().clearContent().setContent(html).run();
-      };
-
-      // markdownToHtml returns string | Promise<string>; handle both.
-      if (result instanceof Promise) {
-        result.then(apply);
-      } else {
-        apply(result);
-      }
+      editor.chain().clearContent().setContent(latestContentRef.current).run();
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      // Allow Tab key to insert spaces instead of moving focus.
-      if (e.key === "Tab") {
-        e.preventDefault();
-        const target = e.currentTarget;
-        const start = target.selectionStart;
-        const end = target.selectionEnd;
-        const newValue =
-          sourceContent.substring(0, start) +
-          "  " +
-          sourceContent.substring(end);
-        setSourceContent(newValue);
-        // Restore cursor position after state update.
-        requestAnimationFrame(() => {
-          target.selectionStart = start + 2;
-          target.selectionEnd = start + 2;
-        });
-      }
-    },
-    [sourceContent],
+  const handleChange = useCallback((value: string, _viewUpdate: ViewUpdate) => {
+    latestContentRef.current = value;
+  }, []);
+
+  const extensions = useMemo(
+    () => [
+      html(),
+      EditorView.lineWrapping,
+      EditorView.theme({
+        "&": {
+          fontSize: "var(--mantine-font-size-sm)",
+        },
+        ".cm-content": {
+          fontFamily:
+            'ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace',
+          padding: "0 1rem 20vh",
+        },
+        ".cm-gutters": {
+          border: "none",
+          background: "transparent",
+        },
+        ".cm-line": {
+          lineHeight: "1.65",
+        },
+        "&.cm-focused": {
+          outline: "none",
+        },
+      }),
+    ],
+    [],
   );
 
   return (
     <div className={classes.sourceEditorWrapper}>
-      <textarea
-        ref={textareaRef}
-        className={classes.sourceTextarea}
-        value={sourceContent}
-        onChange={(e) => setSourceContent(e.target.value)}
-        onKeyDown={handleKeyDown}
-        spellCheck={false}
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
+      <CodeMirror
+        ref={cmRef}
+        value={initialValue}
+        onChange={handleChange}
+        extensions={extensions}
+        theme={colorScheme === "dark" ? "dark" : "light"}
+        basicSetup={{
+          lineNumbers: true,
+          foldGutter: true,
+          highlightActiveLine: true,
+          bracketMatching: true,
+          indentOnInput: true,
+          tabSize: 2,
+          searchKeymap: true,
+        }}
+        autoFocus
       />
     </div>
   );

--- a/apps/client/src/features/editor/styles/source-editor.module.css
+++ b/apps/client/src/features/editor/styles/source-editor.module.css
@@ -1,27 +1,11 @@
 .sourceEditorWrapper {
     width: 100%;
-}
-
-.sourceTextarea {
-    display: block;
-    width: 100%;
     min-height: 70vh;
-    /* Match ProseMirror's horizontal padding so the text aligns with the
-       rich-text editor above and below the toggle. */
-    padding: 0 3rem 20vh;
-    font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace;
-    font-size: var(--mantine-font-size-sm);
-    line-height: 1.65;
-    resize: none;
-    border: none;
-    outline: none;
-    background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
-    color: light-dark(var(--mantine-color-default-color), var(--mantine-color-white));
-    tab-size: 2;
-    white-space: pre-wrap;
 
     @media (max-width: $mantine-breakpoint-sm) {
-        padding-left: 1rem;
-        padding-right: 1rem;
+        :global(.cm-content) {
+            padding-left: 1rem !important;
+            padding-right: 1rem !important;
+        }
     }
 }

--- a/apps/client/src/features/editor/styles/source-editor.module.css
+++ b/apps/client/src/features/editor/styles/source-editor.module.css
@@ -1,0 +1,27 @@
+.sourceEditorWrapper {
+    width: 100%;
+}
+
+.sourceTextarea {
+    display: block;
+    width: 100%;
+    min-height: 70vh;
+    /* Match ProseMirror's horizontal padding so the text aligns with the
+       rich-text editor above and below the toggle. */
+    padding: 0 3rem 20vh;
+    font-family: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace;
+    font-size: var(--mantine-font-size-sm);
+    line-height: 1.65;
+    resize: none;
+    border: none;
+    outline: none;
+    background-color: light-dark(var(--mantine-color-white), var(--mantine-color-dark-7));
+    color: light-dark(var(--mantine-color-default-color), var(--mantine-color-white));
+    tab-size: 2;
+    white-space: pre-wrap;
+
+    @media (max-width: $mantine-breakpoint-sm) {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+}

--- a/apps/client/src/features/page/components/header/page-header-menu.tsx
+++ b/apps/client/src/features/page/components/header/page-header-menu.tsx
@@ -2,6 +2,7 @@ import { ActionIcon, Group, Menu, Text, Tooltip } from "@mantine/core";
 import {
   IconArrowRight,
   IconArrowsHorizontal,
+  IconCode,
   IconDots,
   IconFileExport,
   IconHistory,
@@ -33,6 +34,7 @@ import ExportModal from "@/components/common/export-modal";
 import { htmlToMarkdown } from "@docmost/editor-ext";
 import {
   pageEditorAtom,
+  sourceModeAtom,
   yjsConnectionStatusAtom,
 } from "@/features/editor/atoms/editor-atoms.ts";
 import { formattedDate } from "@/lib/time.ts";
@@ -47,6 +49,7 @@ interface PageHeaderMenuProps {
 export default function PageHeaderMenu({ readOnly }: PageHeaderMenuProps) {
   const { t } = useTranslation();
   const toggleAside = useToggleAside();
+  const [sourceMode, setSourceMode] = useAtom(sourceModeAtom);
 
   useHotkeys(
     [
@@ -74,6 +77,22 @@ export default function PageHeaderMenu({ readOnly }: PageHeaderMenuProps) {
       <ConnectionWarning />
 
       {!readOnly && <PageStateSegmentedControl size="xs" />}
+
+      {!readOnly && (
+        <Tooltip
+          label={sourceMode ? t("Rich text") : t("Source")}
+          openDelay={250}
+          withArrow
+        >
+          <ActionIcon
+            variant={sourceMode ? "filled" : "default"}
+            style={{ border: "none" }}
+            onClick={() => setSourceMode((v) => !v)}
+          >
+            <IconCode size={20} stroke={2} />
+          </ActionIcon>
+        </Tooltip>
+      )}
 
       <PageShareModal readOnly={readOnly} />
 


### PR DESCRIPTION
Adds a toggleable source mode to the page editor that lets users view and edit the page's HTML directly. Useful for debugging, fixing formatting issues, or precise content editing that's hard to do in WYSIWYG mode.

I implemented it because it was not possible to change the URL for an already existing image. I could only remove it and paste it again.
Also, my first iteration was a markdown editor, but some elements like tables might have custom styling to it - so editing it in markdown would lead to information loss. Therefore, it's now a raw HTML editor.

<img width="758" height="275" alt="image" src="https://github.com/user-attachments/assets/0b174b45-6b3d-47bd-a1fb-e7c2efd9d5c2" />


## How it works

- Click the `</>` (code) icon in the page header to toggle between rich-text and source mode
- Source mode shows the TipTap HTML in a CodeMirror editor with syntax highlighting, line numbers, code folding, and bracket matching
- A lightweight HTML pretty-printer formats the raw TipTap output for readability (indentation around block elements)
- On switching back, the edited HTML is applied directly to the TipTap editor via `setContent()`
- The rich-text editor stays mounted (hidden via CSS) while in source mode so the Tiptap/Y.js instance remains alive
- Source mode resets automatically when navigating to a different page

## Changes

**New files:**
- `apps/client/src/features/editor/source-editor.tsx` — CodeMirror-based HTML source editor with pretty-printer, theme matching, and proper cleanup on unmount
- `apps/client/src/features/editor/styles/source-editor.module.css` — Wrapper styles with responsive padding

**Modified files:**
- `apps/client/package.json` — Added `@uiw/react-codemirror` and `@codemirror/lang-html` dependencies
- `apps/client/src/features/editor/atoms/editor-atoms.ts` — Added `sourceModeAtom`
- `apps/client/src/features/editor/full-editor.tsx` — Conditionally renders SourceEditor; keeps PageEditor mounted but hidden in source mode
- `apps/client/src/features/page/components/header/page-header-menu.tsx` — Added source toggle button (`IconCode`) next to the page state control

## Design decisions

- **HTML, not Markdown**: Editing HTML directly avoids lossy markdown round-trips (not all TipTap node types have clean markdown equivalents). What you see is what TipTap stores.
- **CodeMirror**: Provides syntax highlighting, folding, bracket matching, and search out of the box — much better UX than a plain textarea for editing HTML.
- **PageEditor stays mounted**: Unmounting destroys the Tiptap instance, which means `setContent()` on switch-back would silently fail. Hiding with `display: none` keeps Y.js alive.
- **Uncontrolled CodeMirror**: Uses `initialValue` + `onChange` ref pattern instead of a controlled `value` prop, so Y.js editor recreation doesn't clobber user edits mid-session.
- **Only shown for editable pages**: The toggle button is hidden on read-only pages.