### PR TITLE
feat: add dedicated search results page with breadcrumbs

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -34,6 +34,7 @@ import SpacesPage from "@/pages/spaces/spaces.tsx";
 import { MfaChallengePage } from "@/ee/mfa/pages/mfa-challenge-page";
 import { MfaSetupRequiredPage } from "@/ee/mfa/pages/mfa-setup-required-page";
 import SpaceTrash from "@/pages/space/space-trash.tsx";
+import SearchPage from "@/pages/search/search-page.tsx";
 import UserApiKeys from "@/ee/api-key/pages/user-api-keys";
 import WorkspaceApiKeys from "@/ee/api-key/pages/workspace-api-keys";
 import AiSettings from "@/ee/ai/pages/ai-settings.tsx";
@@ -81,6 +82,7 @@ export default function App() {
 
         <Route element={<Layout />}>
           <Route path={"/home"} element={<Home />} />
+          <Route path={"/search"} element={<SearchPage />} />
           <Route path={"/spaces"} element={<SpacesPage />} />
           <Route path={"/s/:spaceSlug"} element={<SpaceHome />} />
           <Route path={"/s/:spaceSlug/trash"} element={<SpaceTrash />} />

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -35,6 +35,7 @@ import SpacesPage from "@/pages/spaces/spaces.tsx";
 import { MfaChallengePage } from "@/ee/mfa/pages/mfa-challenge-page";
 import { MfaSetupRequiredPage } from "@/ee/mfa/pages/mfa-setup-required-page";
 import SpaceTrash from "@/pages/space/space-trash.tsx";
+import SearchPage from "@/pages/search/search-page.tsx";
 import UserApiKeys from "@/ee/api-key/pages/user-api-keys";
 import WorkspaceApiKeys from "@/ee/api-key/pages/workspace-api-keys";
 import AiSettings from "@/ee/ai/pages/ai-settings.tsx";
@@ -91,6 +92,7 @@ export default function App() {
           <Route path={"/home"} element={<Home />} />
           <Route path={"/ai"} element={<AiChat />} />
           <Route path={"/ai/chat/:chatId"} element={<AiChat />} />
+          <Route path={"/search"} element={<SearchPage />} />
           <Route path={"/spaces"} element={<SpacesPage />} />
           <Route path={"/favorites"} element={<FavoritesPage />} />
           <Route path={"/labels/:labelName"} element={<LabelPage />} />

--- a/apps/client/src/features/search/components/search-spotlight.tsx
+++ b/apps/client/src/features/search/components/search-spotlight.tsx
@@ -5,7 +5,8 @@ import React, { useState, useMemo, useEffect } from "react";
 import { useDebouncedValue } from "@mantine/hooks";
 import { useTranslation } from "react-i18next";
 import { notifications } from "@mantine/notifications";
-import { searchSpotlightStore } from "../constants.ts";
+import { Link, useNavigate } from "react-router-dom";
+import { searchSpotlight, searchSpotlightStore } from "../constants.ts";
 import { SearchSpotlightFilters } from "./search-spotlight-filters.tsx";
 import { useUnifiedSearch } from "../hooks/use-unified-search.ts";
 import { useAiSearch } from "../../../ee/ai/hooks/use-ai-search.ts";
@@ -19,6 +20,7 @@ interface SearchSpotlightProps {
 }
 export function SearchSpotlight({ spaceId }: SearchSpotlightProps) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const hasAiFeature = useHasFeature(Feature.AI);
   const hasAttachmentIndexing = useHasFeature(Feature.ATTACHMENT_INDEXING);
   const [query, setQuery] = useState("");
@@ -110,9 +112,24 @@ export function SearchSpotlight({ spaceId }: SearchSpotlightProps) {
     }
   };
 
+  const buildSearchPageUrl = () => {
+    const params = new URLSearchParams();
+    if (query.trim()) params.set("q", query.trim());
+    if (filters.spaceId) params.set("spaceId", filters.spaceId);
+    if (filters.contentType && filters.contentType !== "page")
+      params.set("type", filters.contentType);
+    return `/search?${params.toString()}`;
+  };
+
+  const handleNavigateToSearchPage = () => {
+    if (query.trim()) {
+      searchSpotlight.close();
+      navigate(buildSearchPageUrl());
+    }
+  };
+
   return (
-    <>
-      <Spotlight.Root
+    <Spotlight.Root
         size="xl"
         maxHeight={600}
         store={searchSpotlightStore}
@@ -132,6 +149,9 @@ export function SearchSpotlight({ spaceId }: SearchSpotlightProps) {
               if (e.key === "Enter" && isAiMode && query.trim() && !isAiLoading) {
                 e.preventDefault();
                 handleAiSearchTrigger();
+              } else if (e.key === "Enter" && !isAiMode && query.trim()) {
+                e.preventDefault();
+                handleNavigateToSearchPage();
               }
             }}
           />
@@ -189,11 +209,28 @@ export function SearchSpotlight({ spaceId }: SearchSpotlightProps) {
                 <Spotlight.Empty>{t("No results found...")}</Spotlight.Empty>
               )}
 
