### PR TITLE
fix(members): exclude already-added members from group and space member selectors

### DIFF
--- a/apps/client/src/features/group/components/add-group-member-modal.tsx
+++ b/apps/client/src/features/group/components/add-group-member-modal.tsx
@@ -3,7 +3,7 @@ import { useDisclosure } from "@mantine/hooks";
 import React, { useState } from "react";
 import { MultiUserSelect } from "@/features/group/components/multi-user-select.tsx";
 import { useParams } from "react-router-dom";
-import { useAddGroupMemberMutation } from "@/features/group/queries/group-query.ts";
+import { useAddGroupMemberMutation, useGroupMembersQuery } from "@/features/group/queries/group-query.ts";
 import { useTranslation } from "react-i18next";
 
 export default function AddGroupMemberModal() {
@@ -12,6 +12,8 @@ export default function AddGroupMemberModal() {
   const [opened, { open, close }] = useDisclosure(false);
   const [userIds, setUserIds] = useState<string[]>([]);
   const addGroupMemberMutation = useAddGroupMemberMutation();
+  const { data: groupMembers } = useGroupMembersQuery(groupId, { limit: 500 });
+  const existingMemberIds = groupMembers?.items.map((m) => m.id) ?? [];
 
   const handleMultiSelectChange = (value: string[]) => {
     setUserIds(value);
@@ -37,6 +39,7 @@ export default function AddGroupMemberModal() {
         <MultiUserSelect
           label={t("Add group members")}
           onChange={handleMultiSelectChange}
+          excludeIds={existingMemberIds}
         />
 
         <Group justify="flex-end" mt="md">

--- a/apps/client/src/features/group/components/multi-user-select.tsx
+++ b/apps/client/src/features/group/components/multi-user-select.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 interface MultiUserSelectProps {
   onChange: (value: string[]) => void;
   label?: string;
+  excludeIds?: string[];
 }
 
 const renderMultiSelectOption: MultiSelectProps["renderOption"] = ({
@@ -29,7 +30,7 @@ const renderMultiSelectOption: MultiSelectProps["renderOption"] = ({
   </Group>
 );
 
-export function MultiUserSelect({ onChange, label }: MultiUserSelectProps) {
+export function MultiUserSelect({ onChange, label, excludeIds = [] }: MultiUserSelectProps) {
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState("");
   const [debouncedQuery] = useDebouncedValue(searchValue, 500);
@@ -50,9 +51,10 @@ export function MultiUserSelect({ onChange, label }: MultiUserSelectProps) {
         };
       });
 
-      // Filter out existing users by their ids
+      // Filter out already-existing members and previously seen users
       const filteredUsersData = usersData.filter(
         (user) =>
+          !excludeIds.includes(user.value) &&
           !data.find((existingUser) => existingUser.value === user.value),
       );
 

--- a/apps/client/src/features/space/components/add-space-members-modal.tsx
+++ b/apps/client/src/features/space/components/add-space-members-modal.tsx
@@ -1,7 +1,7 @@
 import { Button, Divider, Group, Modal, Stack } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import React, { useState } from "react";
-import { useAddSpaceMemberMutation } from "@/features/space/queries/space-query.ts";
+import React, { useMemo, useState } from "react";
+import { useAddSpaceMemberMutation, useSpaceMembersInfiniteQuery } from "@/features/space/queries/space-query.ts";
 import { MultiMemberSelect } from "@/features/space/components/multi-member-select.tsx";
 import { SpaceMemberRole } from "@/features/space/components/space-member-role.tsx";
 import { SpaceRole } from "@/lib/types.ts";
@@ -18,6 +18,13 @@ export default function AddSpaceMembersModal({
   const [memberIds, setMemberIds] = useState<string[]>([]);
   const [role, setRole] = useState<string>(SpaceRole.WRITER);
   const addSpaceMemberMutation = useAddSpaceMemberMutation();
+  const { data: spaceMembersData } = useSpaceMembersInfiniteQuery(spaceId);
+  const existingMemberIds = useMemo(() => {
+    const pages = spaceMembersData?.pages ?? [];
+    return pages.flatMap((p) =>
+      p.items.map((m) => `${m.type}-${m.id}`),
+    );
+  }, [spaceMembersData]);
 
   const handleMultiSelectChange = (value: string[]) => {
     setMemberIds(value);
@@ -55,7 +62,7 @@ export default function AddSpaceMembersModal({
         <Divider size="xs" mb="xs" />
 
         <Stack>
-          <MultiMemberSelect onChange={handleMultiSelectChange} />
+          <MultiMemberSelect onChange={handleMultiSelectChange} excludeIds={existingMemberIds} />
           <SpaceMemberRole
             onSelect={handleRoleSelection}
             defaultRole={role}

--- a/apps/client/src/features/space/components/multi-member-select.tsx
+++ b/apps/client/src/features/space/components/multi-member-select.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next";
 interface MultiMemberSelectProps {
   value?: string[];
   onChange: (value: string[]) => void;
+  excludeIds?: string[];
 }
 
 const renderMultiSelectOption: MultiSelectProps["renderOption"] = ({
@@ -34,7 +35,7 @@ const renderMultiSelectOption: MultiSelectProps["renderOption"] = ({
   </Group>
 );
 
-export function MultiMemberSelect({ value, onChange }: MultiMemberSelectProps) {
+export function MultiMemberSelect({ value, onChange, excludeIds = [] }: MultiMemberSelectProps) {
   const { t } = useTranslation();
   const [searchValue, setSearchValue] = useState("");
   const [debouncedQuery] = useDebouncedValue(searchValue, 500);
@@ -62,20 +63,27 @@ export function MultiMemberSelect({ value, onChange }: MultiMemberSelectProps) {
         type: "group",
       }));
 
-      // Create fresh data structure based on current search results
+      // Create fresh data structure based on current search results, excluding existing members
+      const filteredUserItems = userItems
+        ? userItems.filter((u) => !excludeIds.includes(u.value))
+        : [];
+      const filteredGroupItems = groupItems
+        ? groupItems.filter((g) => !excludeIds.includes(g.value))
+        : [];
+
       const newData = [];
       
-      if (userItems && userItems.length > 0) {
+      if (filteredUserItems.length > 0) {
         newData.push({
           group: t("Select a user"),
-          items: userItems,
+          items: filteredUserItems,
         });
       }
       
-      if (groupItems && groupItems.length > 0) {
+      if (filteredGroupItems.length > 0) {
         newData.push({
           group: t("Select a group"),
-          items: groupItems,
+          items: filteredGroupItems,
         });
       }
 


### PR DESCRIPTION
## Summary

When adding members to a group or space, the selector previously showed all workspace members including those already in the group or space. Users had to guess which members were already added.

This adds an excludeIds prop to MultiUserSelect and MultiMemberSelect. The parent modals now fetch existing members and pass their IDs to the selector, which filters them out of the dropdown results.

Fixes #1102

## Testing

- Open a group that already has some members
- Click Add group members
- Verify existing members do not appear in the search dropdown
- Same for spaces: open space settings, click Add space members, verify current members and groups are excluded