### PR TITLE
fix: sync html lang with user locale for spellcheck

### DIFF
--- a/apps/client/src/features/user/user-provider.tsx
+++ b/apps/client/src/features/user/user-provider.tsx
@@ -61,6 +61,10 @@ export function UserProvider({ children }: React.PropsWithChildren) {
   }, [data, isLoading]);
 
   useEffect(() => {
+    document.documentElement.lang = i18n.resolvedLanguage || i18n.language || "en-US";
+  }, [i18n.language, i18n.resolvedLanguage]);
+
+  useEffect(() => {
     if (entitlements) {
       setEntitlements(entitlements);
     }


### PR DESCRIPTION
## Summary
- Update the client to keep the document `<html lang>` attribute in sync with the active i18n language.
- This ensures browser spellcheck uses the selected interface/user locale instead of staying on English.

Fixes #1663

## Testing
- pnpm exec nx run client:build