### PR TITLE
fix: prevent table content clipping in PDF print

### DIFF
--- a/apps/client/src/features/editor/styles/print.css
+++ b/apps/client/src/features/editor/styles/print.css
@@ -18,6 +18,11 @@
   }
 
   .tableWrapper {
-    overflow: hidden !important;
+    overflow: visible !important;
+    max-width: 100%;
+  }
+
+  table {
+    page-break-inside: avoid;
   }
 }


### PR DESCRIPTION
﻿When printing a page to PDF, tables wider than the print area get clipped — the right side is cut off and there's no way to see the missing columns. This happens because .tableWrapper had overflow: hidden, which is fine on screen but wrong in a print context.

Changed .tableWrapper to overflow: visible for print, added max-width: 100% to keep it within the page, and added page-break-inside: avoid on table so rows don't get split across pages.

`diff
   .tableWrapper {
-    overflow: hidden !important;
+    overflow: visible !important;
+    max-width: 100%;
+  }
+
+  table {
+    page-break-inside: avoid;
   }
`

Fixes #1801

## Testing

Create a page with a wide table (more columns than fit on screen). Use the browser print dialog (Ctrl+P / Cmd+P) and check Print Preview — the full table should be visible, not clipped.
