### PR TITLE
fix: show correct default highlight color in color picker

### DIFF
--- a/apps/client/src/features/editor/components/bubble-menu/color-selector.tsx
+++ b/apps/client/src/features/editor/components/bubble-menu/color-selector.tsx
@@ -252,7 +252,7 @@ export const ColorSelector: FC<ColorSelectorProps> = ({
                         width: rem(28),
                         height: rem(28),
                         borderRadius: rem(4),
-                        backgroundColor: color || "var(--mantine-color-gray-2)",
+                        backgroundColor: color || "#faf594",
                         border: "1px solid var(--mantine-color-gray-4)",
                         cursor: "pointer",
                         position: "relative",


### PR DESCRIPTION
## Summary
The 'Default' highlight color swatch in the color picker dialog displayed as light gray (`var(--mantine-color-gray-2)`), which doesn't match the actual applied highlight. The default `<mark>` element renders with a yellow background, so the swatch now shows `#faf594` to accurately represent the applied highlight color.

## Issue
Fixes #2028

## Changes
- Updated the fallback `backgroundColor` in the highlight color swatch from `var(--mantine-color-gray-2)` to `#faf594` (the default highlight yellow)

## Testing
- Open a document in the editor
- Select text and open the highlight color picker
- Verify the 'Default' color swatch now shows yellow instead of gray
- Verify applying the 'Default' highlight still works correctly