### PR TITLE
fix: inline code text always rendered in pink/red

### DIFF
--- a/apps/client/src/features/editor/styles/code.css
+++ b/apps/client/src/features/editor/styles/code.css
@@ -104,12 +104,12 @@
 
     @mixin where-light {
       background-color: var(--code-bg, var(--mantine-color-gray-1));
-      color: var(--mantine-color-pink-7);
+      color: var(--mantine-color-gray-8);
     }
 
     @mixin where-dark {
       background-color: var(--mantine-color-dark-8);
-      color: var(--mantine-color-pink-7);
+      color: var(--mantine-color-dark-1);
     }
   }
 }


### PR DESCRIPTION
Inline code (`:not(pre) > code`) was hardcoded to `var(--mantine-color-pink-7)` in both light and dark modes, making all inline code appear pink/red regardless of the theme.

## Fix
Changed inline code to use theme-appropriate colors:
- Light mode: `var(--mantine-color-gray-8)` (dark gray)
- Dark mode: `var(--mantine-color-dark-1)` (light gray)

Fixes #1837