### PR TITLE
fix: respect dark mode when exporting Excalidraw SVGs

### DIFF
--- a/apps/client/src/features/editor/components/excalidraw/excalidraw-menu.tsx
+++ b/apps/client/src/features/editor/components/excalidraw/excalidraw-menu.tsx
@@ -191,7 +191,7 @@ export function ExcalidrawMenu({ editor }: EditorMenuProps) {
         elements: excalidrawAPI?.getSceneElements(),
         appState: {
           exportEmbedScene: true,
-          exportWithDarkMode: false,
+          exportWithDarkMode: computedColorScheme === 'dark',
         },
         files: excalidrawAPI?.getFiles(),
       });

--- a/apps/client/src/features/editor/components/excalidraw/excalidraw-view.tsx
+++ b/apps/client/src/features/editor/components/excalidraw/excalidraw-view.tsx
@@ -80,7 +80,7 @@ export default function ExcalidrawView(props: NodeViewProps) {
         elements: excalidrawAPI?.getSceneElements(),
         appState: {
           exportEmbedScene: true,
-          exportWithDarkMode: false,
+          exportWithDarkMode: computedColorScheme === 'dark',
         },
         files: excalidrawAPI?.getFiles(),
       });


### PR DESCRIPTION
## Summary
- Use the current color scheme to set exportWithDarkMode when exporting Excalidraw SVGs.
- Previously the export was hardcoded to false, causing white backgrounds in dark mode.

Fixes #1451