### PR TITLE
perf(db): add missing foreign key indexes

### DIFF
--- a/apps/server/src/database/migrations/20260326T191500-add-missing-fk-indexes.ts
+++ b/apps/server/src/database/migrations/20260326T191500-add-missing-fk-indexes.ts
@@ -1,0 +1,78 @@
+import { type Kysely } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createIndex('idx_page_history_page_id')
+    .ifNotExists()
+    .on('page_history')
+    .column('page_id')
+    .execute();
+
+  await db.schema
+    .createIndex('idx_group_users_user_id')
+    .ifNotExists()
+    .on('group_users')
+    .column('user_id')
+    .execute();
+
+  await db.schema
+    .createIndex('idx_space_members_user_id')
+    .ifNotExists()
+    .on('space_members')
+    .column('user_id')
+    .execute();
+
+  await db.schema
+    .createIndex('idx_space_members_group_id')
+    .ifNotExists()
+    .on('space_members')
+    .column('group_id')
+    .execute();
+
+  await db.schema
+    .createIndex('idx_attachments_page_id')
+    .ifNotExists()
+    .on('attachments')
+    .column('page_id')
+    .execute();
+
+  await db.schema
+    .createIndex('idx_attachments_workspace_id')
+    .ifNotExists()
+    .on('attachments')
+    .column('workspace_id')
+    .execute();
+
+  await db.schema
+    .createIndex('idx_backlinks_target_page_id')
+    .ifNotExists()
+    .on('backlinks')
+    .column('target_page_id')
+    .execute();
+
+  await db.schema
+    .createIndex('idx_pages_workspace_id')
+    .ifNotExists()
+    .on('pages')
+    .column('workspace_id')
+    .execute();
+
+  await db.schema
+    .createIndex('idx_pages_creator_id')
+    .ifNotExists()
+    .on('pages')
+    .column('creator_id')
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropIndex('idx_pages_creator_id').ifExists().execute();
+  await db.schema.dropIndex('idx_pages_workspace_id').ifExists().execute();
+  await db.schema.dropIndex('idx_backlinks_target_page_id').ifExists().execute();
+  await db.schema.dropIndex('idx_attachments_workspace_id').ifExists().execute();
+  await db.schema.dropIndex('idx_attachments_page_id').ifExists().execute();
+  await db.schema.dropIndex('idx_space_members_group_id').ifExists().execute();
+  await db.schema.dropIndex('idx_space_members_user_id').ifExists().execute();
+  await db.schema.dropIndex('idx_group_users_user_id').ifExists().execute();
+  await db.schema.dropIndex('idx_page_history_page_id').ifExists().execute();
+}


### PR DESCRIPTION
## Summary

Adds a dedicated migration for the missing standalone foreign-key lookup indexes described in #2047.

This keeps the change scoped to the index set proposed in the issue so the fix stays easy to review and roll back:

- `page_history.page_id`
- `group_users.user_id`
- `space_members.user_id`
- `space_members.group_id`
- `attachments.page_id`
- `attachments.workspace_id`
- `backlinks.target_page_id`
- `pages.workspace_id`
- `pages.creator_id`

I intentionally left more workload-specific partial/composite page-tree indexes out of this PR so the migration remains focused on the missing FK-style lookup indexes already discussed in the issue.

Closes #2047.

## Validation

- Ran `git diff --check`.
- Ran `corepack pnpm install --frozen-lockfile` successfully in a short-path clone to avoid Windows path-length issues during dependency extraction.
- Ran `corepack pnpm exec tsx --eval "import('./apps/server/src/database/migrations/20260326T191500-add-missing-fk-indexes.ts').then(() => console.log('MIGRATION_IMPORT_OK'))"` successfully to verify the migration module imports cleanly.
- Attempted `corepack pnpm exec tsc -p apps/server/tsconfig.build.json --noEmit`, but the fresh checkout currently fails on unrelated existing `@docmost/editor-ext` resolution errors in server files outside this migration.

## Notes

- Uses `ifNotExists()` / `ifExists()` for safer application and rollback on environments that may already have a subset of these indexes.
- Keeps the change atomic to one migration file.