### PR TITLE
feat: sort pages alphabetically in sidebar tree and Subpages block

### DIFF
--- a/apps/client/src/features/editor/components/subpages/subpages-menu.tsx
+++ b/apps/client/src/features/editor/components/subpages/subpages-menu.tsx
@@ -3,10 +3,15 @@ import { posToDOMRect, findParentNode } from "@tiptap/react";
 import { Node as PMNode } from "@tiptap/pm/model";
 import React, { useCallback, type JSX } from "react";
 import { ActionIcon, Tooltip } from "@mantine/core";
-import { IconTrash } from "@tabler/icons-react";
+import { IconSortAZ, IconSortZA, IconTrash } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
 import { Editor } from "@tiptap/core";
 import { isEditorReady } from "@docmost/editor-ext";
+import { useSetAtom } from "jotai";
+import { sortPages } from "@/features/page/services/page-service.ts";
+import { queryClient } from "@/main.tsx";
+import { treeDataAtom } from "@/features/page/tree/atoms/tree-data-atom.ts";
+import { updateSortedChildren } from "@/features/page/tree/utils/utils.ts";
 
 interface SubpagesMenuProps {
   editor: Editor;
@@ -21,6 +26,7 @@ interface ShouldShowProps {
 export const SubpagesMenu = React.memo(
   ({ editor }: SubpagesMenuProps): JSX.Element => {
     const { t } = useTranslation();
+    const setTreeData = useSetAtom(treeDataAtom);
 
     const shouldShow = useCallback(
       ({ state }: ShouldShowProps) => {
@@ -57,6 +63,22 @@ export const SubpagesMenu = React.memo(
         .run();
     }, [editor]);
 
+    const handleSort = useCallback(
+      async (direction: 'asc' | 'desc') => {
+        const pageId = editor.storage["pageId"] as string;
+        if (!pageId) return;
+        const sorted = await sortPages({ parentPageId: pageId, direction });
+        const positionMap = new Map(sorted.map((p) => [p.id, p.position]));
+        setTreeData((prev) =>
+          updateSortedChildren(prev, pageId, direction, positionMap),
+        );
+        queryClient.invalidateQueries({
+          queryKey: ["sidebar-pages", { pageId }],
+        });
+      },
+      [editor, setTreeData, queryClient],
+    );
+
     return (
       <BaseBubbleMenu
         editor={editor}
@@ -64,6 +86,28 @@ export const SubpagesMenu = React.memo(
         updateDelay={0}
         shouldShow={shouldShow}
       >
+        <Tooltip position="top" label={t("Sort A→Z")}>
+          <ActionIcon
+            onClick={() => handleSort('asc')}
+            variant="default"
+            size="lg"
+            aria-label={t("Sort A→Z")}
+          >
+            <IconSortAZ size={18} />
+          </ActionIcon>
+        </Tooltip>
+
+        <Tooltip position="top" label={t("Sort Z→A")}>
+          <ActionIcon
+            onClick={() => handleSort('desc')}
+            variant="default"
+            size="lg"
+            aria-label={t("Sort Z→A")}
+          >
+            <IconSortZA size={18} />
+          </ActionIcon>
+        </Tooltip>
+
         <Tooltip position="top" label={t("Delete")}>
           <ActionIcon
             onClick={deleteNode}

--- a/apps/client/src/features/page/services/page-service.ts
+++ b/apps/client/src/features/page/services/page-service.ts
@@ -53,6 +53,18 @@ export async function movePage(data: IMovePage): Promise<void> {
   await api.post<void>("/pages/move", data);
 }
 
+export async function sortPages(data: {
+  spaceId?: string;
+  parentPageId?: string | null;
+  direction: 'asc' | 'desc';
+}): Promise<{ id: string; position: string }[]> {
+  const req = await api.post<{ id: string; position: string }[]>(
+    "/pages/sort-children",
+    data,
+  );
+  return req.data;
+}
+
 export async function movePageToSpace(data: IMovePageToSpace): Promise<void> {
   await api.post<void>("/pages/move-to-space", data);
 }

--- a/apps/client/src/features/page/tree/components/space-tree-node-menu.tsx
+++ b/apps/client/src/features/page/tree/components/space-tree-node-menu.tsx
@@ -10,6 +10,8 @@ import {
   IconDotsVertical,
   IconFileExport,
   IconLink,
+  IconSortAZ,
+  IconSortZA,
   IconStar,
   IconStarFilled,
   IconTrash,
@@ -21,8 +23,13 @@ import CopyPageModal from "@/features/page/components/copy-page-modal.tsx";
 import { useDeletePageModal } from "@/features/page/hooks/use-delete-page-modal.tsx";
 import { buildPageUrl } from "@/features/page/page.utils.ts";
 import { getPageTitle } from "@/features/page/page.utils";
-import { duplicatePage } from "@/features/page/services/page-service.ts";
+import {
+  duplicatePage,
+  sortPages,
+} from "@/features/page/services/page-service.ts";
 import { useClipboard } from "@/hooks/use-clipboard";
+import { queryClient } from "@/main.tsx";
+import { updateSortedChildren } from "@/features/page/tree/utils/utils.ts";
 import { getAppUrl } from "@/lib/config.ts";
 import { useQueryEmit } from "@/features/websocket/use-query-emit.ts";
 import {
@@ -70,6 +77,28 @@ export function NodeMenu({ node, canEdit }: NodeMenuProps) {
       getAppUrl() + buildPageUrl(spaceSlug, node.slugId, node.name);
     clipboard.copy(pageUrl);
     notifications.show({ message: t("Link copied") });
+  };
+
+  const handleSortChildren = async (direction: 'asc' | 'desc') => {
+    try {
+      const sorted = await sortPages({
+        spaceId: node.spaceId,
+        parentPageId: node.id,
+        direction,
+      });
+      const positionMap = new Map(sorted.map((p) => [p.id, p.position]));
+      setData((prev) =>
+        updateSortedChildren(prev, node.id, direction, positionMap),
+      );
+      queryClient.invalidateQueries({
+        queryKey: ["sidebar-pages", { pageId: node.id }],
+      });
+    } catch (err: any) {
+      notifications.show({
+        message: err?.response?.data?.message || t("Failed to sort pages"),
+        color: "red",
+      });
+    }
   };
 
   const handleDuplicatePage = async () => {
@@ -216,6 +245,31 @@ export function NodeMenu({ node, canEdit }: NodeMenuProps) {
               >
                 {t("Copy to space")}
               </Menu.Item>
+
+              {node.hasChildren && (
+                <>
+                  <Menu.Item
+                    leftSection={<IconSortAZ size={16} />}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleSortChildren('asc');
+                    }}
+                  >
+                    {t("Sort subpages A→Z")}
+                  </Menu.Item>
+                  <Menu.Item
+                    leftSection={<IconSortZA size={16} />}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleSortChildren('desc');
+                    }}
+                  >
+                    {t("Sort subpages Z→A")}
+                  </Menu.Item>
+                </>
+              )}
 
               <Menu.Divider />
               <Menu.Item

--- a/apps/client/src/features/page/tree/hooks/use-tree-mutation.ts
+++ b/apps/client/src/features/page/tree/hooks/use-tree-mutation.ts
@@ -20,6 +20,7 @@ import {
 import { buildPageUrl } from "@/features/page/page.utils.ts";
 import { getSpaceUrl } from "@/lib/config.ts";
 import { useQueryEmit } from "@/features/websocket/use-query-emit.ts";
+import { queryClient } from "@/main.tsx";
 
 export type UseTreeMutation = {
   handleMove: (sourceId: string, op: DropOp) => Promise<void>;
@@ -111,6 +112,12 @@ export function useTreeMutation(spaceId: string): UseTreeMutation {
         payload.parentPageId,
         pageData,
       );
+
+      // Invalidate subpages queries for affected parents so any open Subpages block reflects the new order
+      const affectedParents = new Set([oldParentId, payload.parentPageId].filter(Boolean));
+      affectedParents.forEach((parentId) => {
+        queryClient.invalidateQueries({ queryKey: ["sidebar-pages", { pageId: parentId }] });
+      });
 
       setTimeout(() => {
         emit({

--- a/apps/client/src/features/page/tree/utils/utils.ts
+++ b/apps/client/src/features/page/tree/utils/utils.ts
@@ -196,6 +196,40 @@ export function appendNodeChildren(
   });
 }
 
+export function updateSortedChildren(
+  nodes: SpaceTreeNode[],
+  parentId: string,
+  direction: 'asc' | 'desc',
+  positionMap: Map<string, string>,
+): SpaceTreeNode[] {
+  return nodes.map((n) => {
+    if (n.id === parentId) {
+      const sortedChildren = [...(n.children || [])].sort((a, b) => {
+        const nameA = (a.name || '').toLowerCase();
+        const nameB = (b.name || '').toLowerCase();
+        const cmp = nameA.localeCompare(nameB);
+        return direction === 'asc' ? cmp : -cmp;
+      });
+      return {
+        ...n,
+        children: sortedChildren.map((child) => ({
+          ...child,
+          position: positionMap.get(child.id) ?? child.position,
+        })),
+      };
+    }
+    return {
+      ...n,
+      children: updateSortedChildren(
+        n.children || [],
+        parentId,
+        direction,
+        positionMap,
+      ),
+    };
+  });
+}
+
 /**
  * Merge root nodes; keep existing ones intact, append new ones,
  */

--- a/apps/client/src/features/space/components/sidebar/space-sidebar.tsx
+++ b/apps/client/src/features/space/components/sidebar/space-sidebar.tsx
@@ -16,6 +16,8 @@ import {
   IconPlus,
   IconSearch,
   IconSettings,
+  IconSortAZ,
+  IconSortZA,
   IconStar,
   IconStarFilled,
   IconTemplate,
@@ -28,8 +30,9 @@ import {
 } from "@/features/space/queries/space-watcher-query.ts";
 import classes from "./space-sidebar.module.css";
 import React from "react";
-import { useAtom } from "jotai";
+import { useAtom, useSetAtom } from "jotai";
 import { useTreeMutation } from "@/features/page/tree/hooks/use-tree-mutation.ts";
+import { treeDataAtom } from "@/features/page/tree/atoms/tree-data-atom.ts";
 import { Link, useLocation, useParams } from "react-router-dom";
 import clsx from "clsx";
 import { useDisclosure } from "@mantine/hooks";
@@ -59,6 +62,9 @@ import { useHasFeature } from "@/ee/hooks/use-feature";
 import { useUpgradeLabel } from "@/ee/hooks/use-upgrade-label";
 import { Feature } from "@/ee/features";
 import { ErrorBoundary } from "react-error-boundary";
+import { sortPages } from "@/features/page/services/page-service.ts";
+import { notifications } from "@mantine/notifications";
+import { SpaceTreeNode } from "@/features/page/tree/types";
 
 export function SpaceSidebar() {
   const { t } = useTranslation();
@@ -248,6 +254,7 @@ function SpaceMenu({
 }: SpaceMenuProps) {
   const { t } = useTranslation();
   const { spaceSlug } = useParams();
+  const setTreeData = useSetAtom(treeDataAtom);
   const [importOpened, { open: openImportModal, close: closeImportModal }] =
     useDisclosure(false);
   const [exportOpened, { open: openExportModal, close: closeExportModal }] =
@@ -283,6 +290,33 @@ function SpaceMenu({
       unwatchMutation.mutate(spaceId);
     } else {
       watchMutation.mutate(spaceId);
+    }
+  };
+
+  const handleSortRootPages = async (direction: 'asc' | 'desc') => {
+    try {
+      const sorted = await sortPages({ spaceId, parentPageId: null, direction });
+      const positionMap = new Map(sorted.map((p) => [p.id, p.position]));
+      setTreeData((prev) => {
+        const otherSpaces = prev.filter((n) => n?.spaceId !== spaceId);
+        const currentSpace = prev.filter((n) => n?.spaceId === spaceId);
+        const reordered = [...currentSpace].sort((a, b) => {
+          const nameA = (a.name || '').toLowerCase();
+          const nameB = (b.name || '').toLowerCase();
+          const cmp = nameA.localeCompare(nameB);
+          return direction === 'asc' ? cmp : -cmp;
+        });
+        const updated = reordered.map((node) => ({
+          ...node,
+          position: positionMap.get(node.id) ?? node.position,
+        })) as SpaceTreeNode[];
+        return [...otherSpaces, ...updated];
+      });
+    } catch (err: any) {
+      notifications.show({
+        message: err?.response?.data?.message || t("Failed to sort pages"),
+        color: "red",
+      });
     }
   };
 
@@ -350,6 +384,22 @@ function SpaceMenu({
 
           {canManagePages && (
             <>
+              <Menu.Divider />
+
+              <Menu.Item
+                onClick={() => handleSortRootPages('asc')}
+                leftSection={<IconSortAZ size={16} />}
+              >
+                {t("Sort pages A→Z")}
+              </Menu.Item>
+
+              <Menu.Item
+                onClick={() => handleSortRootPages('desc')}
+                leftSection={<IconSortZA size={16} />}
+              >
+                {t("Sort pages Z→A")}
+              </Menu.Item>
+
               <Menu.Divider />
 
               <Menu.Item

--- a/apps/server/src/core/page/dto/sort-pages.dto.ts
+++ b/apps/server/src/core/page/dto/sort-pages.dto.ts
@@ -1,0 +1,16 @@
+import { IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class SortPagesDto {
+  @IsOptional()
+  @IsString()
+  spaceId?: string;
+
+  @IsOptional()
+  @IsString()
+  parentPageId?: string | null;
+
+  @IsNotEmpty()
+  @IsString()
+  @IsIn(['asc', 'desc'])
+  direction: 'asc' | 'desc';
+}

--- a/apps/server/src/core/page/page.controller.ts
+++ b/apps/server/src/core/page/page.controller.ts
@@ -16,6 +16,7 @@ import { PageAccessService } from './page-access/page-access.service';
 import { CreatePageDto } from './dto/create-page.dto';
 import { UpdatePageDto } from './dto/update-page.dto';
 import { MovePageDto, MovePageToSpaceDto } from './dto/move-page.dto';
+import { SortPagesDto } from './dto/sort-pages.dto';
 import {
   DeletePageDto,
   PageHistoryIdDto,
@@ -734,6 +735,35 @@ export class PageController {
     }
 
     return this.pageService.movePage(dto, movedPage);
+  }
+
+  @HttpCode(HttpStatus.OK)
+  @Post('sort-children')
+  async sortPages(
+    @Body() dto: SortPagesDto,
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    let spaceId = dto.spaceId;
+
+    if (!spaceId) {
+      if (!dto.parentPageId) {
+        throw new BadRequestException(
+          'Either spaceId or parentPageId must be provided',
+        );
+      }
+      const page = await this.pageRepo.findById(dto.parentPageId);
+      if (!page || page.workspaceId !== workspace.id) {
+        throw new NotFoundException('Page not found');
+      }
+      spaceId = page.spaceId;
+    }
+
+    const ability = await this.spaceAbility.createForUser(user, spaceId);
+    if (ability.cannot(SpaceCaslAction.Edit, SpaceCaslSubject.Page)) {
+      throw new ForbiddenException();
+    }
+    return this.pageService.sortPages({ ...dto, spaceId }, workspace.id);
   }
 
   @HttpCode(HttpStatus.OK)

--- a/apps/server/src/core/page/services/page.service.ts
+++ b/apps/server/src/core/page/services/page.service.ts
@@ -18,6 +18,7 @@ import { InjectKysely } from 'nestjs-kysely';
 import { KyselyDB, KyselyTransaction } from '@docmost/db/types/kysely.types';
 import { generateJitteredKeyBetween } from 'fractional-indexing-jittered';
 import { MovePageDto } from '../dto/move-page.dto';
+import { SortPagesDto } from '../dto/sort-pages.dto';
 import { generateSlugId } from '../../../common/helpers';
 import { getPageTitle } from '../../../common/helpers';
 import { executeTx } from '@docmost/db/utils';
@@ -835,6 +836,56 @@ export class PageService {
       },
       dto.pageId,
     );
+  }
+
+  async sortPages(
+    dto: SortPagesDto,
+    workspaceId: string,
+  ): Promise<{ id: string; position: string }[]> {
+    let query = this.db
+      .selectFrom('pages')
+      .select(['id', 'title'])
+      .where('spaceId', '=', dto.spaceId)
+      .where('workspaceId', '=', workspaceId)
+      .where('deletedAt', 'is', null);
+
+    if (dto.parentPageId) {
+      query = query.where('parentPageId', '=', dto.parentPageId);
+    } else {
+      query = query.where('parentPageId', 'is', null);
+    }
+
+    const pages = await query.execute();
+    if (pages.length <= 1) {
+      return [];
+    }
+
+    const sorted = [...pages].sort((a, b) => {
+      const nameA = (a.title || '').toLowerCase();
+      const nameB = (b.title || '').toLowerCase();
+      const cmp = nameA.localeCompare(nameB);
+      return dto.direction === 'asc' ? cmp : -cmp;
+    });
+
+    const positions: string[] = [];
+    let prev: string | null = null;
+    for (const _ of sorted) {
+      const pos = generateJitteredKeyBetween(prev, null);
+      positions.push(pos);
+      prev = pos;
+    }
+
+    await executeTx(this.db, async (trx) => {
+      for (let i = 0; i < sorted.length; i++) {
+        await trx
+          .updateTable('pages')
+          .set({ position: positions[i] })
+          .where('id', '=', sorted[i].id)
+          .execute();
+      }
+    });
+
+    return sorted.map((page, i) => ({ id: page.id, position: positions[i] }));
   }
 
   async getPageBreadCrumbs(childPageId: string) {


### PR DESCRIPTION
## Summary

- Adds **Sort A→Z / Sort Z→A** to the space sidebar menu (sorts all root pages in a space) and to each page's node menu in the tree (sorts direct subpages of that page, only shown when the page has children and the user has edit permission)
- Adds the same sort buttons to the **Subpages block** bubble menu (the inline `/subpages` editor block)
- Keeps the sidebar tree and Subpages block **in sync**: sorting from either place immediately reflects in the other; drag-and-drop reordering in the tree also invalidates the Subpages block cache

Relates to #1568 (subpages sort by name) and #1699 (inability to sort subdocuments — this provides an explicit alphabetical sort as an alternative).

## Implementation

Three commits, each independently reviewable:

1. **`feat(api): add POST /pages/sort-children endpoint`** — fetches direct children (or root pages), sorts by title using `localeCompare`, generates new fractional-index positions, and bulk-updates them in a transaction. `spaceId` is optional: when only `parentPageId` is supplied, the server derives it, so callers that don't have it (the Subpages block) can omit it.

2. **`feat(ui): add A→Z / Z→A sort to sidebar tree and space menu`** — space menu and page node menu items; after sorting, updates `treeDataAtom` directly (no reload) and invalidates the `sidebar-pages` React Query cache for that node.

3. **`feat(ui): keep Subpages block and sidebar tree in sync`** — sort buttons on the Subpages bubble menu update both the query cache and `treeDataAtom`; drag-and-drop moves in the tree now also invalidate the `sidebar-pages` cache for the affected parents.

## Test plan

- [ ] Space sidebar menu → "Sort pages A→Z" / "Sort pages Z→A" reorders root pages immediately
- [ ] Page node menu → "Sort subpages A→Z" / "Sort subpages Z→A" reorders children (menu item absent on pages without children)
- [ ] Sort from tree is reflected in an open Subpages block on the same page
- [ ] Sort from Subpages block bubble menu is reflected in the sidebar tree
- [ ] Drag-and-drop reorder in the tree is reflected in an open Subpages block
- [ ] Users without edit permission do not see the sort options
- [ ] Sorting a page with 0 or 1 children is a no-op

> **Note:** This code was written by Claude (AI) and has been functionally tested by a human. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
