### PR TITLE
fix: strip trailing newlines from pasted text to prevent list breakage

### DIFF
--- a/apps/client/src/features/editor/extensions/markdown-clipboard.ts
+++ b/apps/client/src/features/editor/extensions/markdown-clipboard.ts
@@ -1,7 +1,7 @@
 // adapted from: https://github.com/aguingand/tiptap-markdown/blob/main/src/extensions/tiptap/clipboard.js - MIT
 import { Extension } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
-import { DOMParser } from "@tiptap/pm/model";
+import { DOMParser, Fragment, Slice } from "@tiptap/pm/model";
 import { find } from "linkifyjs";
 import { markdownToHtml } from "@docmost/editor-ext";
 
@@ -40,7 +40,7 @@ export const MarkdownClipboard = Extension.create({
             const { tr } = view.state;
             const { from, to } = view.state.selection;
 
-            const html = markdownToHtml(text);
+            const html = markdownToHtml(text.replace(/\n+$/, ""));
 
             const contentNodes = DOMParser.fromSchema(
               this.editor.schema,
@@ -53,6 +53,37 @@ export const MarkdownClipboard = Extension.create({
             view.dispatch(tr);
             return true;
           },
+          // Strip trailing whitespace-only paragraphs from pasted content.
+          // Terminals (GNOME Terminal, etc.) often include trailing
+          // whitespace in their HTML clipboard data, which ProseMirror
+          // parses as an extra paragraph. Inside a list item this creates
+          // an orphan empty line that breaks the list structure.
+          transformPasted: (slice) => {
+            let { content, openStart, openEnd } = slice;
+
+            // Remove trailing paragraphs that contain only whitespace
+            while (content.childCount > 1) {
+              const lastChild = content.lastChild;
+              if (
+                lastChild?.type.name === "paragraph" &&
+                lastChild.textContent.trim() === ""
+              ) {
+                const children = [];
+                for (let i = 0; i < content.childCount - 1; i++) {
+                  children.push(content.child(i));
+                }
+                content = Fragment.from(children);
+              } else {
+                break;
+              }
+            }
+
+            if (content !== slice.content) {
+              return new Slice(content, openStart, Math.max(openEnd, 1));
+            }
+
+            return slice;
+          },
           clipboardTextParser: (text, context, plainText) => {
             const link = find(text, {
               defaultProtocol: "http",
@@ -64,7 +95,7 @@ export const MarkdownClipboard = Extension.create({
               return null;
             }
 
-            const parsed = markdownToHtml(text);
+            const parsed = markdownToHtml(text.replace(/\n+$/, ""));
             return DOMParser.fromSchema(this.editor.schema).parseSlice(
               elementFromString(parsed),
               {


### PR DESCRIPTION
## Summary

- Strip trailing newlines from pasted text before markdown conversion to prevent broken list behavior
- Terminal output often ends with `\n`, which the markdown parser (with `breaks: true`) converts to a `<br>`, creating an empty line outside the list item
- This caused backspace on the empty line to incorrectly remove the previous bullet's formatting instead of joining lines

Fixes #2049

## Test plan

- [x] Create a bullet point in the editor
- [x] Paste terminal output (e.g. `uname -a`) into the bullet
- [x] Verify no extra empty line is created after the pasted text
- [x] Verify pressing Enter after the pasted text creates a new bullet point
- [x] Verify pasting markdown content from VS Code still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)