-              {resultItems.length > 0 && <>{resultItems}</>}
+              {resultItems.length > 0 && (
+                <>
+                  {resultItems}
+                  <Spotlight.Action
+                    component={Link}
+                    //@ts-ignore
+                    to={buildSearchPageUrl()}
+                    onClick={() => searchSpotlight.close()}
+                    style={{ borderTop: "1px solid var(--mantine-color-default-border)" }}
+                  >
+                    <Group gap="xs" justify="center" w="100%">
+                      <IconSearch size={14} />
+                      <span style={{ fontSize: 13 }}>
+                        {t("View all results for \"{{query}}\"", { query })}
+                      </span>
+                    </Group>
+                  </Spotlight.Action>
+                </>
+              )}
             </>
           )}
         </Spotlight.ActionsList>
       </Spotlight.Root>
-    </>
   );
 }

--- a/apps/client/src/features/search/types/search.types.ts
+++ b/apps/client/src/features/search/types/search.types.ts
@@ -3,6 +3,13 @@ import { IGroup } from "@/features/group/types/group.types.ts";
 import { ISpace } from "@/features/space/types/space.types.ts";
 import { IPage } from "@/features/page/types/page.types.ts";
 
+export interface IPageBreadcrumb {
+  id: string;
+  slugId: string;
+  title: string;
+  icon: string;
+}
+
 export interface IPageSearch {
   id: string;
   title: string;
@@ -15,6 +22,7 @@ export interface IPageSearch {
   rank: string;
   highlight: string;
   space: Partial<ISpace>;
+  breadcrumbs?: IPageBreadcrumb[];
 }
 
 export interface SearchSuggestionParams {
@@ -36,6 +44,8 @@ export interface IPageSearchParams {
   query: string;
   spaceId?: string;
   shareId?: string;
+  limit?: number;
+  offset?: number;
 }
 
 export interface IAttachmentSearch {

--- a/apps/client/src/pages/search/search-page.tsx
+++ b/apps/client/src/pages/search/search-page.tsx
@@ -1,0 +1,506 @@
+import React, { useEffect, useState } from "react";
+import {
+  ActionIcon,
+  Anchor,
+  Badge,
+  Box,
+  Button,
+  Center,
+  Container,
+  Divider,
+  Group,
+  Loader,
+  Menu,
+  ScrollArea,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+  Tooltip,
+  getDefaultZIndex,
+} from "@mantine/core";
+import { useDebouncedValue } from "@mantine/hooks";
+import { Link, useSearchParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Helmet } from "react-helmet-async";
+import {
+  IconBuilding,
+  IconCheck,
+  IconChevronDown,
+  IconChevronLeft,
+  IconChevronRight,
+  IconFile,
+  IconFileDescription,
+  IconSearch,
+} from "@tabler/icons-react";
+import DOMPurify from "dompurify";
+import { buildPageUrl } from "@/features/page/page.utils";
+import { getAppName } from "@/lib/config";
+import { getPageIcon } from "@/lib";
+import { useUnifiedSearch } from "@/features/search/hooks/use-unified-search";
+import { useGetSpacesQuery } from "@/features/space/queries/space-query";
+import { useHasFeature } from "@/ee/hooks/use-feature";
+import { Feature } from "@/ee/features";
+import {
+  IAttachmentSearch,
+  IPageBreadcrumb,
+  IPageSearch,
+} from "@/features/search/types/search.types";
+
+const PAGE_SIZE = 25;
+
+export default function SearchPage() {
+  const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const hasAttachmentIndexing = useHasFeature(Feature.ATTACHMENT_INDEXING);
+
+  const initialQuery = searchParams.get("q") || "";
+  const initialSpaceId = searchParams.get("spaceId") || null;
+  const initialType = searchParams.get("type") || "page";
+  const initialPage = parseInt(searchParams.get("page") || "1", 10);
+
+  const [inputValue, setInputValue] = useState(initialQuery);
+  const [debouncedQuery] = useDebouncedValue(inputValue, 300);
+
+  const [selectedSpaceId, setSelectedSpaceId] = useState<string | null>(
+    initialSpaceId,
+  );
+  const [contentType, setContentType] = useState(initialType);
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const [spaceSearchQuery, setSpaceSearchQuery] = useState("");
+  const [debouncedSpaceQuery] = useDebouncedValue(spaceSearchQuery, 300);
+
+  const { data: spacesData } = useGetSpacesQuery({
+    limit: 100,
+    query: debouncedSpaceQuery,
+  });
+
+  const selectedSpace = spacesData?.items?.find(
+    (s) => s.id === selectedSpaceId,
+  );
+
+  // Reset page when query/filters change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [debouncedQuery, selectedSpaceId, contentType]);
+
+  // Keep URL params in sync
+  useEffect(() => {
+    const params: Record<string, string> = {};
+    if (debouncedQuery) params.q = debouncedQuery;
+    if (selectedSpaceId) params.spaceId = selectedSpaceId;
+    if (contentType !== "page") params.type = contentType;
+    if (currentPage > 1) params.page = String(currentPage);
+    setSearchParams(params, { replace: true });
+  }, [debouncedQuery, selectedSpaceId, contentType, currentPage, setSearchParams]);
+
+  const offset = (currentPage - 1) * PAGE_SIZE;
+
+  const { data: results, isLoading } = useUnifiedSearch(
+    {
+      query: debouncedQuery,
+      spaceId: selectedSpaceId || undefined,
+      contentType,
+      limit: PAGE_SIZE,
+      offset,
+    },
+    !!debouncedQuery,
+  );
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    setCurrentPage(1);
+  };
+
+  const isAttachmentSearch =
+    contentType === "attachment" && hasAttachmentIndexing;
+
+  const contentTypeOptions = [
+    { value: "page", label: t("Pages") },
+    {
+      value: "attachment",
+      label: t("Attachments"),
+      disabled: !hasAttachmentIndexing,
+    },
+  ];
+
+  const hasMore = (results?.length || 0) === PAGE_SIZE;
+  const hasPrev = currentPage > 1;
+
+  return (
+    <>
+      <Helmet>
+        <title>
+          {debouncedQuery
+            ? `${t("Search")}: ${debouncedQuery}`
+            : t("Search")}{" "}
+          - {getAppName()}
+        </title>
+      </Helmet>
+
+      <Container size="800" pt="xl" pb="xl">
+        <Title order={3} mb="lg">
+          {t("Search")}
+        </Title>
+
+        {/* Search input */}
+        <form onSubmit={handleSearch}>
+          <TextInput
+            size="md"
+            leftSection={<IconSearch size={18} />}
+            placeholder={t("Search...")}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.currentTarget.value)}
+            autoFocus
+            mb="md"
+          />
+        </form>
+
+        {/* Filters */}
+        <Group mb="lg" gap="xs">
+          {/* Space filter */}
+          <Menu
+            shadow="md"
+            width={250}
+            position="bottom-start"
+            zIndex={getDefaultZIndex("popover")}
+          >
+            <Menu.Target>
+              <Button
+                variant="light"
+                color="gray"
+                size="sm"
+                rightSection={<IconChevronDown size={14} />}
+                leftSection={<IconBuilding size={16} />}
+              >
+                {selectedSpaceId
+                  ? `${t("Space")}: ${selectedSpace?.name || t("Unknown")}`
+                  : `${t("Space")}: ${t("All spaces")}`}
+              </Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+              <TextInput
+                placeholder={t("Find a space")}
+                autoFocus
+                leftSection={<IconSearch size={16} />}
+                value={spaceSearchQuery}
+                onChange={(e) => setSpaceSearchQuery(e.target.value)}
+                size="sm"
+                variant="filled"
+                radius="sm"
+                m="xs"
+              />
+              <ScrollArea.Autosize mah={280}>
+                <Menu.Item onClick={() => setSelectedSpaceId(null)}>
+                  <Group gap="xs">
+                    <Text size="sm" style={{ flex: 1 }}>
+                      {t("All spaces")}
+                    </Text>
+                    {!selectedSpaceId && <IconCheck size={16} />}
+                  </Group>
+                </Menu.Item>
+                <Divider my="xs" />
+                {(spacesData?.items || []).map((space) => (
+                  <Menu.Item
+                    key={space.id}
+                    onClick={() => setSelectedSpaceId(space.id)}
+                  >
+                    <Group gap="xs">
+                      <Text size="sm" style={{ flex: 1 }} truncate>
+                        {space.name}
+                      </Text>
+                      {selectedSpaceId === space.id && (
+                        <IconCheck size={16} />
+                      )}
+                    </Group>
+                  </Menu.Item>
+                ))}
+              </ScrollArea.Autosize>
+            </Menu.Dropdown>
+          </Menu>
+
+          {/* Type filter */}
+          <Menu
+            shadow="md"
+            width={200}
+            position="bottom-start"
+            zIndex={getDefaultZIndex("popover")}
+          >
+            <Menu.Target>
+              <Button
+                variant="light"
+                color="gray"
+                size="sm"
+                rightSection={<IconChevronDown size={14} />}
+                leftSection={<IconFileDescription size={16} />}
+              >
+                {contentType === "page" ? t("Pages") : t("Attachments")}
+              </Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+              {contentTypeOptions.map((opt) => (
+                <Menu.Item
+                  key={opt.value}
+                  disabled={opt.disabled}
+                  onClick={() => !opt.disabled && setContentType(opt.value)}
+                >
+                  <Group gap="xs">
+                    <div style={{ flex: 1 }}>
+                      <Text size="sm">{opt.label}</Text>
+                      {opt.disabled && (
+                        <Badge size="xs" mt={2}>
+                          {t("Enterprise")}
+                        </Badge>
+                      )}
+                    </div>
+                    {contentType === opt.value && <IconCheck size={16} />}
+                  </Group>
+                </Menu.Item>
+              ))}
+            </Menu.Dropdown>
+          </Menu>
+        </Group>
+
+        {/* Results */}
+        {!debouncedQuery && (
+          <Center py="xl">
+            <Text c="dimmed">{t("Start typing to search...")}</Text>
+          </Center>
+        )}
+
+        {debouncedQuery && isLoading && (
+          <Center py="xl">
+            <Loader size="sm" />
+          </Center>
+        )}
+
+        {debouncedQuery && !isLoading && (results?.length || 0) === 0 && (
+          <Center py="xl">
+            <Text c="dimmed">{t("No results found...")}</Text>
+          </Center>
+        )}
+
+        {(results?.length || 0) > 0 && (
+          <Stack gap={0}>
+            <Text size="sm" c="dimmed" mb="sm">
+              {t("Results for \"{{query}}\"", { query: debouncedQuery })}
+              {currentPage > 1 && ` — ${t("page {{page}}", { page: currentPage })}`}
+            </Text>
+
+            {results!.map((result, i) =>
+              isAttachmentSearch ? (
+                <AttachmentResultCard
+                  key={result.id}
+                  result={result as IAttachmentSearch}
+                  showDivider={i < results!.length - 1}
+                />
+              ) : (
+                <PageResultCard
+                  key={result.id}
+                  result={result as IPageSearch}
+                  showDivider={i < results!.length - 1}
+                  showSpace={!selectedSpaceId}
+                />
+              ),
+            )}
+
+            {/* Pagination */}
+            <Group justify="center" mt="xl" gap="xs">
+              <Tooltip label={t("Previous page")} withArrow>
+                <ActionIcon
+                  variant="default"
+                  disabled={!hasPrev}
+                  onClick={() => setCurrentPage((p) => p - 1)}
+                  aria-label={t("Previous page")}
+                >
+                  <IconChevronLeft size={16} />
+                </ActionIcon>
+              </Tooltip>
+
+              <Text size="sm" c="dimmed" px="xs">
+                {t("Page {{page}}", { page: currentPage })}
+              </Text>
+
+              <Tooltip label={t("Next page")} withArrow>
+                <ActionIcon
+                  variant="default"
+                  disabled={!hasMore}
+                  onClick={() => setCurrentPage((p) => p + 1)}
+                  aria-label={t("Next page")}
+                >
+                  <IconChevronRight size={16} />
+                </ActionIcon>
+              </Tooltip>
+            </Group>
+          </Stack>
+        )}
+      </Container>
+    </>
+  );
+}
+
+function PageResultCard({
+  result,
+  showDivider,
+  showSpace,
+}: {
+  result: IPageSearch;
+  showDivider: boolean;
+  showSpace: boolean;
+}) {
+  const { t } = useTranslation();
+  const url = buildPageUrl(result.space.slug, result.slugId, result.title);
+
+  return (
+    <>
+      <Box
+        component={Link}
+        to={url}
+        style={{
+          display: "block",
+          textDecoration: "none",
+          color: "inherit",
+          padding: "12px 0",
+          borderRadius: 8,
+        }}
+      >
+        <Group gap="xs" mb={4} wrap="nowrap">
+          <Box style={{ flexShrink: 0 }}>{getPageIcon(result.icon)}</Box>
+          <Text fw={600} size="md" style={{ flex: 1 }} lineClamp={1}>
+            {result.title || t("Untitled")}
+          </Text>
+        </Group>
+
+        <Group gap={4} mb={6} ml={24} wrap="nowrap" align="center">
+          {showSpace && result.space?.name && (
+            <Badge variant="light" size="xs" color="blue" style={{ flexShrink: 0 }}>
+              {result.space.name}
+            </Badge>
+          )}
+          {(result.breadcrumbs ?? []).map((crumb, i) => (
+            <React.Fragment key={crumb.id}>
+              <Text size="xs" c="dimmed" style={{ flexShrink: 0 }}>/</Text>
+              <Anchor
+                component={Link}
+                to={buildPageUrl(result.space.slug, crumb.slugId, crumb.title)}
+                size="xs"
+                c="dimmed"
+                underline="hover"
+                onClick={(e) => e.stopPropagation()}
+                style={{ flexShrink: 0 }}
+              >
+                {crumb.icon ? `${crumb.icon} ${crumb.title || t("Untitled")}` : (crumb.title || t("Untitled"))}
+              </Anchor>
+            </React.Fragment>
+          ))}
+          <Text size="xs" c="dimmed" style={{ flexShrink: 0 }}>·</Text>
+          <Text size="xs" c="dimmed" style={{ flexShrink: 0 }}>
+            {t("Updated")} {new Date(result.updatedAt).toLocaleDateString()}
+          </Text>
+        </Group>
+
+        {result.highlight && (
+          <Text
+            size="sm"
+            c="dimmed"
+            ml={24}
+            lineClamp={3}
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(result.highlight, {
+                ALLOWED_TAGS: ["mark", "em", "strong", "b"],
+                ALLOWED_ATTR: [],
+              }),
+            }}
+          />
+        )}
+      </Box>
+      {showDivider && <Divider />}
+    </>
+  );
+}
+
+function AttachmentResultCard({
+  result,
+  showDivider,
+}: {
+  result: IAttachmentSearch;
+  showDivider: boolean;
+}) {
+  const { t } = useTranslation();
+  const pageUrl = buildPageUrl(
+    result.space.slug,
+    result.page.slugId,
+    result.page.title,
+  );
+  const downloadUrl = `/api/files/${result.id}/${result.fileName}`;
+
+  return (
+    <>
+      <Box
+        component={Link}
+        to={pageUrl}
+        style={{
+          display: "block",
+          textDecoration: "none",
+          color: "inherit",
+          padding: "12px 0",
+          borderRadius: 8,
+        }}
+      >
+        <Group gap="xs" mb={4} wrap="nowrap">
+          <Box style={{ flexShrink: 0 }}>
+            <IconFile size={18} />
+          </Box>
+          <Text fw={600} size="md" style={{ flex: 1 }} lineClamp={1}>
+            {result.fileName}
+          </Text>
+          <Tooltip label={t("Download attachment")} withArrow>
+            <ActionIcon
+              component="a"
+              href={downloadUrl}
+              target="_blank"
+              rel="noreferrer"
+              variant="subtle"
+              color="gray"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <IconFile size={16} />
+            </ActionIcon>
+          </Tooltip>
+        </Group>
+
+        <Group gap="xs" mb={6} ml={24}>
+          {result.space?.name && (
+            <Badge variant="light" size="xs" color="blue">
+              {result.space.name}
+            </Badge>
+          )}
+          {result.page?.title && (
+            <Badge variant="light" size="xs" color="gray">
+              {result.page.title}
+            </Badge>
+          )}
+          <Text size="xs" c="dimmed">
+            {t("Updated")} {new Date(result.updatedAt).toLocaleDateString()}
+          </Text>
+        </Group>
+
+        {result.highlight && (
+          <Text
+            size="sm"
+            c="dimmed"
+            ml={24}
+            lineClamp={3}
+            dangerouslySetInnerHTML={{
+              __html: DOMPurify.sanitize(result.highlight, {
+                ALLOWED_TAGS: ["mark", "em", "strong", "b"],
+                ALLOWED_ATTR: [],
+              }),
+            }}
+          />
+        )}
+      </Box>
+      {showDivider && <Divider />}
+    </>
+  );
+}

