### PR TITLE
fix(share): use fluid container on shared pages so wide tables are not clipped

### DIFF
--- a/apps/client/src/pages/share/shared-page.tsx
+++ b/apps/client/src/pages/share/shared-page.tsx
@@ -59,7 +59,7 @@ export default function SharedPage() {
         )}
       </Helmet>
 
-      <Container size={900} p={0}>
+      <Container fluid p={0}>
         <ReadonlyPageEditor
           key={data.page.id}
           title={data.page.title}


### PR DESCRIPTION
## Summary

Shared pages were rendered in a fixed 900px container, which clipped wide tables and did not reflect the author's full-width layout choice. This switches shared pages to a fluid container so wide tables and other content can use the available viewport width. The editor's built-in horizontal padding (3rem each side) preserves readable line lengths for prose.

Fixes #1863

## Testing

- Create a page with a wide table (more than 900px)
- Enable Full width in the editor
- Share the page and open the share link
- Verify the table is no longer clipped and renders at full width