### PR TITLE
fix: print PDF broken characters for Chinese/Japanese/Korean text

### DIFF
--- a/apps/client/src/features/editor/styles/code.css
+++ b/apps/client/src/features/editor/styles/code.css
@@ -96,7 +96,7 @@
   }
 
   :not(pre) > code {
-    font-family: "JetBrainsMono", var(--mantine-font-family-monospace);
+    font-family: "JetBrainsMono", var(--mantine-font-family-monospace), "Noto Sans CJK SC", "Microsoft YaHei", "PingFang SC", sans-serif;
     line-height: var(--mantine-line-height);
     padding: 2px calc(var(--mantine-spacing-xs) / 2);
     border-radius: var(--mantine-radius-sm);

--- a/apps/client/src/features/editor/styles/print.css
+++ b/apps/client/src/features/editor/styles/print.css
@@ -1,4 +1,12 @@
 @media print {
+  body {
+    font-family: "Noto Sans CJK SC", "Source Han Sans SC", "Microsoft YaHei", "PingFang SC", system-ui, -apple-system, sans-serif;
+  }
+
+  pre, code, :not(pre) > code {
+    font-family: "JetBrainsMono", "Noto Sans Mono CJK SC", "Microsoft YaHei Mono", monospace;
+  }
+
   .mantine-AppShell-header,
   .mantine-AppShell-navbar,
   .mantine-AppShell-aside,


### PR DESCRIPTION
When printing pages containing Chinese/Japanese/Korean characters via the PDF print feature, characters render as broken/tofu because the default font stack doesn't include CJK-capable fonts.

## Fix
- Added CJK font fallbacks (`Noto Sans CJK SC`, `Microsoft YaHei`, `PingFang SC`) to the `@media print` block for body text
- Added CJK fallbacks for code blocks (`Noto Sans Mono CJK SC`, `Microsoft YaHei Mono`)
- Added CJK font fallback to inline code font-family

The fonts will be used if available on the system — no additional font files need to be bundled.

Fixes #1894