### PR TITLE
fix(header): remove excess horizontal padding on mobile to prevent overflow

### DIFF
--- a/apps/client/src/components/layouts/global/app-header.tsx
+++ b/apps/client/src/components/layouts/global/app-header.tsx
@@ -117,7 +117,7 @@ export function AppHeader() {
           </Group>
         </div>
 
-        <Group px={"xl"} wrap="nowrap">
+        <Group px={{ base: 0, sm: "xl" }} wrap="nowrap">
           {aiChatEnabled && (
             <>
               <UnstyledButton


### PR DESCRIPTION
## Summary

The right-side header group had px=xl padding on all screen sizes, which combined with wrap=nowrap caused the notification and user menu icons to be clipped off screen on mobile browsers (reported on Firefox for Android).

This removes the extra horizontal padding on mobile (base: 0) while keeping it on desktop (sm: xl).

Fixes #1687

## Testing

- Open the app in Firefox Mobile or Chrome DevTools mobile emulation
- Verify all header icons (search, notifications, user menu) are fully visible and tappable