### PR TITLE
fix: inline code text always rendered in pink/red

### DIFF
--- a/apps/client/src/features/editor/styles/code.css
+++ b/apps/client/src/features/editor/styles/code.css
@@ -104,12 +104,12 @@
 
     @mixin where-light {
       background-color: var(--code-bg, var(--mantine-color-gray-1));
-      color: var(--mantine-color-pink-7);
+      color: var(--mantine-color-gray-8);
     }
 
     @mixin where-dark {
       background-color: var(--mantine-color-dark-8);
-      color: var(--mantine-color-pink-7);
+      color: var(--mantine-color-dark-1);
     }
   }
 }


### PR DESCRIPTION
Fixes #1837