### PR TITLE
fix(sidebar): increase favorite spaces display limit from 10 to 20

### DIFF
--- a/apps/client/src/components/layouts/global/global-sidebar.tsx
+++ b/apps/client/src/components/layouts/global/global-sidebar.tsx
@@ -81,7 +81,7 @@ export default function GlobalSidebar() {
             </Text>
           ) : (
             <>
-              {sortedFavoriteSpaces.slice(0, 10).map((fav) => (
+              {sortedFavoriteSpaces.slice(0, 20).map((fav) => (
                 <Link
                   key={fav.id}
                   className={classes.spaceItem}
@@ -101,7 +101,7 @@ export default function GlobalSidebar() {
                   </Text>
                 </Link>
               ))}
-              {sortedFavoriteSpaces.length > 10 && (
+              {sortedFavoriteSpaces.length > 20 && (
                 <Link
                   className={classes.spaceItem}
                   to="/spaces"


### PR DESCRIPTION
﻿The sidebar only showed up to 10 favorite spaces before showing a "View all" link. If you use spaces heavily, you hit that limit quickly and end up clicking through to a separate page just to navigate.

Bumped the limit to 20. Two-line change, both the slice and the condition that hides the "View all" link.

`diff
-{sortedFavoriteSpaces.slice(0, 10).map((fav) => (
+{sortedFavoriteSpaces.slice(0, 20).map((fav) => (

-{sortedFavoriteSpaces.length > 10 && (
+{sortedFavoriteSpaces.length > 20 && (
`

Fixes #2126

## Testing

Add more than 10 spaces to favorites. The sidebar should now show up to 20 before the "View all" link appears.
