### PR TITLE
fix: preserve self page references when duplicating pages

### DIFF
--- a/apps/server/src/core/page/services/page.service.ts
+++ b/apps/server/src/core/page/services/page.service.ts
@@ -593,7 +593,7 @@ export class PageService {
             const referencedPageId = node.attrs.entityId;
 
             // Check if the referenced page is within the pages being copied
-            if (referencedPageId && pageMap.has(referencedPageId)) {
+            if (referencedPageId && referencedPageId !== page.id && pageMap.has(referencedPageId)) {
               const mappedPage = pageMap.get(referencedPageId);
               //@ts-ignore
               node.attrs.entityId = mappedPage.newPageId;
@@ -623,7 +623,7 @@ export class PageService {
               const match = mark.attrs.href.match(INTERNAL_LINK_REGEX);
               if (match) {
                 const slugId = extractPageSlugId(match[5]);
-                if (slugId && slugIdMap.has(slugId)) {
+                if (slugId && slugId !== pageFromMap.oldSlugId && slugIdMap.has(slugId)) {
                   const mappedPage = slugIdMap.get(slugId);
                   //@ts-ignore
                   mark.attrs.href = mark.attrs.href.replace(


### PR DESCRIPTION
## Fix self page links remapping during duplication

When duplicating a page containing a self page mention/internal link, the duplicated page rewrote the reference to point to itself instead of preserving the original page reference.

This caused template-style pages to unexpectedly self-reference after duplication.

This behavior was caused by internal page references being remapped for all copied pages during duplication, including self-references.

### Fix

Skip remapping for:

* self page mention nodes
* self internal page links

while still preserving remapping behavior for other duplicated child pages.

### Before


https://github.com/user-attachments/assets/cf273c84-96a6-45d3-b293-12371607a011



### After


https://github.com/user-attachments/assets/68c7dbec-b583-48ea-b502-f81de655f968


Fixes #2086 
