### PR TITLE
fix(table): preserve editor selection in Safari when applying cell background color

### DIFF
--- a/apps/client/src/features/editor/components/table/table-background-color.tsx
+++ b/apps/client/src/features/editor/components/table/table-background-color.tsx
@@ -98,7 +98,10 @@ export const TableBackgroundColor: FC<TableBackgroundColorProps> = ({
             variant="subtle"
             size="lg"
             aria-label={t("Background color")}
-            onClick={() => setOpened(!opened)}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              setOpened(!opened);
+            }}
           >
             <IconPalette size={18} />
           </ActionIcon>
@@ -121,7 +124,10 @@ export const TableBackgroundColor: FC<TableBackgroundColorProps> = ({
             {TABLE_COLORS.map((item, index) => (
               <UnstyledButton
                 key={index}
-                onClick={() => setTableCellBackground(item.color, item.name)}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  setTableCellBackground(item.color, item.name);
+                }}
                 style={{
                   position: "relative",
                   width: "24px",


### PR DESCRIPTION
## Summary

In Safari, clicking a color swatch in the table background color popover caused the editor to lose its selection before the command ran, so updateAttributes had no active cell to target and the color was silently dropped.

Switching from onClick to onMouseDown with e.preventDefault() prevents the editor from blurring, keeping the table cell selection intact when the color is applied. The same fix is applied to the popover trigger button.

Fixes #1503

## Testing

- Open the app in Safari
- Click inside a table cell to select it
- Open the cell background color picker from the table bubble menu
- Click a color swatch and verify the cell background color changes