### PR TITLE
fix(page-permission): make people-with-access list scroll past 4 entries

### DIFF
--- a/apps/client/src/ee/page-permission/components/page-permission-list.tsx
+++ b/apps/client/src/ee/page-permission/components/page-permission-list.tsx
@@ -140,7 +140,7 @@ export function PagePermissionList({
         )}
       </Group>
 
-      <ScrollArea mah={250} viewportRef={viewportRef}>
+      <ScrollArea.Autosize mah={400} viewportRef={viewportRef}>
         {sortedMembers.map((member) => (
           <PagePermissionItem
             key={`${member.type}-${member.id}`}
@@ -158,7 +158,7 @@ export function PagePermissionList({
             <Loader size="xs" />
           </Center>
         )}
-      </ScrollArea>
+      </ScrollArea.Autosize>
     </>
   );
 }


### PR DESCRIPTION
## Summary

Closes #2135.

In the page share modal, the **"People with access"** list used `<ScrollArea mah={250}>`. `mah` caps the *container* height but does not make the inner viewport scroll on its own — Mantine's `ScrollArea` requires a fixed height for the viewport to scroll. The result: items beyond ~4 entries were rendered into the DOM correctly but clipped out of view, with no scrollbar.

### Fix

Switch to `<ScrollArea.Autosize mah={400}>`, which is Mantine's dedicated primitive for *"grow with content up to a max, then scroll"* — exactly the behavior wanted here.

Bumped the cap from 250px → 400px while we're here, since 250px is fairly tight (~4–5 rows) and pages with longer access lists are common.

### Compare with `apps/client/src/features/space/components/space-members.tsx`

That sibling list works correctly because it uses `<ScrollArea h={450}>` (fixed height). Either pattern is valid; `Autosize` was the better fit here because the access list is usually short and we don't want a tall empty box for pages with only 1–2 entries.

## Test plan

- [x] Open a page → Share → Access tab → add 6+ members/groups
- [x] All entries are visible and the list scrolls
- [x] List stays compact (no large empty area) when only 1–2 entries are present