### PR TITLE
fix: ensure default text color applies to current selection

### DIFF
--- a/apps/client/src/features/editor/components/bubble-menu/color-selector.tsx
+++ b/apps/client/src/features/editor/components/bubble-menu/color-selector.tsx
@@ -192,7 +192,7 @@ export const ColorSelector: FC<ColorSelectorProps> = ({
                 {TEXT_COLORS.map(({ name, color }, index) => {
                   const applyTextColor = () => {
                     if (name === "Default") {
-                      editor.commands.unsetColor();
+                      editor.chain().focus().unsetColor().run();
                     } else {
                       editor
                         .chain()
@@ -311,8 +311,7 @@ export const ColorSelector: FC<ColorSelectorProps> = ({
               variant="default"
               fullWidth
               onClick={() => {
-                editor.commands.unsetColor();
-                editor.commands.unsetHighlight();
+                editor.chain().focus().unsetColor().unsetHighlight().run();
                 setIsOpen(false);
               }}
             >


### PR DESCRIPTION
## Summary
- Route Default text color and Remove color actions through a focused editor chain.
- This makes color removal apply to the active selection and avoids stored-mark leakage across list items.

Fixes #1728

## Testing
- pnpm exec nx run client:build