### PR TITLE
fix(members): show pending invitation count on Pending tab

### DIFF
--- a/apps/client/src/pages/settings/workspace/workspace-members.tsx
+++ b/apps/client/src/pages/settings/workspace/workspace-members.tsx
@@ -11,6 +11,7 @@ import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
 import { useAtom } from "jotai";
 import { workspaceAtom } from "@/features/user/atoms/current-user-atom.ts";
+import { useWorkspaceInvitationsQuery } from "@/features/workspace/queries/workspace-query.ts";
 
 export default function WorkspaceMembers() {
   const { t } = useTranslation();
@@ -19,6 +20,8 @@ export default function WorkspaceMembers() {
   const [searchParams] = useSearchParams();
   const { isAdmin } = useUserRole();
   const navigate = useNavigate();
+  const { data: invitationsData } = useWorkspaceInvitationsQuery({ limit: 100 });
+  const pendingCount = invitationsData?.items.length ?? 0;
 
   useEffect(() => {
     const currentTab = searchParams.get("tab");
@@ -57,7 +60,7 @@ export default function WorkspaceMembers() {
               label: t("Members") + ` (${workspace?.memberCount})`,
               value: "members",
             },
-            { label: t("Pending"), value: "invites" },
+            { label: t("Pending") + (pendingCount > 0 ? ` (${pendingCount})` : ""), value: "invites" },
           ]}
           withItemsBorders={false}
         />


### PR DESCRIPTION
﻿The Members tab shows the member count in its label — "Members (12)" — but the Pending tab just said "Pending" with no count. You had to click into it to see if there were any outstanding invitations.

Reused the existing useWorkspaceInvitationsQuery (already used inside WorkspaceInvitesTable) at the parent level and appended the count to the label, matching how Members works. The count only shows when it's above 0 to avoid a permanent "(0)".

`diff
+const { data: invitationsData } = useWorkspaceInvitationsQuery({ limit: 100 });
+const pendingCount = invitationsData?.items.length ?? 0;

-{ label: t("Pending"), value: "invites" },
+{ label: t("Pending") + (pendingCount > 0 ?  () : ""), value: "invites" },
`

Fixes #2077

## Testing

Send a workspace invitation. Go to Settings > Members — the Pending tab should show the count, e.g. "Pending (1)". Accept or delete the invite and confirm the count updates on next load.
