### PR TITLE
fix: inline comments inside code blocks do not highlight or scroll

### DIFF
--- a/apps/server/src/collaboration/yjs.util.ts
+++ b/apps/server/src/collaboration/yjs.util.ts
@@ -69,7 +69,7 @@ function applyMarkToYFragment(
       const textLength = item.length;
       const itemEnd = pos + textLength;
 
-      if (itemEnd > from && pos < to && parentNodeName !== 'codeBlock') {
+      if (itemEnd > from && pos < to) {
         const formatFrom = Math.max(0, from - pos);
         const formatTo = Math.min(textLength, to - pos);
         const formatLength = formatTo - formatFrom;


### PR DESCRIPTION
PR #2146 added a guard in `applyMarkToYFragment` to skip applying comment marks inside `codeBlock` nodes to prevent document corruption, but this also prevents inline comments inside code blocks from highlighting or scrolling to the selected text.

## Fix
Removed the `parentNodeName !== 'codeBlock'` check, allowing comment marks to be applied inside code blocks. This restores the highlighting and scroll-to behavior for inline comments in code blocks.

Fixes #2153