--- a/apps/server/src/core/search/dto/search-response.dto.ts
+++ b/apps/server/src/core/search/dto/search-response.dto.ts
@@ -1,5 +1,12 @@
 import { Space } from '@docmost/db/types/entity.types';
 
+export class BreadcrumbItemDto {
+  id: string;
+  slugId: string;
+  title: string;
+  icon: string;
+}
+
 export class SearchResponseDto {
   id: string;
   title: string;
@@ -11,4 +18,5 @@ export class SearchResponseDto {
   createdAt: Date;
   updatedAt: Date;
   space: Partial<Space>;
+  breadcrumbs?: BreadcrumbItemDto[];
 }

--- a/apps/server/src/core/search/search.service.ts
+++ b/apps/server/src/core/search/search.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { SearchDTO, SearchSuggestionDTO } from './dto/search.dto';
-import { SearchResponseDto } from './dto/search-response.dto';
+import {
+  BreadcrumbItemDto,
+  SearchResponseDto,
+} from './dto/search-response.dto';
 import { InjectKysely } from 'nestjs-kysely';
 import { KyselyDB } from '@docmost/db/types/kysely.types';
 import { sql } from 'kysely';
@@ -138,6 +141,15 @@ export class SearchService {
       results = results.filter((r: any) => accessibleSet.has(r.id));
     }
 
+    const pageIdsWithParent = results
+      .filter((r: any) => r.parentPageId)
+      .map((r: any) => r.id);
+
+    const breadcrumbMap =
+      pageIdsWithParent.length > 0
+        ? await this.getBreadcrumbsForPages(pageIdsWithParent)
+        : new Map<string, BreadcrumbItemDto[]>();
+
     //@ts-ignore
     const searchResults = results.map((result: SearchResponseDto) => {
       if (result.highlight) {
@@ -145,6 +157,7 @@ export class SearchService {
           .replace(/\r\n|\r|\n/g, ' ')
           .replace(/\s+/g, ' ');
       }
+      result.breadcrumbs = breadcrumbMap.get(result.id) ?? [];
       return result;
     });
 
@@ -246,5 +259,59 @@ export class SearchService {
     }
 
     return { users, groups, pages };
+  }
+
+  private async getBreadcrumbsForPages(
+    pageIds: string[],
+  ): Promise<Map<string, BreadcrumbItemDto[]>> {
+    // Single recursive CTE to fetch all ancestors for all given page IDs at once.
+    // Each row carries origin_id (the result page it belongs to) for grouping.
+    const rows = await this.db
+      .withRecursive('page_ancestors', (db) =>
+        db
+          .selectFrom('pages')
+          .select([
+            'id',
+            'slugId',
+            'title',
+            'icon',
+            'parentPageId',
+            sql<string>`id`.as('origin_id'),
+          ])
+          .where('id', 'in', pageIds)
+          .where('deletedAt', 'is', null)
+          .unionAll((exp) =>
+            exp
+              .selectFrom('pages as p')
+              .select([
+                'p.id',
+                'p.slugId',
+                'p.title',
+                'p.icon',
+                'p.parentPageId',
+                sql<string>`pa."origin_id"`.as('origin_id'),
+              ])
+              .innerJoin('page_ancestors as pa', 'pa.parentPageId', 'p.id')
+              .where('p.deletedAt', 'is', null),
+          ),
+      )
+      .selectFrom('page_ancestors')
+      .select(['id', 'slugId', 'title', 'icon', sql<string>`"origin_id"`.as('originId')])
+      // Exclude the page itself — only keep its ancestors
+      .where(sql<boolean>`page_ancestors.id != page_ancestors."origin_id"`)
+      .execute();
+
+    // Group ancestor rows by originId; reverse so root comes first
+    const map = new Map<string, BreadcrumbItemDto[]>();
+    for (const row of rows as any[]) {
+      const list = map.get(row.originId) ?? [];
+      list.push({ id: row.id, slugId: row.slugId, title: row.title, icon: row.icon });
+      map.set(row.originId, list);
+    }
+    // The CTE walks child→parent, so rows are deepest-first; reverse for root-first order
+    for (const [key, list] of map.entries()) {
+      map.set(key, list.reverse());
+    }
+    return map;
   }
 }


