### PR TITLE
fix: align todo-list checkbox with text vertically

### DIFF
--- a/apps/client/src/features/editor/styles/task-list.css
+++ b/apps/client/src/features/editor/styles/task-list.css
@@ -10,6 +10,8 @@ ul[data-type="taskList"] {
         display: flex;
 
         > label {
+            display: flex;
+            align-items: center;
             padding-top: 0.2rem;
             flex: 0 0 auto;
             margin-right: 0.5rem;


### PR DESCRIPTION
﻿The checkbox in todo list items wasn't vertically centered with the text. On multi-line items it sat at the top, and on single-line items it looked slightly off depending on font size.

The label element that wraps the checkbox was using padding-top to compensate, which only works for single-line text. Switching it to flexbox with align-items: center fixes it properly for both cases.

`diff
 > label {
+    display: flex;
+    align-items: center;
     padding-top: 0.2rem;
`

Fixes #1332

## Testing

Open a page with a todo list. Check that:
- The checkbox sits on the same baseline as the text on single-line items
- On items with wrapped text, the checkbox stays centered vertically next to the full block of text, not pinned to the top
