### PR TITLE
fix: add null check for Host header in share SEO controller

### DIFF
--- a/apps/server/src/core/share/share-seo.controller.ts
+++ b/apps/server/src/core/share/share-seo.controller.ts
@@ -38,6 +38,9 @@ export class ShareSeoController {
       workspace = await this.workspaceRepo.findFirst();
     } else {
       const header = req.raw.headers.host;
+      if (!header) {
+        return this.sendIndex(indexFilePath, res);
+      }
       const subdomain = header.split('.')[0];
       workspace = await this.workspaceRepo.findByHostname(subdomain);
     }


### PR DESCRIPTION
## Summary
- Add null/undefined check for the `Host` header in `share-seo.controller.ts` before calling `.split('.')`
- Without this check, a missing Host header causes an unhandled `TypeError: Cannot read properties of undefined (reading 'split')` which crashes the request handler

## Bug Details

In `apps/server/src/core/share/share-seo.controller.ts` (line 40-41), in the cloud-hosted path:

```typescript
const header = req.raw.headers.host;
const subdomain = header.split('.')[0];
```

If a request arrives without a `Host` header (e.g., HTTP/1.0 requests, malformed requests, or certain proxy configurations), `req.raw.headers.host` will be `undefined`, and calling `.split('.')` on it will throw:

```
TypeError: Cannot read properties of undefined (reading 'split')
```

The same pattern in `domain.middleware.ts` (line 29-30) has the same vulnerability but is outside the scope of this PR.

## Fix

Added a null check that falls back to serving the default index.html when the Host header is missing:

```typescript
const header = req.raw.headers.host;
if (!header) {
  return this.sendIndex(indexFilePath, res);
}
const subdomain = header.split('.')[0];
```

## Test plan
- [ ] Send a request to `/share/{shareId}/p/{pageSlug}` without a Host header and verify it returns index.html instead of 500
- [ ] Verify normal share page functionality with valid Host headers still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)