### PR TITLE
fix: notification items are now real links

### DIFF
--- a/apps/client/src/features/notification/components/notification-item.tsx
+++ b/apps/client/src/features/notification/components/notification-item.tsx
@@ -13,7 +13,7 @@ import {
 import { CustomAvatar } from "@/components/ui/custom-avatar";
 import { INotification } from "../types/notification.types";
 import { Trans, useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useState } from "react";
 import { useMarkReadMutation } from "../queries/notification-query";
 import { buildPageUrl } from "@/features/page/page.utils";
@@ -30,7 +30,6 @@ export function NotificationItem({
   onNavigate,
 }: NotificationItemProps) {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const markRead = useMarkReadMutation();
   const [hovered, setHovered] = useState(false);
 
@@ -55,32 +54,39 @@ export function NotificationItem({
     }
   };
 
-  const handleClick = () => {
-    if (notification.page && notification.space) {
-      if (isUnread) {
-        markRead.mutate([notification.id]);
-      }
-      navigate(
-        buildPageUrl(
+  const pageUrl =
+    notification.page && notification.space
+      ? buildPageUrl(
           notification.space.slug,
           notification.page.slugId,
           notification.page.title,
-        ),
-      );
-      onNavigate();
-    }
-  };
+        )
+      : undefined;
 
-  const handleMarkRead = (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const markReadIfNeeded = () => {
     if (isUnread) {
       markRead.mutate([notification.id]);
     }
   };
 
+  const handleClick = () => {
+    markReadIfNeeded();
+    onNavigate();
+  };
+
+  const handleMarkRead = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    markReadIfNeeded();
+  };
+
   return (
     <UnstyledButton
+      component={Link}
+      to={pageUrl ?? ""}
       onClick={handleClick}
+      // auxclick fires for all non-primary buttons; guard to middle-click only (button 1)
+      // so that right-click (button 2, context menu) does not mark as read
+      onAuxClick={(e: React.MouseEvent) => e.button === 1 && markReadIfNeeded()}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       w="100%"

--- a/apps/client/src/features/notification/notification.module.css
+++ b/apps/client/src/features/notification/notification.module.css
@@ -1,4 +1,5 @@
 .notificationItem {
+  display: block;
   padding: 8px 12px;
   border-radius: 4px;
   cursor: pointer;


### PR DESCRIPTION
## Summary

- Notification items in the notification panel were rendered as `<button>` elements with a `useNavigate()` click handler, making it impossible to open them in a new tab or window.
- Replaced `UnstyledButton` (button) with `UnstyledButton component={Link}` so each item renders as a real `<a>` element — the browser handles all navigation natively.
- Regular left-click still uses SPA navigation and closes the popover.
- Ctrl/Cmd/Shift+click and middle-click open the page in a new tab; all of these mark the notification as read.
- Right-click (context menu) does **not** mark as read.
- Added `display: block` to the CSS class to fix layout regression caused by `<a>` defaulting to `display: inline` (unlike `<button>`).

## Notes

> ⚠️ This code was written by an AI assistant (Claude) and has been manually tested by a human. Please review carefully before merging.

## Test plan

- [ ] Left-click a notification — navigates in-place, marks as read, closes popover
- [ ] Ctrl/Cmd+click — opens in new tab, marks as read
- [ ] Middle-click — opens in new tab, marks as read
- [ ] Right-click — opens context menu, does **not** mark as read
- [ ] Notification items display correctly (no extra spacing, hover highlight is a single block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)