### PR DESCRIPTION
## Summary

- Adds a dedicated `/search` page that shows richer results than the spotlight modal: page icon, space badge, ancestor breadcrumb trail, last-updated date, and highlighted content snippets
- All result items are standard anchor links, so middle-click and Ctrl+click open pages in a new tab (this was not possible with the `Spotlight.Action` components)
- Results are paginated (25 per page) with query and filters (space, content type) reflected in the URL, making search results bookmarkable and shareable
- Breadcrumbs are fetched server-side in a single recursive CTE alongside the main search query — no extra round-trips
- The search spotlight gains two entry points to the new page: pressing Enter navigates there directly, and a "View all results for ..." footer link appears below the result list

Relates to #1217 — while that issue asks for breadcrumbs in the spotlight itself, this PR takes a complementary approach: a full search results page where there is more room to display breadcrumbs and other metadata clearly.

<img width="3172" height="2380" alt="Screen Shot 2026-03-20 at 18 19 25" src="https://github.com/user-attachments/assets/d3b9d2c0-c708-4b31-b684-498018259d08" />

## ⚠️ AI-generated code

This code was written by [Claude Code](https://claude.com/claude-code) and has been tested by a human, but **please review it carefully** before merging. Mistakes may have slipped through that a human author would not have made.

## Test plan

- [ ] Open the search spotlight (Ctrl+K), type a query, press Enter → lands on `/search?q=...`
- [ ] Type a query in the spotlight, click "View all results for ..." → same navigation, middle-click opens in new tab
- [ ] On the search page, results for nested pages show the full ancestor breadcrumb (e.g. `Architecture Overview / API Design / Authentication`)
- [ ] Breadcrumb links navigate to the correct ancestor page; middle-click opens them in a new tab
- [ ] Space and content-type filters update the URL and re-fetch results
- [ ] Pagination works; URL reflects the current page number
- [ ] Root-level pages show no breadcrumb (only space badge + date)

🤖 Generated with [Claude Code](https://claude.com/claude-code)