### PR TITLE
fix: add horizontal scroll to code blocks

### DIFF
--- a/apps/client/src/features/editor/styles/code.css
+++ b/apps/client/src/features/editor/styles/code.css
@@ -11,6 +11,7 @@
     font-family: "JetBrainsMono", var(--mantine-font-family-monospace);
     border-radius: var(--mantine-radius-default);
     tab-size: 4;
+    overflow-x: auto;
 
     @mixin light {
       background-color: var(--mantine-color-gray-0);


### PR DESCRIPTION
﻿Code blocks with long lines wrap instead of scroll. On narrow viewports or when the editor panel is small, this breaks indentation and makes code unreadable.

The fix is one line — overflow-x: auto on the pre element. The code block already has a fixed background and border radius, so the scrollbar appears contained within the block exactly as expected.

`diff
     tab-size: 4;
+    overflow-x: auto;
`

Fixes #1120

## Testing

Paste a code block with lines longer than the editor width (e.g. a minified JS file or a long SQL query). The block should scroll horizontally instead of wrapping the text.
