### PR TITLE
fix(security): restrict WebSocket CORS origin instead of wildcard

### DIFF
--- a/apps/server/src/ws/ws.gateway.ts
+++ b/apps/server/src/ws/ws.gateway.ts
@@ -16,7 +16,7 @@ import { getSpaceRoomName, getUserRoomName } from './ws.utils';
 import * as cookie from 'cookie';
 
 @WebSocketGateway({
-  cors: { origin: '*' },
+  cors: { origin: process.env.APP_URL || 'http://localhost:3000', credentials: true },
   transports: ['websocket'],
 })
 export class WsGateway


### PR DESCRIPTION
## Summary
- Replace `cors: { origin: '*' }` with a restricted origin using the `APP_URL` environment variable in the WebSocket gateway
- The wildcard CORS origin allows any website to make cross-origin WebSocket connections to the Docmost server
- This enables potential CSRF attacks where a malicious website could establish a WebSocket connection and interact with the server on behalf of an authenticated user

## Vulnerability Details

In `apps/server/src/ws/ws.gateway.ts` (line 19), the WebSocket gateway is configured with:

```typescript
cors: { origin: '*' },
```

While the `handleConnection` method does authenticate connections via JWT tokens, the wildcard CORS origin means:
1. Any malicious website can initiate a WebSocket connection to the Docmost server
2. Combined with cookie-based authentication, this could enable cross-site WebSocket hijacking
3. The `credentials: true` option was missing, which is needed for cookie-based auth to work properly with restricted origins

## Fix

Changed to use the `APP_URL` environment variable as the allowed origin, with `http://localhost:3000` as default for development:

```typescript
cors: { origin: process.env.APP_URL || 'http://localhost:3000', credentials: true },
```

## Test plan
- [ ] Verify WebSocket connections still work from the configured APP_URL
- [ ] Verify WebSocket connections are rejected from unauthorized origins
- [ ] Test both development (localhost) and production deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)