### PR TITLE
feat(editor): replace emoji picker with browse + search

### DIFF
--- a/apps/client/src/features/editor/components/emoji-menu/emoji-items.ts
+++ b/apps/client/src/features/editor/components/emoji-menu/emoji-items.ts
@@ -2,6 +2,8 @@ import { CommandProps, EmojiMenuItemType } from "./types";
 import { SearchIndex } from "emoji-mart";
 import { getFrequentlyUsedEmoji, sortFrequentlyUsedEmoji } from "./utils";
 
+const MAX_EMOJI_RESULTS = 8;
+
 const searchEmoji = async (value: string): Promise<EmojiMenuItemType[]> => {
   if (value === "") {
     const frequentlyUsedEmoji = getFrequentlyUsedEmoji();
@@ -9,22 +11,18 @@ const searchEmoji = async (value: string): Promise<EmojiMenuItemType[]> => {
   }
 
   const emojis = await SearchIndex.search(value);
-  const results = emojis.map((emoji: any) => {
-    return {
-      id: emoji.id,
-      emoji: emoji.skins[0].native,
-      command: ({ editor, range }: CommandProps) => {
-        editor
-          .chain()
-          .focus()
-          .deleteRange(range)
-          .insertContent(emoji.skins[0].native + " ")
-          .run();
-      },
-    };
-  });
-
-  return results;
+  return emojis.slice(0, MAX_EMOJI_RESULTS).map((emoji: any) => ({
+    id: emoji.id,
+    emoji: emoji.skins[0].native,
+    command: ({ editor, range }: CommandProps) => {
+      editor
+        .chain()
+        .focus()
+        .deleteRange(range)
+        .insertContent(emoji.skins[0].native + " ")
+        .run();
+    },
+  }));
 };
 
 export const getEmojiItems = async ({

--- a/apps/client/src/features/editor/components/emoji-menu/emoji-items.ts
+++ b/apps/client/src/features/editor/components/emoji-menu/emoji-items.ts
@@ -1,28 +1,26 @@
 import { CommandProps, EmojiMenuItemType } from "./types";
-import { SearchIndex } from "emoji-mart";
-import { getFrequentlyUsedEmoji, sortFrequentlyUsedEmoji } from "./utils";
+import { buildEmojiIndex, getFrequentlyUsedEmoji, sortFrequentlyUsedEmoji } from "./utils";
 
-const MAX_EMOJI_RESULTS = 8;
+const MAX_RESULTS = 5;
 
-const searchEmoji = async (value: string): Promise<EmojiMenuItemType[]> => {
-  if (value === "") {
-    const frequentlyUsedEmoji = getFrequentlyUsedEmoji();
-    return sortFrequentlyUsedEmoji(frequentlyUsedEmoji);
+const searchEmoji = async (query: string): Promise<EmojiMenuItemType[]> => {
+  if (query === "") {
+    return sortFrequentlyUsedEmoji(getFrequentlyUsedEmoji());
   }
 
-  const emojis = await SearchIndex.search(value);
-  return emojis.slice(0, MAX_EMOJI_RESULTS).map((emoji: any) => ({
-    id: emoji.id,
-    emoji: emoji.skins[0].native,
-    command: ({ editor, range }: CommandProps) => {
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertContent(emoji.skins[0].native + " ")
-        .run();
-    },
-  }));
+  const q = query.toLowerCase();
+  const index = await buildEmojiIndex();
+
+  return index
+    .filter((e) => e.name.includes(q) || e.id.includes(q))
+    .slice(0, MAX_RESULTS)
+    .map((entry) => ({
+      id: entry.id,
+      emoji: entry.native,
+      command: ({ editor, range }: CommandProps) => {
+        editor.chain().focus().deleteRange(range).insertContent(entry.native + " ").run();
+      },
+    }));
 };
 
 export const getEmojiItems = async ({

--- a/apps/client/src/features/editor/components/emoji-menu/emoji-list.tsx
+++ b/apps/client/src/features/editor/components/emoji-menu/emoji-list.tsx
@@ -1,6 +1,7 @@
 import { Loader, Paper, ScrollArea, Text, UnstyledButton } from "@mantine/core";
 import clsx from "clsx";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { EmojiMenuItemType } from "./types";
 import {
   EmojiCategory,
@@ -38,6 +39,7 @@ function EmojiList({
   range: any;
   query?: string;
 }) {
+  const { t } = useTranslation();
   const [idx, setIdx] = useState(0);
   const [cats, setCats] = useState<EmojiCategory[]>([]);
   const [activeCat, setActiveCat] = useState("");
@@ -45,6 +47,7 @@ function EmojiList({
   const gridViewport = useRef<HTMLDivElement>(null);
 
   const searching = query.length > 0;
+  const browseLoading = !searching && cats.length === 0;
   const gridItems = cats.find((c) => c.id === activeCat)?.emojis ?? [];
 
   useEffect(() => {
@@ -106,7 +109,7 @@ function EmojiList({
       withBorder
       style={{ width: 280 }}
       role="listbox"
-      aria-label="Emoji picker"
+      aria-label={t("Emoji picker")}
     >
       {searching ? (
         <>
@@ -114,7 +117,7 @@ function EmojiList({
           <ScrollArea.Autosize mah={260} scrollbarSize={6} viewportRef={listViewport}>
             <div style={{ padding: 4 }}>
               {items.length === 0 && !isLoading ? (
-                <Text size="sm" c="dimmed" p="xs">No results</Text>
+                <Text size="sm" c="dimmed" p="xs">{t("No results")}</Text>
               ) : items.map((item, i) => (
                 <UnstyledButton
                   key={item.id}
@@ -133,6 +136,8 @@ function EmojiList({
             </div>
           </ScrollArea.Autosize>
         </>
+      ) : browseLoading ? (
+        <Loader m="xs" size="xs" color="blue" type="dots" />
       ) : (
         <>
           <div className={classes.catBar} role="tablist">

--- a/apps/client/src/features/editor/components/emoji-menu/emoji-list.tsx
+++ b/apps/client/src/features/editor/components/emoji-menu/emoji-list.tsx
@@ -1,23 +1,14 @@
-import {
-  ActionIcon,
-  Loader,
-  Paper,
-  ScrollArea,
-  SimpleGrid,
-  Text,
-} from "@mantine/core";
+import { Group, Loader, Paper, ScrollArea, Text, UnstyledButton } from "@mantine/core";
 import { EmojiMenuItemType } from "./types";
 import clsx from "clsx";
 import classes from "./emoji-menu.module.css";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { GRID_COLUMNS, incrementEmojiUsage } from "./utils";
+import { incrementEmojiUsage } from "./utils";
 
 const EmojiList = ({
   items,
   isLoading,
   command,
-  editor,
-  range,
 }: {
   items: EmojiMenuItemType[];
   isLoading: boolean;
@@ -36,65 +27,31 @@ const EmojiList = ({
         incrementEmojiUsage(item.id);
       }
     },
-    [command, items]
+    [command, items],
   );
 
   useEffect(() => {
-    const navigationKeys = [
-      "ArrowRight",
-      "ArrowLeft",
-      "ArrowUp",
-      "ArrowDown",
-      "Enter",
-    ];
     const onKeyDown = (e: KeyboardEvent) => {
-      if (navigationKeys.includes(e.key)) {
+      if (e.key === "ArrowDown") {
         e.preventDefault();
-
-        if (e.key === "ArrowRight") {
-          setSelectedIndex(
-            selectedIndex + 1 < items.length ? selectedIndex + 1 : selectedIndex
-          );
-          return true;
-        }
-
-        if (e.key === "ArrowLeft") {
-          setSelectedIndex(
-            selectedIndex - 1 >= 0 ? selectedIndex - 1 : selectedIndex
-          );
-          return true;
-        }
-
-        if (e.key === "ArrowUp") {
-          setSelectedIndex(
-            selectedIndex - GRID_COLUMNS >= 0
-              ? selectedIndex - GRID_COLUMNS
-              : selectedIndex
-          );
-          return true;
-        }
-
-        if (e.key === "ArrowDown") {
-          setSelectedIndex(
-            selectedIndex + GRID_COLUMNS < items.length
-              ? selectedIndex + GRID_COLUMNS
-              : selectedIndex
-          );
-          return true;
-        }
-
-        if (e.key === "Enter") {
-          selectItem(selectedIndex);
-          return true;
-        }
-        return false;
+        setSelectedIndex((prev) => (prev + 1 < items.length ? prev + 1 : prev));
+        return true;
       }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev - 1 >= 0 ? prev - 1 : prev));
+        return true;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        selectItem(selectedIndex);
+        return true;
+      }
+      return false;
     };
     document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [items, selectedIndex, setSelectedIndex]);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [items, selectedIndex, selectItem]);
 
   useEffect(() => {
     setSelectedIndex(0);
@@ -106,12 +63,15 @@ const EmojiList = ({
       ?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
 
-  return items.length > 0 || isLoading ? (
+  if (!items.length && !isLoading) return null;
+
+  return (
     <Paper
       id="emoji-command"
       p="0"
       shadow="md"
       withBorder
+      style={{ minWidth: 200 }}
       role="listbox"
       aria-label="Emoji results"
       aria-activedescendant={
@@ -120,35 +80,36 @@ const EmojiList = ({
     >
       {isLoading && <Loader m="xs" color="blue" type="dots" />}
       {items.length > 0 && (
-        <ScrollArea.Autosize
-          viewportRef={viewportRef}
-          mah={250}
-          scrollbarSize={8}
-          pr="5"
-        >
-          <SimpleGrid cols={GRID_COLUMNS} p="xs" spacing="xs">
-            {items.map((item, index: number) => (
-              <ActionIcon
+        <ScrollArea.Autosize viewportRef={viewportRef} mah={300} scrollbarSize={6}>
+          <div style={{ padding: "4px" }}>
+            {items.map((item, index) => (
+              <UnstyledButton
                 data-item-index={index}
                 id={`emoji-command-option-${index}`}
                 role="option"
                 aria-selected={index === selectedIndex}
-                aria-label={item.id}
-                variant="transparent"
                 key={item.id}
-                className={clsx(classes.menuBtn, {
+                w="100%"
+                className={clsx(classes.menuItem, {
                   [classes.selectedItem]: index === selectedIndex,
                 })}
                 onClick={() => selectItem(index)}
               >
-                <Text size="xl">{item.emoji}</Text>
-              </ActionIcon>
+                <Group gap="sm" wrap="nowrap">
+                  <Text size="xl" style={{ lineHeight: 1, minWidth: 28 }}>
+                    {item.emoji}
+                  </Text>
+                  <Text size="sm" c="dimmed" ff="monospace">
+                    :{item.id}:
+                  </Text>
+                </Group>
+              </UnstyledButton>
             ))}
-          </SimpleGrid>
+          </div>
         </ScrollArea.Autosize>
       )}
     </Paper>
-  ) : null;
+  );
 };
 
 export default EmojiList;

--- a/apps/client/src/features/editor/components/emoji-menu/emoji-list.tsx
+++ b/apps/client/src/features/editor/components/emoji-menu/emoji-list.tsx
@@ -1,115 +1,174 @@
-import { Group, Loader, Paper, ScrollArea, Text, UnstyledButton } from "@mantine/core";
-import { EmojiMenuItemType } from "./types";
+import { Loader, Paper, ScrollArea, Text, UnstyledButton } from "@mantine/core";
 import clsx from "clsx";
-import classes from "./emoji-menu.module.css";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { incrementEmojiUsage } from "./utils";
+import { EmojiMenuItemType } from "./types";
+import {
+  EmojiCategory,
+  EmojiIndexEntry,
+  getEmojiCategories,
+  incrementEmojiUsage,
+} from "./utils";
+import classes from "./emoji-menu.module.css";
 
-const EmojiList = ({
+const COLS = 8;
+
+const CAT_ICONS: Record<string, string> = {
+  people:   "😀",
+  nature:   "🌿",
+  foods:    "🍕",
+  activity: "🎮",
+  places:   "🗺️",
+  objects:  "🔧",
+  symbols:  "💯",
+  flags:    "🚩",
+};
+
+function EmojiList({
   items,
   isLoading,
   command,
+  editor,
+  range,
+  query = "",
 }: {
   items: EmojiMenuItemType[];
   isLoading: boolean;
-  command: any;
+  command: (item: EmojiMenuItemType) => void;
   editor: any;
   range: any;
-}) => {
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const viewportRef = useRef<HTMLDivElement>(null);
+  query?: string;
+}) {
+  const [idx, setIdx] = useState(0);
+  const [cats, setCats] = useState<EmojiCategory[]>([]);
+  const [activeCat, setActiveCat] = useState("");
+  const listViewport = useRef<HTMLDivElement>(null);
+  const gridViewport = useRef<HTMLDivElement>(null);
 
-  const selectItem = useCallback(
-    (index: number) => {
-      const item = items[index];
-      if (item) {
-        command(item);
-        incrementEmojiUsage(item.id);
-      }
+  const searching = query.length > 0;
+  const gridItems = cats.find((c) => c.id === activeCat)?.emojis ?? [];
+
+  useEffect(() => {
+    getEmojiCategories().then((data) => {
+      setCats(data);
+      setActiveCat((prev) => prev || data[0]?.id || "");
+    });
+  }, []);
+
+  useEffect(() => { setIdx(0); }, [query, activeCat]);
+
+  useEffect(() => {
+    const vp = searching ? listViewport.current : gridViewport.current;
+    vp?.querySelector<HTMLElement>(`[data-i="${idx}"]`)?.scrollIntoView({ block: "nearest" });
+  }, [idx, searching]);
+
+  const pickSearchItem = useCallback(
+    (i: number) => {
+      const item = items[i];
+      if (!item) return;
+      command(item);
+      incrementEmojiUsage(item.id);
     },
     [command, items],
   );
 
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setSelectedIndex((prev) => (prev + 1 < items.length ? prev + 1 : prev));
-        return true;
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setSelectedIndex((prev) => (prev - 1 >= 0 ? prev - 1 : prev));
-        return true;
-      }
-      if (e.key === "Enter") {
-        e.preventDefault();
-        selectItem(selectedIndex);
-        return true;
-      }
-      return false;
-    };
-    document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, [items, selectedIndex, selectItem]);
+  const pickGridItem = useCallback(
+    (entry: EmojiIndexEntry) => {
+      editor.chain().focus().deleteRange(range).insertContent(entry.native + " ").run();
+      incrementEmojiUsage(entry.id);
+    },
+    [editor, range],
+  );
 
   useEffect(() => {
-    setSelectedIndex(0);
-  }, [items]);
-
-  useEffect(() => {
-    viewportRef.current
-      ?.querySelector(`[data-item-index="${selectedIndex}"]`)
-      ?.scrollIntoView({ block: "nearest" });
-  }, [selectedIndex]);
-
-  if (!items.length && !isLoading) return null;
+    function onKey(e: KeyboardEvent) {
+      if (searching) {
+        if      (e.key === "ArrowDown") { e.preventDefault(); setIdx((i) => Math.min(i + 1, items.length - 1)); }
+        else if (e.key === "ArrowUp")   { e.preventDefault(); setIdx((i) => Math.max(i - 1, 0)); }
+        else if (e.key === "Enter")     { e.preventDefault(); pickSearchItem(idx); }
+      } else {
+        const total = gridItems.length;
+        if      (e.key === "ArrowRight") { e.preventDefault(); setIdx((i) => Math.min(i + 1, total - 1)); }
+        else if (e.key === "ArrowLeft")  { e.preventDefault(); setIdx((i) => Math.max(i - 1, 0)); }
+        else if (e.key === "ArrowDown")  { e.preventDefault(); setIdx((i) => Math.min(i + COLS, total - 1)); }
+        else if (e.key === "ArrowUp")    { e.preventDefault(); setIdx((i) => Math.max(i - COLS, 0)); }
+        else if (e.key === "Enter")      { e.preventDefault(); if (gridItems[idx]) pickGridItem(gridItems[idx]); }
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [searching, items, idx, gridItems, pickSearchItem, pickGridItem]);
 
   return (
     <Paper
       id="emoji-command"
-      p="0"
+      p={0}
       shadow="md"
       withBorder
-      style={{ minWidth: 200 }}
+      style={{ width: 280 }}
       role="listbox"
-      aria-label="Emoji results"
-      aria-activedescendant={
-        items.length > 0 ? `emoji-command-option-${selectedIndex}` : undefined
-      }
+      aria-label="Emoji picker"
     >
-      {isLoading && <Loader m="xs" color="blue" type="dots" />}
-      {items.length > 0 && (
-        <ScrollArea.Autosize viewportRef={viewportRef} mah={300} scrollbarSize={6}>
-          <div style={{ padding: "4px" }}>
-            {items.map((item, index) => (
-              <UnstyledButton
-                data-item-index={index}
-                id={`emoji-command-option-${index}`}
-                role="option"
-                aria-selected={index === selectedIndex}
-                key={item.id}
-                w="100%"
-                className={clsx(classes.menuItem, {
-                  [classes.selectedItem]: index === selectedIndex,
-                })}
-                onClick={() => selectItem(index)}
+      {searching ? (
+        <>
+          {isLoading && <Loader m="xs" size="xs" color="blue" type="dots" />}
+          <ScrollArea.Autosize mah={260} scrollbarSize={6} viewportRef={listViewport}>
+            <div style={{ padding: 4 }}>
+              {items.length === 0 && !isLoading ? (
+                <Text size="sm" c="dimmed" p="xs">No results</Text>
+              ) : items.map((item, i) => (
+                <UnstyledButton
+                  key={item.id}
+                  data-i={i}
+                  w="100%"
+                  className={clsx(classes.row, { [classes.active]: i === idx })}
+                  onClick={() => pickSearchItem(i)}
+                  onMouseEnter={() => setIdx(i)}
+                  role="option"
+                  aria-selected={i === idx}
+                >
+                  <span style={{ fontSize: 20, lineHeight: 1, minWidth: 26 }}>{item.emoji}</span>
+                  <Text size="sm" c="dimmed" ff="monospace" span>:{item.id}:</Text>
+                </UnstyledButton>
+              ))}
+            </div>
+          </ScrollArea.Autosize>
+        </>
+      ) : (
+        <>
+          <div className={classes.catBar} role="tablist">
+            {cats.map((c) => (
+              <button
+                key={c.id}
+                title={c.id}
+                role="tab"
+                aria-selected={c.id === activeCat}
+                className={clsx(classes.catTab, { [classes.catTabActive]: c.id === activeCat })}
+                onClick={() => setActiveCat(c.id)}
               >
-                <Group gap="sm" wrap="nowrap">
-                  <Text size="xl" style={{ lineHeight: 1, minWidth: 28 }}>
-                    {item.emoji}
-                  </Text>
-                  <Text size="sm" c="dimmed" ff="monospace">
-                    :{item.id}:
-                  </Text>
-                </Group>
-              </UnstyledButton>
+                {CAT_ICONS[c.id] ?? "🔣"}
+              </button>
             ))}
           </div>
-        </ScrollArea.Autosize>
+          <ScrollArea.Autosize mah={220} scrollbarSize={6} viewportRef={gridViewport}>
+            <div className={classes.grid} style={{ gridTemplateColumns: `repeat(${COLS}, 1fr)` }}>
+              {gridItems.map((entry, i) => (
+                <button
+                  key={entry.id}
+                  data-i={i}
+                  title={`:${entry.id}:`}
+                  className={clsx(classes.emojiBtn, { [classes.active]: i === idx })}
+                  onClick={() => pickGridItem(entry)}
+                  onMouseEnter={() => setIdx(i)}
+                >
+                  {entry.native}
+                </button>
+              ))}
+            </div>
+          </ScrollArea.Autosize>
+        </>
       )}
     </Paper>
   );
-};
+}
 
 export default EmojiList;

--- a/apps/client/src/features/editor/components/emoji-menu/emoji-menu.module.css
+++ b/apps/client/src/features/editor/components/emoji-menu/emoji-menu.module.css
@@ -1,9 +1,10 @@
-.menuBtn {
+.menuItem {
+  padding: 6px 10px;
   border-radius: var(--mantine-radius-sm);
 
   &:hover {
     @mixin light {
-      background: var(--mantine-color-gray-2);
+      background: var(--mantine-color-gray-1);
     }
 
     @mixin dark {

--- a/apps/client/src/features/editor/components/emoji-menu/emoji-menu.module.css
+++ b/apps/client/src/features/editor/components/emoji-menu/emoji-menu.module.css
@@ -1,4 +1,7 @@
-.menuItem {
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 6px 10px;
   border-radius: var(--mantine-radius-sm);
 
@@ -13,7 +16,7 @@
   }
 }
 
-.selectedItem {
+.active {
   @mixin light {
     background: var(--mantine-color-gray-2);
   }
@@ -22,3 +25,78 @@
     background: var(--mantine-color-gray-light);
   }
 }
+
+.catBar {
+  display: flex;
+  gap: 2px;
+  padding: 4px 6px;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  @mixin light {
+    border-bottom: 1px solid var(--mantine-color-gray-2);
+  }
+
+  @mixin dark {
+    border-bottom: 1px solid var(--mantine-color-dark-4);
+  }
+}
+
+.catTab {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 4px 5px;
+  border-radius: var(--mantine-radius-sm);
+  flex-shrink: 0;
+
+  &:hover {
+    @mixin light {
+      background: var(--mantine-color-gray-1);
+    }
+
+    @mixin dark {
+      background: var(--mantine-color-gray-light);
+    }
+  }
+}
+
+.catTabActive {
+  @mixin light {
+    background: var(--mantine-color-gray-2);
+  }
+
+  @mixin dark {
+    background: var(--mantine-color-gray-light);
+  }
+}
+
+.grid {
+  display: grid;
+  gap: 1px;
+  padding: 6px;
+}
+
+.emojiBtn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+  padding: 3px;
+  border-radius: var(--mantine-radius-sm);
+  aspect-ratio: 1 / 1;
+
+  &:hover {
+    @mixin light {
+      background: var(--mantine-color-gray-1);
+    }
+
+    @mixin dark {
+      background: var(--mantine-color-gray-light);
+    }
+  }
+}
+

--- a/apps/client/src/features/editor/components/emoji-menu/render-emoji-items.ts
+++ b/apps/client/src/features/editor/components/emoji-menu/render-emoji-items.ts
@@ -1,6 +1,5 @@
 import { ReactRenderer, useEditor } from "@tiptap/react";
 import EmojiList from "./emoji-list";
-import { init } from "emoji-mart";
 import {
   autoUpdate,
   computePosition,
@@ -37,10 +36,6 @@ const renderEmojiItems = () => {
       editor: ReturnType<typeof useEditor>;
       clientRect: () => DOMRect;
     }) => {
-      init({
-        data: async () => (await import("@emoji-mart/data")).default,
-      });
-
       component = new ReactRenderer(EmojiList, {
         props: { isLoading: true, items: [] },
         editor: props.editor,

--- a/apps/client/src/features/editor/components/emoji-menu/utils.ts
+++ b/apps/client/src/features/editor/components/emoji-menu/utils.ts
@@ -66,3 +66,25 @@ export const getFrequentlyUsedEmoji = (): EmojiMartFrequentlyType => {
     localStorage.getItem(LOCAL_STORAGE_FREQUENT_KEY) || DEFAULT_FREQUENTLY_USED_EMOJI_MART,
   );
 };
+
+export type EmojiCategory = { id: string; emojis: EmojiIndexEntry[] };
+
+let _cats: EmojiCategory[] | null = null;
+
+export const getEmojiCategories = async (): Promise<EmojiCategory[]> => {
+  if (_cats) return _cats;
+  const [{ default: data }, index] = await Promise.all([
+    import("@emoji-mart/data"),
+    buildEmojiIndex(),
+  ]);
+  const byId = new Map(index.map((e) => [e.id, e]));
+  _cats = ((data as any).categories as { id: string; emojis: string[] }[])
+    .map((cat) => ({
+      id: cat.id,
+      emojis: cat.emojis
+        .map((id) => byId.get(id))
+        .filter((e): e is EmojiIndexEntry => !!e),
+    }))
+    .filter((c) => c.emojis.length > 0);
+  return _cats;
+};

--- a/apps/client/src/features/editor/components/emoji-menu/utils.ts
+++ b/apps/client/src/features/editor/components/emoji-menu/utils.ts
@@ -1,8 +1,4 @@
-import { CommandProps } from "./types";
-import { getEmojiDataFromNative } from "emoji-mart";
-import { EmojiMartFrequentlyType, EmojiMenuItemType } from "./types";
-
-export const GRID_COLUMNS = 10;
+import { CommandProps, EmojiMartFrequentlyType, EmojiMenuItemType } from "./types";
 
 export const LOCAL_STORAGE_FREQUENT_KEY = "emoji-mart.frequently";
 
@@ -19,41 +15,54 @@ export const DEFAULT_FREQUENTLY_USED_EMOJI_MART = `{
     "rocket": 1
 }`;
 
+export type EmojiIndexEntry = { id: string; name: string; native: string };
+
+let _emojiIndex: EmojiIndexEntry[] | null = null;
+
+export const buildEmojiIndex = async (): Promise<EmojiIndexEntry[]> => {
+  if (_emojiIndex) return _emojiIndex;
+  const { default: data } = await import("@emoji-mart/data");
+  _emojiIndex = (Object.values((data as any).emojis) as any[])
+    .filter((e) => e.id && e.name && e.skins?.[0]?.native)
+    .map((e) => ({
+      id: e.id as string,
+      name: (e.name as string).toLowerCase(),
+      native: e.skins[0].native as string,
+    }));
+  return _emojiIndex;
+};
+
 export const incrementEmojiUsage = (emojiId: string) => {
-  const frequentlyUsedEmoji =
-    JSON.parse(localStorage.getItem(LOCAL_STORAGE_FREQUENT_KEY) || DEFAULT_FREQUENTLY_USED_EMOJI_MART);
-  frequentlyUsedEmoji[emojiId]
-    ? (frequentlyUsedEmoji[emojiId] += 1)
-    : (frequentlyUsedEmoji[emojiId] = 1);
-  localStorage.setItem(
-    LOCAL_STORAGE_FREQUENT_KEY,
-    JSON.stringify(frequentlyUsedEmoji)
+  const stored = JSON.parse(
+    localStorage.getItem(LOCAL_STORAGE_FREQUENT_KEY) || DEFAULT_FREQUENTLY_USED_EMOJI_MART,
   );
+  stored[emojiId] = (stored[emojiId] ?? 0) + 1;
+  localStorage.setItem(LOCAL_STORAGE_FREQUENT_KEY, JSON.stringify(stored));
 };
 
 export const sortFrequentlyUsedEmoji = async (
-  frequentlyUsedEmoji: EmojiMartFrequentlyType
+  frequentlyUsedEmoji: EmojiMartFrequentlyType,
 ): Promise<EmojiMenuItemType[]> => {
-  const data = await Promise.all(
-    Object.entries(frequentlyUsedEmoji).map(
-      async ([id, count]): Promise<EmojiMenuItemType> => ({
+  const index = await buildEmojiIndex();
+  const results: EmojiMenuItemType[] = Object.entries(frequentlyUsedEmoji)
+    .map(([id, count]): EmojiMenuItemType | null => {
+      const entry = index.find((e) => e.id === id);
+      if (!entry) return null;
+      return {
         id,
         count,
-        emoji: (await getEmojiDataFromNative(id))?.native,
-        command: async ({ editor, range }: CommandProps) => {
-          editor
-            .chain()
-            .focus()
-            .deleteRange(range)
-            .insertContent((await getEmojiDataFromNative(id))?.native + " ")
-            .run();
+        emoji: entry.native,
+        command: ({ editor, range }: CommandProps) => {
+          editor.chain().focus().deleteRange(range).insertContent(entry.native + " ").run();
         },
-      })
-    )
-  );
-  return data.sort((a, b) => b.count - a.count);
+      };
+    })
+    .filter((e): e is EmojiMenuItemType => e !== null);
+  return results.sort((a, b) => (b.count ?? 0) - (a.count ?? 0)).slice(0, 5);
 };
 
-export const getFrequentlyUsedEmoji = () => {
-  return JSON.parse(localStorage.getItem(LOCAL_STORAGE_FREQUENT_KEY) || DEFAULT_FREQUENTLY_USED_EMOJI_MART);
-}
+export const getFrequentlyUsedEmoji = (): EmojiMartFrequentlyType => {
+  return JSON.parse(
+    localStorage.getItem(LOCAL_STORAGE_FREQUENT_KEY) || DEFAULT_FREQUENTLY_USED_EMOJI_MART,
+  );
+};


### PR DESCRIPTION
## What

This replaces the current emoji picker with a two-mode popup.

- Typing bare `:` opens a browse view with category tabs and an 8-column grid.
- Typing after `:` switches to a compact search list that shows both the emoji and its `:shortcode:`.
- Search now uses a simple `name.includes()` / `id.includes()` match against a lazily built index from `@emoji-mart/data`.

There are also two small follow-ups in the last commit:

- visible copy now goes through `t(...)`
- the browse view shows a loader while categories are still being prepared

No new dependencies.

## How to test

1. Type `:` in the editor and confirm the category browser opens.
2. Move around the grid with the arrow keys and press Enter to insert an emoji.
3. Type `:` followed by a search term and confirm it switches to the search list.
4. Use Up / Down + Enter in search mode.
5. Reopen the picker once or twice and check that the first open does not flash an empty browse state.
