### PR TITLE
fix: prevent code block deletion when adding inline comments in read mode 

### DIFF
--- a/apps/server/src/collaboration/yjs.util.ts
+++ b/apps/server/src/collaboration/yjs.util.ts
@@ -62,14 +62,14 @@ function applyMarkToYFragment(
 ) {
   let pos = 0;
 
-  const processItem = (item: any): boolean => {
+  const processItem = (item: any, parentNodeName?: string): boolean => {
     if (pos >= to) return false;
 
     if (item instanceof Y.XmlText) {
       const textLength = item.length;
       const itemEnd = pos + textLength;
 
-      if (itemEnd > from && pos < to) {
+      if (itemEnd > from && pos < to && parentNodeName !== 'codeBlock') {
         const formatFrom = Math.max(0, from - pos);
         const formatTo = Math.min(textLength, to - pos);
         const formatLength = formatTo - formatFrom;
@@ -82,7 +82,7 @@ function applyMarkToYFragment(
     } else if (item instanceof Y.XmlElement) {
       pos++; // Opening tag
       for (let i = 0; i < item.length; i++) {
-        if (!processItem(item.get(i))) return false;
+        if (!processItem(item.get(i), item.nodeName)) return false;
       }
       pos++; // Closing tag
     }


### PR DESCRIPTION
## Fix: prevent code block deletion when adding inline comments in read mode

### Summary

Fixes an issue where adding an inline comment in **read mode** on text inside a `codeBlock` causes the entire code block to be deleted.

---

### Root Cause

Inline comments in read mode use `yjsSelection`, which is passed to the backend and applied via:

- `setCommentMark` → `setYjsMark` → `applyMarkToYFragment`

This directly applies a mark to Yjs text nodes:

```ts
item.format(...)
```
However, codeBlock nodes do not allow marks in the ProseMirror schema.
Applying marks inside them leads to an invalid document state and results in the code block being removed.

### Fix

Skip applying comment marks when the selection is inside a `codeBlock`.

This is done by detecting the parent node (nodeName) in applyMarkToYFragment and avoiding item.format(...) when inside a codeBlock.

### Result
✅ Code block no longer gets deleted in read mode
✅ Paragraph inline comments continue to work (highlight + scroll)
⚠️ Inline highlighting inside code blocks is not supported (consistent with existing edit-mode behavior)

### After Change - 

https://github.com/user-attachments/assets/876e9ff6-957b-4c83-982f-b29f8f0bcce6



### Alternative considered (frontend-only fix)

I also tested skipping yjsSelection in the frontend:

```
if (!isCodeBlockSelection) {
  payload.yjsSelection = readOnlyCommentData.yjsSelection;
}
```

This approach was not chosen because:

- It only protects one UI path
- The issue originates from the backend applying invalid marks

Handling it in the backend ensures:

- Centralized safety
- No regression in existing functionality

### Notes

This PR focuses on preventing document corruption.

Inline highlighting inside code blocks is currently not supported (also not working in edit mode). Supporting it would require changes to the schema or decoration.

Happy to explore that separately if needed.

Fixes #2122 