### PR TITLE
fix: display pending user count on Pending tab button

### DIFF
--- a/apps/client/src/features/workspace/types/workspace.types.ts
+++ b/apps/client/src/features/workspace/types/workspace.types.ts
@@ -19,6 +19,7 @@ export interface IWorkspace {
   updatedAt: Date;
   emailDomains: string[];
   memberCount?: number;
+  invitationCount?: number;
   plan?: string;
   enforceMfa?: boolean;
   aiSearch?: boolean;

--- a/apps/client/src/pages/settings/workspace/workspace-members.tsx
+++ b/apps/client/src/pages/settings/workspace/workspace-members.tsx
@@ -57,7 +57,14 @@ export default function WorkspaceMembers() {
               label: t("Members") + ` (${workspace?.memberCount})`,
               value: "members",
             },
-            { label: t("Pending"), value: "invites" },
+            {
+              label:
+                t("Pending") +
+                (workspace?.invitationCount
+                  ? ` (${workspace.invitationCount})`
+                  : ""),
+              value: "invites",
+            },
           ]}
           withItemsBorders={false}
         />

--- a/apps/server/src/core/user/user.controller.ts
+++ b/apps/server/src/core/user/user.controller.ts
@@ -13,6 +13,8 @@ import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import { AuthWorkspace } from '../../common/decorators/auth-workspace.decorator';
 import { User, Workspace } from '@docmost/db/types/entity.types';
 import { WorkspaceRepo } from '@docmost/db/repos/workspace/workspace.repo';
+import { InjectKysely } from 'nestjs-kysely';
+import { KyselyDB } from '@docmost/db/types/kysely.types';
 
 @UseGuards(JwtAuthGuard)
 @Controller('users')
@@ -20,6 +22,7 @@ export class UserController {
   constructor(
     private readonly userService: UserService,
     private readonly workspaceRepo: WorkspaceRepo,
+    @InjectKysely() private readonly db: KyselyDB,
   ) {}
 
   @HttpCode(HttpStatus.OK)
@@ -32,11 +35,19 @@ export class UserController {
       workspace.id,
     );
 
+    const invitationResult = await this.db
+      .selectFrom('workspaceInvitations')
+      .select((eb) => eb.fn.countAll().as('count'))
+      .where('workspaceId', '=', workspace.id)
+      .executeTakeFirst();
+    const invitationCount = Number(invitationResult?.count ?? 0);
+
     const { licenseKey, ...rest } = workspace;
 
     const workspaceInfo = {
       ...rest,
       memberCount,
+      invitationCount,
     };
 
     return { user: authUser, workspace: workspaceInfo };


### PR DESCRIPTION
## Summary
Display the count of pending invitations on the Pending tab button, matching the existing behavior of the Members tab button.

## Issue
Fixes #2077

## Changes
- Added `invitationCount` to the workspace data returned by the `/users/me` API endpoint, querying the `workspaceInvitations` table
- Added `invitationCount` to the `IWorkspace` TypeScript interface
- Updated the Pending tab label to show the count (only displayed when > 0)

## Testing
- Verified that the Pending tab now shows the count consistent with the Members tab
- When there are no pending invitations, the tab shows just "Pending" without "(0)"