### PR TITLE
fix: hamburger menu not working on Firefox for Android

### DIFF
--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
     <title>Docmost</title>
     <meta name="theme-color" content="#1f1f1f" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#f6f7f9" media="(prefers-color-scheme: light)" />

--- a/apps/client/src/components/ui/sidebar-toggle-button.tsx
+++ b/apps/client/src/components/ui/sidebar-toggle-button.tsx
@@ -1,27 +1,9 @@
 import React from "react";
-import {
-  IconLayoutSidebarRightCollapse,
-  IconLayoutSidebarRightExpand
-} from "@tabler/icons-react";
-import { ActionIcon, BoxProps, ElementProps, MantineColor, MantineSize } from "@mantine/core";
+import { Burger, BurgerProps } from "@mantine/core";
 
-export interface SidebarToggleProps extends BoxProps, ElementProps<"button"> {
-  size?: MantineSize | `compact-${MantineSize}` | (string & {});
-  color?: MantineColor;
-  opened?: boolean;
-}
-
-const SidebarToggle = React.forwardRef<HTMLButtonElement, SidebarToggleProps>(
-  ({ opened, size = "sm", ...others }, ref) => {
-    return (
-      <ActionIcon size={size} {...others} variant="subtle" color="gray" ref={ref}>
-        {opened ? (
-          <IconLayoutSidebarRightExpand />
-        ) : (
-          <IconLayoutSidebarRightCollapse />
-        )}
-      </ActionIcon>
-    );
+const SidebarToggle = React.forwardRef<HTMLButtonElement, BurgerProps>(
+  ({ opened, ...others }, ref) => {
+    return <Burger opened={opened} {...others} ref={ref} />;
   }
 );
 


### PR DESCRIPTION
The sidebar toggle button on Firefox for Android was unresponsive because:
1. The custom `SidebarToggle` component used `ActionIcon` with custom icons instead of Mantine's `Burger` component, which has proper touch event handling for mobile.
2. The viewport meta tag was missing a comma separator between `initial-scale=1.0` and `user-scalable=no`, causing Firefox to misinterpret the viewport directive.

## Changes
- Replaced `SidebarToggle` (ActionIcon + custom icons) with Mantine `Burger` component
- Fixed missing comma in viewport meta tag

Fixes #1815