### PR TITLE
fix(security): prevent SQL injection in space settings update

### DIFF
--- a/apps/server/src/database/repos/space/space.repo.ts
+++ b/apps/server/src/database/repos/space/space.repo.ts
@@ -102,7 +102,7 @@ export class SpaceRepo {
       .set({
         settings: sql`COALESCE(settings, '{}'::jsonb)
           || jsonb_build_object('sharing', COALESCE(settings->'sharing', '{}'::jsonb)
-          || jsonb_build_object('${sql.raw(prefKey)}', ${sql.lit(prefValue)}))`,
+          || jsonb_build_object(${sql.lit(prefKey)}, ${sql.lit(prefValue)}))`,
         updatedAt: new Date(),
       })
       .where('id', '=', spaceId)
@@ -124,7 +124,7 @@ export class SpaceRepo {
       .set({
         settings: sql`COALESCE(settings, '{}'::jsonb)
           || jsonb_build_object('comments', COALESCE(settings->'comments', '{}'::jsonb)
-          || jsonb_build_object('${sql.raw(prefKey)}', ${sql.lit(prefValue)}))`,
+          || jsonb_build_object(${sql.lit(prefKey)}, ${sql.lit(prefValue)}))`,
         updatedAt: new Date(),
       })
       .where('id', '=', spaceId)


### PR DESCRIPTION
## Summary
- Replace `sql.raw(prefKey)` with `sql.lit(prefKey)` in `updateSharingSettings` and `updateCommentSettings` methods in `space.repo.ts`
- `sql.raw()` directly interpolates user input into the SQL query string without escaping, which enables SQL injection attacks
- `sql.lit()` properly escapes the value as a SQL literal, preventing injection

## Vulnerability Details

In `apps/server/src/database/repos/space/space.repo.ts`, the `updateSharingSettings` (line 105) and `updateCommentSettings` (line 127) methods use:

```typescript
|| jsonb_build_object('${sql.raw(prefKey)}', ${sql.lit(prefValue)}))
```

The `prefKey` parameter comes from user-controlled API input. Since `sql.raw()` inserts the string directly into the SQL without any escaping, an attacker could inject arbitrary SQL by crafting a malicious `prefKey` value.

## Fix

Changed to use `sql.lit(prefKey)` which properly escapes the key as a SQL literal:

```typescript
|| jsonb_build_object(${sql.lit(prefKey)}, ${sql.lit(prefValue)}))
```

## Test plan
- [ ] Verify that existing space sharing settings update functionality still works correctly
- [ ] Verify that existing space comment settings update functionality still works correctly
- [ ] Test with special characters in setting keys to confirm proper escaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)