### PR TITLE
fix: workspace description truncated at ~150 chars in space list

### DIFF
--- a/apps/client/src/features/space/components/space-list.tsx
+++ b/apps/client/src/features/space/components/space-list.tsx
@@ -58,7 +58,7 @@ export default function SpaceList() {
                       <AutoTooltipText fz="sm" fw={500} lineClamp={1}>
                         {space.name}
                       </AutoTooltipText>
-                      <Text fz="xs" c="dimmed" lineClamp={2}>
+                      <Text fz="xs" c="dimmed" lineClamp={4}>
                         {space.description}
                       </Text>
                     </div>

--- a/apps/client/src/features/space/components/spaces-page/all-spaces-list.tsx
+++ b/apps/client/src/features/space/components/spaces-page/all-spaces-list.tsx
@@ -149,7 +149,7 @@ export default function AllSpacesList({
                             {space.name}
                           </AutoTooltipText>
                           {space.description && (
-                            <Text fz="xs" c="dimmed" lineClamp={2}>
+                            <Text fz="xs" c="dimmed" lineClamp={4}>
                               {space.description}
                             </Text>
                           )}


### PR DESCRIPTION
The space description in both `SpaceList` and `AllSpacesList` was limited to 2 lines via `lineClamp={2}`, which only shows ~150 characters. The frontend Zod validation allows up to 500 characters.

## Fix
Increased `lineClamp={2}` to `lineClamp={4}` in both components, showing ~300-360 characters which covers the expected range.

Fixes #1713