### PR TITLE
fix(security): prevent SQL injection in user preference update

### DIFF
--- a/apps/server/src/database/repos/user/user.repo.ts
+++ b/apps/server/src/database/repos/user/user.repo.ts
@@ -187,8 +187,8 @@ export class UserRepo {
       .updateTable('users')
       .set({
         settings: sql`COALESCE(settings, '{}'::jsonb)
-                || jsonb_build_object('preferences', COALESCE(settings->'preferences', '{}'::jsonb) 
-                || jsonb_build_object('${sql.raw(prefKey)}', ${sql.lit(prefValue)}))`,
+                || jsonb_build_object('preferences', COALESCE(settings->'preferences', '{}'::jsonb)
+                || jsonb_build_object(${sql.lit(prefKey)}, ${sql.lit(prefValue)}))`,
         updatedAt: new Date(),
       })
       .where('id', '=', userId)


### PR DESCRIPTION
## Summary
- Replace `sql.raw(prefKey)` with `sql.lit(prefKey)` in `updatePreference` method in `user.repo.ts`
- `sql.raw()` directly interpolates user input into the SQL query string without escaping, which enables SQL injection attacks
- `sql.lit()` properly escapes the value as a SQL literal, preventing injection

## Vulnerability Details

In `apps/server/src/database/repos/user/user.repo.ts`, the `updatePreference` method (line 191) uses:

```typescript
|| jsonb_build_object('${sql.raw(prefKey)}', ${sql.lit(prefValue)}))
```

The `prefKey` parameter comes from user-controlled API input. Since `sql.raw()` inserts the string directly into the SQL without any escaping, an attacker could inject arbitrary SQL by crafting a malicious `prefKey` value.

## Fix

Changed to use `sql.lit(prefKey)` which properly escapes the key as a SQL literal:

```typescript
|| jsonb_build_object(${sql.lit(prefKey)}, ${sql.lit(prefValue)}))
```

## Test plan
- [ ] Verify that user preference updates still work correctly
- [ ] Test with special characters in preference keys to confirm proper escaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)