### PR TITLE
fix: prevent page scroll when dragging list items

### DIFF
--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -10,6 +10,7 @@ import { Typography } from "@tiptap/extension-typography";
 import { TextStyle } from "@tiptap/extension-text-style";
 import { Color } from "@tiptap/extension-color";
 import GlobalDragHandle from "tiptap-extension-global-drag-handle";
+import { PreventScrollOnDrag } from "./prevent-scroll-on-drag";
 import { Youtube } from "@tiptap/extension-youtube";
 import SlashCommand, { SlashCommandExtension as Command } from "@/features/editor/extensions/slash-command";
 import renderItems from "@/features/editor/components/slash-menu/render-items";
@@ -216,6 +217,7 @@ export const mainExtensions = [
   Typography,
   TrailingNode,
   GlobalDragHandle,
+  PreventScrollOnDrag,
   TextStyle,
   Color,
   SlashCommand,

--- a/apps/client/src/features/editor/extensions/prevent-scroll-on-drag.ts
+++ b/apps/client/src/features/editor/extensions/prevent-scroll-on-drag.ts
@@ -1,0 +1,48 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+const PreventScrollOnDragKey = new PluginKey("prevent-scroll-on-drag");
+
+export const PreventScrollOnDrag = Extension.create({
+  name: "prevent-scroll-on-drag",
+
+  addProseMirrorPlugins() {
+    const extensionThis = this;
+
+    return [
+      new Plugin({
+        key: PreventScrollOnDragKey,
+
+        props: {
+          handleDOMEvents: {
+            dragstart: (_view, event) => {
+              if (!(event instanceof DragEvent)) return false;
+              if (!event.dataTransfer) return false;
+
+              const dragHandle = document.querySelector(".drag-handle");
+              if (!dragHandle) return false;
+
+              const scrollY = window.scrollY;
+              window.scrollTo({ top: scrollY, behavior: "instant" });
+
+              const handleDrag = (e: DragEvent) => {
+                e.preventDefault();
+                window.scrollTo({ top: scrollY, behavior: "instant" });
+              };
+
+              const handleDragEnd = () => {
+                document.removeEventListener("drag", handleDrag, true);
+                document.removeEventListener("dragend", handleDragEnd, true);
+              };
+
+              document.addEventListener("drag", handleDrag, true);
+              document.addEventListener("dragend", handleDragEnd, true);
+
+              return false;
+            },
+          },
+        },
+      }),
+    ];
+  },
+});


### PR DESCRIPTION
## Summary
- Created `PreventScrollOnDrag` TipTap extension that intercepts `dragstart` events from the editor's drag handle
- On drag start, captures current `scrollY` and immediately restores it
- Adds document-level `drag` and `dragend` listeners to continuously reset scroll position during drag operations

## Fixes
- The external `tiptap-extension-global-drag-handle` package calls `window.scrollTo({ top: scrollY - 30 })` during drag, causing the page to scroll to top when cursor is near viewport edges

## Testing
- Built successfully with `pnpm nx run client:build` (no errors)

Fixes #1389