### PR TITLE
fix(i18n): Correct German column count label rendering

### DIFF
--- a/apps/client/public/locales/de-DE/translation.json
+++ b/apps/client/public/locales/de-DE/translation.json
@@ -370,7 +370,7 @@
   "Write anything. Enter \"/\" for commands": "Schreiben Sie irgendetwas. Geben Sie \"/\" für Befehle ein",
   "Write...": "\"Schreiben...\"",
   "Column count": "Spaltenanzahl",
-  "{{count}} Columns": "{count, plural, one {# Spalte} other {# Spalten}}",
+  "{{count}} Columns": "{{count}} Spalten",
   "Equal columns": "Gleich breite Spalten",
   "Left sidebar": "Linke Seitenleiste",
   "Right sidebar": "Rechte Seitenleiste",


### PR DESCRIPTION
## Fix German column count label rendering

The German translation for column count was using ICU plural syntax:
```
{count, plural, one {# Spalte} other {# Spalten}}
```
However, the current i18n setup (react-i18next) does not support ICU formatting, causing the raw string to be displayed in the UI.

## Fix
Replaced ICU syntax with standard i18next interpolation:
```
"{{count}} Spalten"
```

Since the UI only supports 2–5 columns, plural form is always correct.

## Result
Column count now renders correctly in German:
- 2 Spalten
- 3 Spalten
- etc.

### Before Fix - 

<img width="1596" height="428" alt="Screenshot 2026-04-27 190616" src="https://github.com/user-attachments/assets/473e7152-9606-4dcb-83e4-582b5d4dc738" />


### After Fix - 

<img width="1253" height="482" alt="Screenshot 2026-04-27 192256" src="https://github.com/user-attachments/assets/ede27466-2bbd-440d-98e1-3c7e75cf24df" />



Fixes #2130 