### PR TITLE
feat: allow hyphens and underscores in space slugs

### DIFF
--- a/apps/client/src/features/space/components/create-space-form.tsx
+++ b/apps/client/src/features/space/components/create-space-form.tsx
@@ -17,8 +17,8 @@ const formSchema = z.object({
     .min(2)
     .max(100)
     .regex(
-      /^[a-zA-Z0-9]+$/,
-      "Space slug must be alphanumeric. No special characters",
+      /^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$/,
+      "Space slug may contain letters, numbers, hyphens, or underscores, and must start and end with a letter or number",
     ),
   description: z.string().max(500),
 });

--- a/apps/client/src/features/space/components/edit-space-form.tsx
+++ b/apps/client/src/features/space/components/edit-space-form.tsx
@@ -15,8 +15,8 @@ const formSchema = z.object({
     .min(2)
     .max(100)
     .regex(
-      /^[a-zA-Z0-9]+$/,
-      "Space slug must be alphanumeric. No special characters",
+      /^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$/,
+      "Space slug may contain letters, numbers, hyphens, or underscores, and must start and end with a letter or number",
     ),
 });
 

--- a/apps/client/src/lib/utils.tsx
+++ b/apps/client/src/lib/utils.tsx
@@ -24,15 +24,18 @@ export function extractPageSlugId(slug: string): string {
 }
 
 export const computeSpaceSlug = (name: string) => {
-  const alphanumericName = name.replace(/[^a-zA-Z0-9\s]/g, "");
-  if (alphanumericName.includes(" ")) {
-    return alphanumericName
-      .split(" ")
+  const cleaned = name.replace(/[^a-zA-Z0-9_\-\s]/g, "");
+  let slug: string;
+  if (/\s/.test(cleaned.trim())) {
+    slug = cleaned
+      .split(/\s+/)
+      .filter(Boolean)
       .map((word) => word.charAt(0).toUpperCase())
       .join("");
   } else {
-    return alphanumericName.toLowerCase();
+    slug = cleaned.toLowerCase();
   }
+  return slug.replace(/^[-_]+|[-_]+$/g, "");
 };
 
 export const formatBytes = (bytes: number): string => {

--- a/apps/server/src/core/space/dto/create-space.dto.ts
+++ b/apps/server/src/core/space/dto/create-space.dto.ts
@@ -1,7 +1,7 @@
 import {
-  IsAlphanumeric,
   IsOptional,
   IsString,
+  Matches,
   MaxLength,
   MinLength,
 } from 'class-validator';
@@ -20,6 +20,9 @@ export class CreateSpaceDto {
 
   @MinLength(2)
   @MaxLength(100)
-  @IsAlphanumeric()
+  @Matches(/^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$/, {
+    message:
+      'slug must contain only letters, numbers, hyphens, or underscores, and must start and end with a letter or number',
+  })
   slug: string;
 }


### PR DESCRIPTION
## Summary

Closes #1712.

Currently space slugs are restricted to alphanumeric only. This means readable URLs like `sales-strategy` are rejected and users have to fall back to `salesstrategy`. This PR allows `-` and `_` inside the slug, while still requiring it to start and end with a letter or number.

### Changes

- **Backend** (`create-space.dto.ts`): replace `@IsAlphanumeric()` with a `@Matches` decorator using regex `^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$`.
- **Frontend** (`create-space-form.tsx`, `edit-space-form.tsx`): mirror the same regex in the Zod schemas and update the validation message.
- **Slug auto-generation** (`computeSpaceSlug` in `lib/utils.tsx`): preserve `-`/`_` in single-word names so typing `sales-strategy` produces `sales-strategy` instead of `sales`. Behavior for multi-word names (initials, e.g. `Product Team` → `PT`) is unchanged. Trailing/leading separators are stripped to keep the output valid.

### Validation rules (after this PR)

| Slug | Result |
| --- | --- |
| `sales-strategy` | accepted |
| `sales_strategy` | accepted |
| `Sales-Strategy-2024` | accepted |
| `sa--les` / `sa__les` | accepted |
| `-sales` / `sales-` | rejected |
| `_sales` / `sales_` | rejected |
| `sales` (existing) | accepted |

Min length (2), max length (100), and the case-insensitive uniqueness constraint per workspace are unchanged.

## Test plan

- [x] Create a new space with slug `sales-strategy` — succeeds
- [x] Create a new space with slug `sales_strategy` — succeeds
- [x] Create a new space with slug `-sales` — rejected client-side and server-side
- [x] Edit an existing space and change its slug to one containing `-` — succeeds, URL updates
- [x] Type `sales-strategy` as the space name during creation — slug field auto-fills with `sales-strategy`
- [x] Type `Product Team` as the space name — slug field auto-fills with `PT` (existing behavior preserved)