### PR TITLE
webhooks POC

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -39,6 +39,7 @@ import UserApiKeys from "@/ee/api-key/pages/user-api-keys";
 import WorkspaceApiKeys from "@/ee/api-key/pages/workspace-api-keys";
 import AiSettings from "@/ee/ai/pages/ai-settings.tsx";
 import AuditLogs from "@/ee/audit/pages/audit-logs.tsx";
+import Webhooks from "@/ee/webhook/pages/webhooks.tsx";
 import VerifiedPages from "@/ee/page-verification/pages/verified-pages.tsx";
 import TemplateList from "@/ee/template/pages/template-list";
 import TemplateEditor from "@/ee/template/pages/template-editor";
@@ -124,6 +125,7 @@ export default function App() {
             <Route path={"ai"} element={<AiSettings />} />
             <Route path={"ai/mcp"} element={<AiSettings />} />
             <Route path={"audit"} element={<AuditLogs />} />
+            <Route path={"webhooks"} element={<Webhooks />} />
             <Route path={"verifications"} element={<VerifiedPages />} />
             {!isCloud() && <Route path={"license"} element={<License />} />}
             {isCloud() && <Route path={"billing"} element={<Billing />} />}

--- a/apps/client/src/components/settings/settings-queries.tsx
+++ b/apps/client/src/components/settings/settings-queries.tsx
@@ -14,6 +14,7 @@ import { getApiKeys } from "@/ee/api-key";
 import { getAuditLogs } from "@/ee/audit/services/audit-service";
 import { getVerificationList } from "@/ee/page-verification/services/page-verification-service";
 import { getScimTokens } from "@/ee/scim/services/scim-token-service";
+import { getWebhooks } from "@/ee/webhook/services/webhook-service";
 
 export const prefetchWorkspaceMembers = () => {
   const params: QueryParams = { limit: 100, query: "" };
@@ -104,5 +105,13 @@ export const prefetchScimTokens = () => {
   queryClient.prefetchQuery({
     queryKey: ["scim-token-list", { cursor: undefined }],
     queryFn: () => getScimTokens({}),
+  });
+};
+
+export const prefetchWebhooks = () => {
+  const params = { limit: 50 };
+  queryClient.prefetchQuery({
+    queryKey: ["webhook-list", params],
+    queryFn: () => getWebhooks(params),
   });
 };

--- a/apps/client/src/components/settings/settings-sidebar.tsx
+++ b/apps/client/src/components/settings/settings-sidebar.tsx
@@ -15,6 +15,7 @@ import {
   IconSparkles,
   IconHistory,
   IconShieldCheck,
+  IconWebhook,
 } from "@tabler/icons-react";
 import { Link, useLocation } from "react-router-dom";
 import classes from "./settings.module.css";
@@ -38,6 +39,7 @@ import {
   prefetchWorkspaceMembers,
   prefetchAuditLogs,
   prefetchVerifiedPages,
+  prefetchWebhooks,
 } from "@/components/settings/settings-queries.tsx";
 import AppVersion from "@/components/settings/app-version.tsx";
 import { mobileSidebarAtom } from "@/components/layouts/global/hooks/atoms/sidebar-atom.ts";
@@ -124,6 +126,13 @@ const groupedData: DataGroup[] = [
         feature: Feature.AUDIT_LOGS,
         role: "owner",
         env: "selfhosted",
+      },
+      {
+        label: "Webhooks",
+        icon: IconWebhook,
+        path: "/settings/webhooks",
+        feature: Feature.WEBHOOKS,
+        role: "admin",
       },
     ],
   },
@@ -221,6 +230,9 @@ export default function SettingsSidebar() {
               break;
             case "Audit log":
               prefetchHandler = prefetchAuditLogs;
+              break;
+            case "Webhooks":
+              prefetchHandler = prefetchWebhooks;
               break;
             case "Verified pages":
               prefetchHandler = prefetchVerifiedPages;

--- a/apps/client/src/ee/features.ts
+++ b/apps/client/src/ee/features.ts
@@ -19,4 +19,5 @@ export const Feature = {
   SHARING_CONTROLS: 'sharing:controls',
   TEMPLATES: 'templates',
   VIEWER_COMMENTS: 'comment:viewer',
+  WEBHOOKS: 'webhooks',
 } as const;

--- a/apps/client/src/ee/webhook/components/create-webhook-modal.tsx
+++ b/apps/client/src/ee/webhook/components/create-webhook-modal.tsx
@@ -1,0 +1,140 @@
+import {
+  Button,
+  Group,
+  Modal,
+  MultiSelect,
+  Stack,
+  Switch,
+  TextInput,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { zod4Resolver } from "mantine-form-zod-resolver";
+import { z } from "zod/v4";
+import { useTranslation } from "react-i18next";
+import { useCreateWebhookMutation } from "@/ee/webhook/queries/webhook-query";
+import {
+  EVENT_GROUPS,
+  multiSelectData,
+} from "@/ee/webhook/lib/webhook-event-labels";
+import type { WebhookEvent } from "@/ee/webhook/types/webhook.types";
+
+interface CreateWebhookModalProps {
+  opened: boolean;
+  onClose: () => void;
+  onSuccess: (signingSecret: string) => void;
+}
+
+const allowedEvents: WebhookEvent[] = EVENT_GROUPS.flatMap((g) => g.events);
+
+const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(100, "Name is too long"),
+  url: z
+    .string()
+    .min(1, "URL is required")
+    .refine(
+      (value) => /^https?:\/\//i.test(value),
+      "URL must start with http:// or https://",
+    ),
+  subscribedEvents: z
+    .array(z.enum(allowedEvents as [WebhookEvent, ...WebhookEvent[]]))
+    .min(1, "Select at least one event"),
+  isActive: z.boolean(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export function CreateWebhookModal({
+  opened,
+  onClose,
+  onSuccess,
+}: CreateWebhookModalProps) {
+  const { t } = useTranslation();
+  const createWebhookMutation = useCreateWebhookMutation();
+
+  const form = useForm<FormValues>({
+    validate: zod4Resolver(formSchema),
+    initialValues: {
+      name: "",
+      url: "",
+      subscribedEvents: [],
+      isActive: true,
+    },
+  });
+
+  const handleClose = () => {
+    form.reset();
+    onClose();
+  };
+
+  const handleSubmit = async (values: FormValues) => {
+    try {
+      const result = await createWebhookMutation.mutateAsync({
+        name: values.name,
+        url: values.url,
+        subscribedEvents: values.subscribedEvents,
+        isActive: values.isActive,
+      });
+      form.reset();
+      onClose();
+      onSuccess(result.signingSecret);
+    } catch (_err) {
+      // notification handled inside mutation
+    }
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={handleClose}
+      title={t("Create webhook")}
+      size="lg"
+    >
+      <form onSubmit={form.onSubmit(handleSubmit)}>
+        <Stack gap="md">
+          <TextInput
+            label={t("Name")}
+            placeholder={t("e.g. Production alerts")}
+            required
+            data-autofocus
+            {...form.getInputProps("name")}
+          />
+
+          <TextInput
+            label={t("URL")}
+            placeholder="https://example.com/webhook"
+            required
+            {...form.getInputProps("url")}
+          />
+
+          <MultiSelect
+            label={t("Events")}
+            placeholder={t("Select events to subscribe to")}
+            data={multiSelectData()}
+            searchable
+            clearable
+            required
+            {...form.getInputProps("subscribedEvents")}
+          />
+
+          <Switch
+            label={t("Active")}
+            description={t("Deliveries fire only when the webhook is active")}
+            checked={form.values.isActive}
+            onChange={(event) =>
+              form.setFieldValue("isActive", event.currentTarget.checked)
+            }
+          />
+
+          <Group justify="flex-end" mt="md">
+            <Button variant="default" onClick={handleClose}>
+              {t("Cancel")}
+            </Button>
+            <Button type="submit" loading={createWebhookMutation.isPending}>
+              {t("Create")}
+            </Button>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
+  );
+}

--- a/apps/client/src/ee/webhook/components/delivery-drawer.tsx
+++ b/apps/client/src/ee/webhook/components/delivery-drawer.tsx
@@ -1,0 +1,310 @@
+import { Fragment, useState } from "react";
+import {
+  Badge,
+  Box,
+  Button,
+  Collapse,
+  Drawer,
+  Group,
+  ScrollArea,
+  Skeleton,
+  Table,
+  Text,
+} from "@mantine/core";
+import {
+  IconChevronDown,
+  IconChevronRight,
+  IconRefresh,
+} from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+import {
+  useRedeliverMutation,
+  useWebhookDeliveries,
+} from "@/ee/webhook/queries/webhook-query";
+import { formattedDate } from "@/lib/time";
+import NoTableResults from "@/components/common/no-table-results";
+import type {
+  IWebhookDelivery,
+  WebhookDeliveryStatus,
+} from "@/ee/webhook/types/webhook.types";
+
+interface DeliveryDrawerProps {
+  opened: boolean;
+  onClose: () => void;
+  webhookId: string | null;
+}
+
+function statusColor(status: WebhookDeliveryStatus): string {
+  switch (status) {
+    case "success":
+      return "green";
+    case "failed":
+      return "red";
+    case "pending":
+      return "yellow";
+    case "skipped_cooldown":
+    case "skipped_inflight":
+    case "skipped_disabled":
+    default:
+      return "gray";
+  }
+}
+
+function statusLabel(status: WebhookDeliveryStatus): string {
+  switch (status) {
+    case "skipped_cooldown":
+      return "skipped (cooldown)";
+    case "skipped_inflight":
+      return "skipped (in-flight)";
+    case "skipped_disabled":
+      return "skipped (disabled)";
+    default:
+      return status;
+  }
+}
+
+function canRedeliver(status: WebhookDeliveryStatus): boolean {
+  return (
+    status === "failed" ||
+    status === "skipped_cooldown" ||
+    status === "skipped_inflight" ||
+    status === "skipped_disabled"
+  );
+}
+
+function DeliveryRow({
+  delivery,
+  expanded,
+  onToggle,
+  onRedeliver,
+  isRedelivering,
+}: {
+  delivery: IWebhookDelivery;
+  expanded: boolean;
+  onToggle: () => void;
+  onRedeliver: () => void;
+  isRedelivering: boolean;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Fragment>
+      <Table.Tr style={{ cursor: "pointer" }} onClick={onToggle}>
+        <Table.Td>
+          <Group gap="xs" wrap="nowrap">
+            {expanded ? (
+              <IconChevronDown
+                size={16}
+                color="var(--mantine-color-dimmed)"
+              />
+            ) : (
+              <IconChevronRight
+                size={16}
+                color="var(--mantine-color-dimmed)"
+              />
+            )}
+            <Text fz="sm" fw={500}>
+              {delivery.event}
+            </Text>
+          </Group>
+        </Table.Td>
+        <Table.Td>
+          <Badge color={statusColor(delivery.status)} variant="light">
+            {statusLabel(delivery.status)}
+          </Badge>
+        </Table.Td>
+        <Table.Td>
+          <Text fz="sm">
+            {delivery.httpStatus ?? "—"}
+          </Text>
+        </Table.Td>
+        <Table.Td>
+          <Text fz="sm">
+            {delivery.durationMs != null ? `${delivery.durationMs} ms` : "—"}
+          </Text>
+        </Table.Td>
+        <Table.Td>
+          <Text fz="sm" style={{ whiteSpace: "nowrap" }}>
+            {formattedDate(new Date(delivery.createdAt))}
+          </Text>
+        </Table.Td>
+        <Table.Td onClick={(e) => e.stopPropagation()}>
+          {canRedeliver(delivery.status) ? (
+            <Button
+              size="compact-xs"
+              variant="default"
+              leftSection={<IconRefresh size={12} />}
+              onClick={onRedeliver}
+              loading={isRedelivering}
+            >
+              {t("Redeliver")}
+            </Button>
+          ) : null}
+        </Table.Td>
+      </Table.Tr>
+
+      <Table.Tr>
+        <Table.Td colSpan={6} p={0} style={{ border: "none" }}>
+          <Collapse in={expanded}>
+            <Box
+              px="md"
+              py="sm"
+              style={{ background: "var(--mantine-color-gray-light)" }}
+            >
+              <Text fz="xs" fw={600} mb={4}>
+                {t("Payload")}
+              </Text>
+              <Box
+                component="pre"
+                style={{
+                  fontSize: 11,
+                  margin: 0,
+                  padding: 8,
+                  background: "var(--mantine-color-body)",
+                  borderRadius: 4,
+                  overflowX: "auto",
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                }}
+              >
+                {JSON.stringify(delivery.payload, null, 2)}
+              </Box>
+
+              {delivery.responseBody && (
+                <>
+                  <Text fz="xs" fw={600} mt="sm" mb={4}>
+                    {t("Response body")}
+                  </Text>
+                  <Box
+                    component="pre"
+                    style={{
+                      fontSize: 11,
+                      margin: 0,
+                      padding: 8,
+                      background: "var(--mantine-color-body)",
+                      borderRadius: 4,
+                      overflowX: "auto",
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-word",
+                    }}
+                  >
+                    {delivery.responseBody}
+                  </Box>
+                </>
+              )}
+
+              {delivery.errorMessage && (
+                <>
+                  <Text fz="xs" fw={600} mt="sm" mb={4} c="red">
+                    {t("Error")}
+                  </Text>
+                  <Text fz="xs" c="red">
+                    {delivery.errorMessage}
+                  </Text>
+                </>
+              )}
+            </Box>
+          </Collapse>
+        </Table.Td>
+      </Table.Tr>
+    </Fragment>
+  );
+}
+
+export function DeliveryDrawer({
+  opened,
+  onClose,
+  webhookId,
+}: DeliveryDrawerProps) {
+  const { t } = useTranslation();
+  const { data, isLoading } = useWebhookDeliveries(opened ? webhookId : null);
+  const redeliverMutation = useRedeliverMutation(webhookId ?? undefined);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleRedeliver = async (deliveryId: string) => {
+    setPendingId(deliveryId);
+    try {
+      await redeliverMutation.mutateAsync({ deliveryId });
+    } catch (_err) {
+      // notification handled inside mutation
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  return (
+    <Drawer
+      opened={opened}
+      onClose={onClose}
+      title={t("Recent deliveries")}
+      position="right"
+      size="xl"
+    >
+      <ScrollArea h="calc(100vh - 80px)">
+        <Table verticalSpacing="xs" striped={false}>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>{t("Event")}</Table.Th>
+              <Table.Th>{t("Status")}</Table.Th>
+              <Table.Th>{t("HTTP")}</Table.Th>
+              <Table.Th>{t("Duration")}</Table.Th>
+              <Table.Th>{t("Timestamp")}</Table.Th>
+              <Table.Th aria-label={t("Action")} />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {isLoading ? (
+              Array.from({ length: 6 }).map((_, i) => (
+                <Table.Tr key={i}>
+                  <Table.Td>
+                    <Skeleton height={14} width={120} />
+                  </Table.Td>
+                  <Table.Td>
+                    <Skeleton height={14} width={70} />
+                  </Table.Td>
+                  <Table.Td>
+                    <Skeleton height={14} width={40} />
+                  </Table.Td>
+                  <Table.Td>
+                    <Skeleton height={14} width={60} />
+                  </Table.Td>
+                  <Table.Td>
+                    <Skeleton height={14} width={140} />
+                  </Table.Td>
+                  <Table.Td>
+                    <Skeleton height={14} width={70} />
+                  </Table.Td>
+                </Table.Tr>
+              ))
+            ) : data && data.length > 0 ? (
+              data.map((delivery) => (
+                <DeliveryRow
+                  key={delivery.id}
+                  delivery={delivery}
+                  expanded={expanded.has(delivery.id)}
+                  onToggle={() => toggle(delivery.id)}
+                  onRedeliver={() => handleRedeliver(delivery.id)}
+                  isRedelivering={
+                    pendingId === delivery.id && redeliverMutation.isPending
+                  }
+                />
+              ))
+            ) : (
+              <NoTableResults colSpan={6} text={t("No deliveries yet")} />
+            )}
+          </Table.Tbody>
+        </Table>
+      </ScrollArea>
+    </Drawer>
+  );
+}

--- a/apps/client/src/ee/webhook/components/edit-webhook-modal.tsx
+++ b/apps/client/src/ee/webhook/components/edit-webhook-modal.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Divider,
+  Group,
+  Modal,
+  MultiSelect,
+  PasswordInput,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { zod4Resolver } from "mantine-form-zod-resolver";
+import { z } from "zod/v4";
+import { useTranslation } from "react-i18next";
+import {
+  useRotateSecretMutation,
+  useSendTestMutation,
+  useUpdateWebhookMutation,
+  useWebhook,
+} from "@/ee/webhook/queries/webhook-query";
+import {
+  EVENT_GROUPS,
+  multiSelectData,
+} from "@/ee/webhook/lib/webhook-event-labels";
+import type { WebhookEvent } from "@/ee/webhook/types/webhook.types";
+import { WebhookSecretModal } from "@/ee/webhook/components/webhook-secret-modal";
+
+interface EditWebhookModalProps {
+  opened: boolean;
+  onClose: () => void;
+  webhookId: string | null;
+}
+
+const allowedEvents: WebhookEvent[] = EVENT_GROUPS.flatMap((g) => g.events);
+
+const formSchema = z.object({
+  name: z.string().min(1, "Name is required").max(100, "Name is too long"),
+  url: z
+    .string()
+    .min(1, "URL is required")
+    .refine(
+      (value) => /^https?:\/\//i.test(value),
+      "URL must start with http:// or https://",
+    ),
+  subscribedEvents: z
+    .array(z.enum(allowedEvents as [WebhookEvent, ...WebhookEvent[]]))
+    .min(1, "Select at least one event"),
+  isActive: z.boolean(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export function EditWebhookModal({
+  opened,
+  onClose,
+  webhookId,
+}: EditWebhookModalProps) {
+  const { t } = useTranslation();
+  const { data: webhook, isLoading } = useWebhook(opened ? webhookId : null);
+  const updateMutation = useUpdateWebhookMutation();
+  const rotateMutation = useRotateSecretMutation();
+  const sendTestMutation = useSendTestMutation();
+
+  const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
+
+  const form = useForm<FormValues>({
+    validate: zod4Resolver(formSchema),
+    initialValues: {
+      name: "",
+      url: "",
+      subscribedEvents: [],
+      isActive: true,
+    },
+  });
+
+  useEffect(() => {
+    if (opened && webhook) {
+      form.setValues({
+        name: webhook.name,
+        url: webhook.url,
+        subscribedEvents: webhook.subscribedEvents,
+        isActive: webhook.isActive,
+      });
+      form.resetDirty();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opened, webhook?.id]);
+
+  const handleClose = () => {
+    form.reset();
+    onClose();
+  };
+
+  const handleSubmit = async (values: FormValues) => {
+    if (!webhookId) return;
+    try {
+      await updateMutation.mutateAsync({
+        webhookId,
+        name: values.name,
+        url: values.url,
+        subscribedEvents: values.subscribedEvents,
+        isActive: values.isActive,
+      });
+      onClose();
+    } catch (_err) {
+      // notification handled inside mutation
+    }
+  };
+
+  const handleRotate = async () => {
+    if (!webhookId) return;
+    try {
+      const result = await rotateMutation.mutateAsync({ webhookId });
+      setRevealedSecret(result.signingSecret);
+    } catch (_err) {
+      // notification handled inside mutation
+    }
+  };
+
+  const handleSendTest = async () => {
+    if (!webhookId) return;
+    try {
+      await sendTestMutation.mutateAsync({ webhookId });
+    } catch (_err) {
+      // notification handled inside mutation
+    }
+  };
+
+  return (
+    <>
+      <Modal
+        opened={opened}
+        onClose={handleClose}
+        title={t("Edit webhook")}
+        size="lg"
+      >
+        <form onSubmit={form.onSubmit(handleSubmit)}>
+          <Stack gap="md">
+            <TextInput
+              label={t("Name")}
+              placeholder={t("e.g. Production alerts")}
+              required
+              disabled={isLoading}
+              {...form.getInputProps("name")}
+            />
+
+            <TextInput
+              label={t("URL")}
+              placeholder="https://example.com/webhook"
+              required
+              disabled={isLoading}
+              {...form.getInputProps("url")}
+            />
+
+            <MultiSelect
+              label={t("Events")}
+              placeholder={t("Select events to subscribe to")}
+              data={multiSelectData()}
+              searchable
+              clearable
+              required
+              disabled={isLoading}
+              {...form.getInputProps("subscribedEvents")}
+            />
+
+            <Switch
+              label={t("Active")}
+              description={t(
+                "Deliveries fire only when the webhook is active",
+              )}
+              checked={form.values.isActive}
+              disabled={isLoading}
+              onChange={(event) =>
+                form.setFieldValue("isActive", event.currentTarget.checked)
+              }
+            />
+
+            <Divider my="xs" />
+
+            <div>
+              <Text size="sm" fw={500} mb="xs">
+                {t("Signing secret")}
+              </Text>
+              <Group gap="xs" wrap="nowrap" align="flex-start">
+                <PasswordInput
+                  value="dm_wh_••••••••••••••••••••••••••••••••"
+                  readOnly
+                  visible={false}
+                  style={{ flex: 1 }}
+                />
+                <Button
+                  variant="default"
+                  onClick={handleRotate}
+                  loading={rotateMutation.isPending}
+                >
+                  {t("Rotate")}
+                </Button>
+              </Group>
+              <Text size="xs" c="dimmed" mt={4}>
+                {t(
+                  "Rotating generates a new signing secret. The previous secret stops working immediately.",
+                )}
+              </Text>
+            </div>
+
+            <Divider my="xs" />
+
+            <Group justify="space-between" mt="md">
+              <Button
+                variant="default"
+                onClick={handleSendTest}
+                loading={sendTestMutation.isPending}
+              >
+                {t("Send test event")}
+              </Button>
+
+              <Group>
+                <Button variant="default" onClick={handleClose}>
+                  {t("Cancel")}
+                </Button>
+                <Button type="submit" loading={updateMutation.isPending}>
+                  {t("Save")}
+                </Button>
+              </Group>
+            </Group>
+          </Stack>
+        </form>
+      </Modal>
+
+      <WebhookSecretModal
+        opened={!!revealedSecret}
+        onClose={() => setRevealedSecret(null)}
+        secret={revealedSecret}
+      />
+    </>
+  );
+}

--- a/apps/client/src/ee/webhook/components/webhook-secret-modal.tsx
+++ b/apps/client/src/ee/webhook/components/webhook-secret-modal.tsx
@@ -1,0 +1,78 @@
+import {
+  Alert,
+  Button,
+  Code,
+  Group,
+  Modal,
+  Stack,
+  Text,
+} from "@mantine/core";
+import { IconAlertTriangle } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+import CopyTextButton from "@/components/common/copy";
+
+interface WebhookSecretModalProps {
+  opened: boolean;
+  onClose: () => void;
+  secret: string | null;
+}
+
+export function WebhookSecretModal({
+  opened,
+  onClose,
+  secret,
+}: WebhookSecretModalProps) {
+  const { t } = useTranslation();
+
+  if (!secret) return null;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={t("Save this signing secret")}
+      size="lg"
+    >
+      <Stack gap="md">
+        <Alert
+          icon={<IconAlertTriangle size={16} />}
+          title={t("Important")}
+          color="red"
+        >
+          {t(
+            "We won't show it again. Copy it now and store it somewhere safe. You can rotate it later if needed.",
+          )}
+        </Alert>
+
+        <div>
+          <Text size="sm" fw={500} mb="xs">
+            {t("Signing secret")}
+          </Text>
+          <Group gap="xs" wrap="nowrap" align="center">
+            <Code
+              block
+              style={{
+                flex: 1,
+                wordBreak: "break-all",
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {secret}
+            </Code>
+            <CopyTextButton text={secret} />
+          </Group>
+        </div>
+
+        <Text size="sm" c="dimmed">
+          {t(
+            "Use this secret to verify the X-Docmost-Signature header on incoming webhook deliveries.",
+          )}
+        </Text>
+
+        <Button fullWidth onClick={onClose} mt="md">
+          {t("I've saved my signing secret")}
+        </Button>
+      </Stack>
+    </Modal>
+  );
+}

--- a/apps/client/src/ee/webhook/components/webhook-table.tsx
+++ b/apps/client/src/ee/webhook/components/webhook-table.tsx
@@ -1,0 +1,226 @@
+import {
+  ActionIcon,
+  Anchor,
+  Badge,
+  Group,
+  Menu,
+  Skeleton,
+  Table,
+  Text,
+  Tooltip,
+} from "@mantine/core";
+import { modals } from "@mantine/modals";
+import {
+  IconDots,
+  IconEdit,
+  IconList,
+  IconSend,
+  IconTrash,
+} from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+import {
+  useDeleteWebhookMutation,
+  useSendTestMutation,
+} from "@/ee/webhook/queries/webhook-query";
+import { formattedDate } from "@/lib/time";
+import NoTableResults from "@/components/common/no-table-results";
+import type { IWebhook } from "@/ee/webhook/types/webhook.types";
+
+interface WebhookTableProps {
+  webhooks: IWebhook[] | undefined;
+  isLoading: boolean;
+  onEdit: (webhook: IWebhook) => void;
+  onViewDeliveries: (webhook: IWebhook) => void;
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return value.slice(0, max) + "…";
+}
+
+function TableSkeleton() {
+  return (
+    <>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <Table.Tr key={i}>
+          <Table.Td>
+            <Skeleton height={14} width={140} />
+          </Table.Td>
+          <Table.Td>
+            <Skeleton height={14} width={220} />
+          </Table.Td>
+          <Table.Td>
+            <Skeleton height={14} width={70} />
+          </Table.Td>
+          <Table.Td>
+            <Skeleton height={14} width={70} />
+          </Table.Td>
+          <Table.Td>
+            <Skeleton height={14} width={120} />
+          </Table.Td>
+          <Table.Td>
+            <Skeleton height={14} width={24} />
+          </Table.Td>
+        </Table.Tr>
+      ))}
+    </>
+  );
+}
+
+export function WebhookTable({
+  webhooks,
+  isLoading,
+  onEdit,
+  onViewDeliveries,
+}: WebhookTableProps) {
+  const { t } = useTranslation();
+  const deleteMutation = useDeleteWebhookMutation();
+  const sendTestMutation = useSendTestMutation();
+
+  const handleDelete = (webhook: IWebhook) => {
+    modals.openConfirmModal({
+      title: t("Delete webhook"),
+      children: (
+        <Text size="sm">
+          {t(
+            "Are you sure you want to delete the webhook {{name}}? This action cannot be undone.",
+            { name: webhook.name },
+          )}
+        </Text>
+      ),
+      labels: { confirm: t("Delete"), cancel: t("Cancel") },
+      confirmProps: { color: "red" },
+      onConfirm: () => {
+        deleteMutation.mutate({ webhookId: webhook.id });
+      },
+    });
+  };
+
+  return (
+    <Table.ScrollContainer minWidth={760}>
+      <Table highlightOnHover verticalSpacing="sm">
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>{t("Name")}</Table.Th>
+            <Table.Th>{t("URL")}</Table.Th>
+            <Table.Th>{t("Events")}</Table.Th>
+            <Table.Th>{t("Status")}</Table.Th>
+            <Table.Th>{t("Created")}</Table.Th>
+            <Table.Th aria-label={t("Action")} />
+          </Table.Tr>
+        </Table.Thead>
+
+        <Table.Tbody>
+          {isLoading ? (
+            <TableSkeleton />
+          ) : webhooks && webhooks.length > 0 ? (
+            webhooks.map((webhook) => (
+              <Table.Tr key={webhook.id}>
+                <Table.Td>
+                  <Anchor
+                    component="button"
+                    type="button"
+                    onClick={() => onEdit(webhook)}
+                    underline="never"
+                    style={{ color: "var(--mantine-color-text)" }}
+                  >
+                    <Text fz="sm" fw={500} lineClamp={1}>
+                      {webhook.name}
+                    </Text>
+                  </Anchor>
+                </Table.Td>
+
+                <Table.Td>
+                  <Tooltip label={webhook.url} withArrow position="top-start">
+                    <Text fz="sm" c="dimmed" style={{ fontFamily: "monospace" }}>
+                      {truncate(webhook.url, 60)}
+                    </Text>
+                  </Tooltip>
+                </Table.Td>
+
+                <Table.Td>
+                  <Tooltip
+                    label={webhook.subscribedEvents.join(", ")}
+                    withArrow
+                    multiline
+                    w={280}
+                  >
+                    <Badge variant="light" color="blue">
+                      {t("{{count}} events", {
+                        count: webhook.subscribedEvents.length,
+                      })}
+                    </Badge>
+                  </Tooltip>
+                </Table.Td>
+
+                <Table.Td>
+                  <Badge
+                    color={webhook.isActive ? "green" : "gray"}
+                    variant="light"
+                  >
+                    {webhook.isActive ? t("Active") : t("Inactive")}
+                  </Badge>
+                </Table.Td>
+
+                <Table.Td>
+                  <Text fz="sm" style={{ whiteSpace: "nowrap" }}>
+                    {formattedDate(new Date(webhook.createdAt))}
+                  </Text>
+                </Table.Td>
+
+                <Table.Td>
+                  <Menu position="bottom-end" withinPortal>
+                    <Menu.Target>
+                      <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        aria-label={t("Webhook menu")}
+                      >
+                        <IconDots size={16} />
+                      </ActionIcon>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                      <Menu.Item
+                        leftSection={<IconEdit size={16} />}
+                        onClick={() => onEdit(webhook)}
+                      >
+                        {t("Edit")}
+                      </Menu.Item>
+                      <Menu.Item
+                        leftSection={<IconSend size={16} />}
+                        onClick={() =>
+                          sendTestMutation.mutate({ webhookId: webhook.id })
+                        }
+                      >
+                        {t("Send test event")}
+                      </Menu.Item>
+                      <Menu.Item
+                        leftSection={<IconList size={16} />}
+                        onClick={() => onViewDeliveries(webhook)}
+                      >
+                        {t("View deliveries")}
+                      </Menu.Item>
+                      <Menu.Divider />
+                      <Menu.Item
+                        leftSection={<IconTrash size={16} />}
+                        color="red"
+                        onClick={() => handleDelete(webhook)}
+                      >
+                        {t("Delete")}
+                      </Menu.Item>
+                    </Menu.Dropdown>
+                  </Menu>
+                </Table.Td>
+              </Table.Tr>
+            ))
+          ) : (
+            <NoTableResults
+              colSpan={6}
+              text={t("No webhooks yet. Add one to start receiving events.")}
+            />
+          )}
+        </Table.Tbody>
+      </Table>
+    </Table.ScrollContainer>
+  );
+}

--- a/apps/client/src/ee/webhook/lib/webhook-event-labels.ts
+++ b/apps/client/src/ee/webhook/lib/webhook-event-labels.ts
@@ -1,0 +1,43 @@
+import type { WebhookEvent } from "@/ee/webhook/types/webhook.types";
+
+export const EVENT_GROUPS: { group: string; events: WebhookEvent[] }[] = [
+  {
+    group: "Pages",
+    events: [
+      "page.created",
+      "page.updated",
+      "page.moved",
+      "page.deleted",
+      "page.restored",
+    ],
+  },
+  {
+    group: "Comments",
+    events: [
+      "comment.created",
+      "comment.updated",
+      "comment.deleted",
+      "comment.resolved",
+    ],
+  },
+  {
+    group: "Spaces",
+    events: ["space.created", "space.updated", "space.deleted"],
+  },
+  {
+    group: "Attachments",
+    events: ["attachment.uploaded"],
+  },
+  {
+    group: "Members",
+    events: ["user.created", "user.deactivated"],
+  },
+];
+
+export const eventLabel = (event: string): string => event;
+
+export const multiSelectData = () =>
+  EVENT_GROUPS.map(({ group, events }) => ({
+    group,
+    items: events.map((e) => ({ value: e, label: e })),
+  }));

--- a/apps/client/src/ee/webhook/pages/webhooks.tsx
+++ b/apps/client/src/ee/webhook/pages/webhooks.tsx
@@ -1,0 +1,108 @@
+import { useMemo, useState } from "react";
+import { Button, Group, Space } from "@mantine/core";
+import { Helmet } from "react-helmet-async";
+import { useTranslation } from "react-i18next";
+import SettingsTitle from "@/components/settings/settings-title";
+import { getAppName } from "@/lib/config";
+import Paginate from "@/components/common/paginate";
+import { useCursorPaginate } from "@/hooks/use-cursor-paginate";
+import useUserRole from "@/hooks/use-user-role";
+import { useWebhooks } from "@/ee/webhook/queries/webhook-query";
+import { WebhookTable } from "@/ee/webhook/components/webhook-table";
+import { CreateWebhookModal } from "@/ee/webhook/components/create-webhook-modal";
+import { EditWebhookModal } from "@/ee/webhook/components/edit-webhook-modal";
+import { WebhookSecretModal } from "@/ee/webhook/components/webhook-secret-modal";
+import { DeliveryDrawer } from "@/ee/webhook/components/delivery-drawer";
+import type { IWebhook, IListWebhooksParams } from "@/ee/webhook/types/webhook.types";
+
+export default function Webhooks() {
+  const { t } = useTranslation();
+  const { isAdmin } = useUserRole();
+  const { cursor, goNext, goPrev } = useCursorPaginate();
+
+  const [createOpened, setCreateOpened] = useState(false);
+  const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
+  const [editingWebhookId, setEditingWebhookId] = useState<string | null>(null);
+  const [deliveryWebhookId, setDeliveryWebhookId] = useState<string | null>(
+    null,
+  );
+
+  const params: IListWebhooksParams = useMemo(
+    () => ({ cursor, limit: 50 }),
+    [cursor],
+  );
+
+  const { data, isLoading } = useWebhooks(params);
+
+  if (!isAdmin) {
+    return null;
+  }
+
+  const handleEdit = (webhook: IWebhook) => {
+    setEditingWebhookId(webhook.id);
+  };
+
+  const handleViewDeliveries = (webhook: IWebhook) => {
+    setDeliveryWebhookId(webhook.id);
+  };
+
+  return (
+    <>
+      <Helmet>
+        <title>
+          {t("Webhooks")} - {getAppName()}
+        </title>
+      </Helmet>
+
+      <SettingsTitle title={t("Webhooks")} />
+
+      <Group justify="flex-end" mb="md">
+        <Button onClick={() => setCreateOpened(true)}>
+          {t("Add webhook")}
+        </Button>
+      </Group>
+
+      <WebhookTable
+        webhooks={data?.items}
+        isLoading={isLoading}
+        onEdit={handleEdit}
+        onViewDeliveries={handleViewDeliveries}
+      />
+
+      <Space h="md" />
+
+      {data?.items && data.items.length > 0 && (
+        <Paginate
+          hasPrevPage={data?.meta?.hasPrevPage}
+          hasNextPage={data?.meta?.hasNextPage}
+          onNext={() => goNext(data?.meta?.nextCursor)}
+          onPrev={goPrev}
+        />
+      )}
+
+      <CreateWebhookModal
+        opened={createOpened}
+        onClose={() => setCreateOpened(false)}
+        onSuccess={(signingSecret) => setRevealedSecret(signingSecret)}
+      />
+
+      <WebhookSecretModal
+        opened={!!revealedSecret}
+        onClose={() => setRevealedSecret(null)}
+        secret={revealedSecret}
+      />
+
+      <EditWebhookModal
+        opened={!!editingWebhookId}
+        onClose={() => setEditingWebhookId(null)}
+        webhookId={editingWebhookId}
+      />
+
+      <DeliveryDrawer
+        opened={!!deliveryWebhookId}
+        onClose={() => setDeliveryWebhookId(null)}
+        webhookId={deliveryWebhookId}
+      />
+    </>
+  );
+}

--- a/apps/client/src/ee/webhook/queries/webhook-query.ts
+++ b/apps/client/src/ee/webhook/queries/webhook-query.ts
@@ -1,0 +1,190 @@
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import { notifications } from "@mantine/notifications";
+import { useTranslation } from "react-i18next";
+import {
+  createWebhook,
+  deleteWebhook,
+  getWebhook,
+  getWebhookDeliveries,
+  getWebhooks,
+  redeliverWebhook,
+  rotateWebhookSecret,
+  sendWebhookTest,
+  updateWebhook,
+} from "@/ee/webhook/services/webhook-service";
+import {
+  ICreateWebhook,
+  IListWebhooksParams,
+  IUpdateWebhook,
+  IWebhook,
+  IWebhookCreated,
+  IWebhookDelivery,
+} from "@/ee/webhook/types/webhook.types";
+import { IPagination } from "@/lib/types";
+
+const WEBHOOK_LIST_KEY = "webhook-list";
+const WEBHOOK_INFO_KEY = "webhook-info";
+const WEBHOOK_DELIVERIES_KEY = "webhook-deliveries";
+
+export function useWebhooks(
+  params?: IListWebhooksParams,
+): UseQueryResult<IPagination<IWebhook>, Error> {
+  return useQuery({
+    queryKey: [WEBHOOK_LIST_KEY, params],
+    queryFn: () => getWebhooks(params),
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useWebhook(
+  webhookId: string | null | undefined,
+): UseQueryResult<IWebhook, Error> {
+  return useQuery({
+    queryKey: [WEBHOOK_INFO_KEY, webhookId],
+    queryFn: () => getWebhook(webhookId as string),
+    enabled: !!webhookId,
+  });
+}
+
+export function useWebhookDeliveries(
+  webhookId: string | null | undefined,
+): UseQueryResult<IWebhookDelivery[], Error> {
+  return useQuery({
+    queryKey: [WEBHOOK_DELIVERIES_KEY, webhookId],
+    queryFn: () => getWebhookDeliveries(webhookId as string),
+    enabled: !!webhookId,
+  });
+}
+
+function invalidateLists(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({
+    predicate: (item) => item.queryKey[0] === WEBHOOK_LIST_KEY,
+  });
+}
+
+export function useCreateWebhookMutation() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation<IWebhookCreated, Error, ICreateWebhook>({
+    mutationFn: (data) => createWebhook(data),
+    onSuccess: () => {
+      notifications.show({ message: t("Webhook created") });
+      invalidateLists(queryClient);
+    },
+    onError: (error) => {
+      const errorMessage = error["response"]?.data?.message;
+      notifications.show({ message: errorMessage, color: "red" });
+    },
+  });
+}
+
+export function useUpdateWebhookMutation() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation<IWebhook, Error, IUpdateWebhook>({
+    mutationFn: (data) => updateWebhook(data),
+    onSuccess: (data) => {
+      notifications.show({ message: t("Webhook updated") });
+      invalidateLists(queryClient);
+      queryClient.invalidateQueries({
+        queryKey: [WEBHOOK_INFO_KEY, data.id],
+      });
+    },
+    onError: (error) => {
+      const errorMessage = error["response"]?.data?.message;
+      notifications.show({ message: errorMessage, color: "red" });
+    },
+  });
+}
+
+export function useDeleteWebhookMutation() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation<{ success: boolean }, Error, { webhookId: string }>({
+    mutationFn: ({ webhookId }) => deleteWebhook(webhookId),
+    onSuccess: () => {
+      notifications.show({ message: t("Webhook deleted") });
+      invalidateLists(queryClient);
+    },
+    onError: (error) => {
+      const errorMessage = error["response"]?.data?.message;
+      notifications.show({ message: errorMessage, color: "red" });
+    },
+  });
+}
+
+export function useRotateSecretMutation() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation<
+    { signingSecret: string },
+    Error,
+    { webhookId: string }
+  >({
+    mutationFn: ({ webhookId }) => rotateWebhookSecret(webhookId),
+    onSuccess: (_data, variables) => {
+      notifications.show({ message: t("Signing secret rotated") });
+      queryClient.invalidateQueries({
+        queryKey: [WEBHOOK_INFO_KEY, variables.webhookId],
+      });
+    },
+    onError: (error) => {
+      const errorMessage = error["response"]?.data?.message;
+      notifications.show({ message: errorMessage, color: "red" });
+    },
+  });
+}
+
+export function useSendTestMutation() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation<{ deliveryId: string }, Error, { webhookId: string }>({
+    mutationFn: ({ webhookId }) => sendWebhookTest(webhookId),
+    onSuccess: (_data, variables) => {
+      notifications.show({ message: t("Test event sent") });
+      queryClient.invalidateQueries({
+        queryKey: [WEBHOOK_DELIVERIES_KEY, variables.webhookId],
+      });
+    },
+    onError: (error) => {
+      const errorMessage = error["response"]?.data?.message;
+      notifications.show({ message: errorMessage, color: "red" });
+    },
+  });
+}
+
+export function useRedeliverMutation(webhookId?: string) {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation<{ deliveryId: string }, Error, { deliveryId: string }>({
+    mutationFn: ({ deliveryId }) => redeliverWebhook(deliveryId),
+    onSuccess: () => {
+      notifications.show({ message: t("Redelivery queued") });
+      if (webhookId) {
+        queryClient.invalidateQueries({
+          queryKey: [WEBHOOK_DELIVERIES_KEY, webhookId],
+        });
+      } else {
+        queryClient.invalidateQueries({
+          predicate: (item) => item.queryKey[0] === WEBHOOK_DELIVERIES_KEY,
+        });
+      }
+    },
+    onError: (error) => {
+      const errorMessage = error["response"]?.data?.message;
+      notifications.show({ message: errorMessage, color: "red" });
+    },
+  });
+}

--- a/apps/client/src/ee/webhook/services/webhook-service.ts
+++ b/apps/client/src/ee/webhook/services/webhook-service.ts
@@ -1,0 +1,81 @@
+import api from "@/lib/api-client";
+import { IPagination } from "@/lib/types";
+import {
+  ICreateWebhook,
+  IListWebhooksParams,
+  IUpdateWebhook,
+  IWebhook,
+  IWebhookCreated,
+  IWebhookDelivery,
+} from "@/ee/webhook/types/webhook.types";
+
+export async function getWebhooks(
+  params?: IListWebhooksParams,
+): Promise<IPagination<IWebhook>> {
+  const req = await api.post("/webhooks", { ...params });
+  return req.data;
+}
+
+export async function getWebhook(webhookId: string): Promise<IWebhook> {
+  const req = await api.post<IWebhook>("/webhooks/info", { webhookId });
+  return req.data;
+}
+
+export async function createWebhook(
+  data: ICreateWebhook,
+): Promise<IWebhookCreated> {
+  const req = await api.post<IWebhookCreated>("/webhooks/create", data);
+  return req.data;
+}
+
+export async function updateWebhook(data: IUpdateWebhook): Promise<IWebhook> {
+  const req = await api.post<IWebhook>("/webhooks/update", data);
+  return req.data;
+}
+
+export async function deleteWebhook(
+  webhookId: string,
+): Promise<{ success: boolean }> {
+  const req = await api.post("/webhooks/delete", { webhookId });
+  return req.data;
+}
+
+export async function rotateWebhookSecret(
+  webhookId: string,
+): Promise<{ signingSecret: string }> {
+  const req = await api.post<{ signingSecret: string }>(
+    "/webhooks/rotate-secret",
+    { webhookId },
+  );
+  return req.data;
+}
+
+export async function sendWebhookTest(
+  webhookId: string,
+): Promise<{ deliveryId: string }> {
+  const req = await api.post<{ deliveryId: string }>("/webhooks/test", {
+    webhookId,
+  });
+  return req.data;
+}
+
+export async function getWebhookDeliveries(
+  webhookId: string,
+  limit?: number,
+): Promise<IWebhookDelivery[]> {
+  const req = await api.post<IWebhookDelivery[]>("/webhooks/deliveries", {
+    webhookId,
+    limit,
+  });
+  return req.data;
+}
+
+export async function redeliverWebhook(
+  deliveryId: string,
+): Promise<{ deliveryId: string }> {
+  const req = await api.post<{ deliveryId: string }>(
+    "/webhooks/deliveries/redeliver",
+    { deliveryId },
+  );
+  return req.data;
+}

--- a/apps/client/src/ee/webhook/types/webhook.types.ts
+++ b/apps/client/src/ee/webhook/types/webhook.types.ts
@@ -1,0 +1,77 @@
+export type WebhookEvent =
+  | "page.created"
+  | "page.updated"
+  | "page.moved"
+  | "page.deleted"
+  | "page.restored"
+  | "comment.created"
+  | "comment.updated"
+  | "comment.deleted"
+  | "comment.resolved"
+  | "space.created"
+  | "space.updated"
+  | "space.deleted"
+  | "attachment.uploaded"
+  | "user.created"
+  | "user.deactivated";
+
+export type WebhookDeliveryStatus =
+  | "pending"
+  | "success"
+  | "failed"
+  | "skipped_cooldown"
+  | "skipped_disabled"
+  | "skipped_inflight";
+
+export interface IWebhook {
+  id: string;
+  workspaceId: string;
+  name: string;
+  url: string;
+  subscribedEvents: WebhookEvent[];
+  isActive: boolean;
+  consecutiveFailureCount: number;
+  disabledAt: string | null;
+  creatorId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IWebhookCreated extends IWebhook {
+  signingSecret: string;
+}
+
+export interface IWebhookDelivery {
+  id: string;
+  webhookId: string;
+  event: string;
+  payload: Record<string, unknown>;
+  status: WebhookDeliveryStatus;
+  httpStatus: number | null;
+  responseBody: string | null;
+  errorMessage: string | null;
+  attemptCount: number;
+  durationMs: number | null;
+  deliveredAt: string | null;
+  createdAt: string;
+}
+
+export interface ICreateWebhook {
+  name: string;
+  url: string;
+  subscribedEvents: WebhookEvent[];
+  isActive?: boolean;
+}
+
+export interface IUpdateWebhook {
+  webhookId: string;
+  name?: string;
+  url?: string;
+  subscribedEvents?: WebhookEvent[];
+  isActive?: boolean;
+}
+
+export interface IListWebhooksParams {
+  cursor?: string;
+  limit?: number;
+}

--- a/apps/client/src/features/editor/components/audio/audio-menu.tsx
+++ b/apps/client/src/features/editor/components/audio/audio-menu.tsx
@@ -2,6 +2,7 @@ import { BubbleMenu as BaseBubbleMenu } from "@tiptap/react/menus";
 import { findParentNode, posToDOMRect, useEditorState } from "@tiptap/react";
 import { useCallback } from "react";
 import { Node as PMNode } from "@tiptap/pm/model";
+import { isEditorReady } from "@docmost/editor-ext";
 import {
   EditorMenuProps,
   ShouldShowProps,
@@ -46,7 +47,7 @@ export function AudioMenu({ editor }: EditorMenuProps) {
   );
 
   const getReferencedVirtualElement = useCallback(() => {
-    if (!editor) return;
+    if (!isEditorReady(editor)) return;
     const { selection } = editor.state;
     const predicate = (node: PMNode) => node.type.name === "audio";
     const parent = findParentNode(predicate)(selection);

--- a/apps/client/src/features/editor/components/callout/callout-menu.tsx
+++ b/apps/client/src/features/editor/components/callout/callout-menu.tsx
@@ -16,7 +16,7 @@ import {
   IconMoodSmile,
   IconNotes,
 } from "@tabler/icons-react";
-import { CalloutType, isTextSelected } from "@docmost/editor-ext";
+import { CalloutType, isEditorReady, isTextSelected } from "@docmost/editor-ext";
 import { useTranslation } from "react-i18next";
 import EmojiPicker from "@/components/ui/emoji-picker.tsx";
 import classes from "../common/toolbar-menu.module.css";
@@ -55,7 +55,7 @@ export function CalloutMenu({ editor }: EditorMenuProps) {
   });
 
   const getReferencedVirtualElement = useCallback(() => {
-    if (!editor) return;
+    if (!isEditorReady(editor)) return;
     const { selection } = editor.state;
     const predicate = (node: PMNode) => node.type.name === "callout";
     const parent = findParentNode(predicate)(selection);

--- a/apps/client/src/features/editor/components/columns/columns-menu.tsx
+++ b/apps/client/src/features/editor/components/columns/columns-menu.tsx
@@ -19,7 +19,7 @@ import {
   IconCopy,
   IconTrash,
 } from "@tabler/icons-react";
-import { isTextSelected } from "@docmost/editor-ext";
+import { isEditorReady, isTextSelected } from "@docmost/editor-ext";
 import type { WidthMode, ColumnsLayout } from "@docmost/editor-ext";
 import { useTranslation } from "react-i18next";
 import classes from "../common/toolbar-menu.module.css";
@@ -82,7 +82,7 @@ export function ColumnsMenu({ editor }: EditorMenuProps) {
 
   const shouldShow = useCallback(
     ({ state }: ShouldShowProps) => {
-      if (!state) return false;
+      if (!state || !isEditorReady(editor)) return false;
       if (!editor.isActive("columns")) return false;
       if (isTextSelected(editor)) return false;
       if (nodesWithMenus.some((name) => editor.isActive(name))) return false;
@@ -121,7 +121,7 @@ export function ColumnsMenu({ editor }: EditorMenuProps) {
   });
 
   const getReferencedVirtualElement = useCallback(() => {
-    if (!editor) return;
+    if (!isEditorReady(editor)) return;
     const { selection } = editor.state;
     const predicate = (node: PMNode) => node.type.name === "columns";
     const parent = findParentNode(predicate)(selection);

--- a/apps/client/src/features/editor/components/drawio/drawio-menu.tsx
+++ b/apps/client/src/features/editor/components/drawio/drawio-menu.tsx
@@ -2,6 +2,7 @@ import { BubbleMenu as BaseBubbleMenu } from "@tiptap/react/menus";
 import { findParentNode, posToDOMRect, useEditorState } from "@tiptap/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Node as PMNode } from "@tiptap/pm/model";
+import { isEditorReady } from "@docmost/editor-ext";
 import {
   EditorMenuProps,
   ShouldShowProps,
@@ -81,7 +82,7 @@ export function DrawioMenu({ editor }: EditorMenuProps) {
   );
 
   const getReferencedVirtualElement = useCallback(() => {
-    if (!editor) return;
+    if (!isEditorReady(editor)) return;
     const { selection } = editor.state;
     const predicate = (node: PMNode) => node.type.name === "drawio";
     const parent = findParentNode(predicate)(selection);

--- a/apps/client/src/features/editor/components/excalidraw/excalidraw-menu-lazy.tsx
+++ b/apps/client/src/features/editor/components/excalidraw/excalidraw-menu-lazy.tsx
@@ -1,0 +1,14 @@
+import { lazy, Suspense } from "react";
+import { EditorMenuProps } from "@/features/editor/components/table/types/types.ts";
+
+const ExcalidrawMenu = lazy(
+  () => import("@/features/editor/components/excalidraw/excalidraw-menu.tsx"),
+);
+
+export default function ExcalidrawMenuLazy(props: EditorMenuProps) {
+  return (
+    <Suspense fallback={null}>
+      <ExcalidrawMenu {...props} />
+    </Suspense>
+  );
+}

--- a/apps/client/src/features/editor/components/excalidraw/excalidraw-menu.tsx
+++ b/apps/client/src/features/editor/components/excalidraw/excalidraw-menu.tsx
@@ -2,6 +2,7 @@ import { BubbleMenu as BaseBubbleMenu } from "@tiptap/react/menus";
 import { findParentNode, posToDOMRect, useEditorState } from "@tiptap/react";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { Node as PMNode } from "@tiptap/pm/model";
+import { isEditorReady } from "@docmost/editor-ext";
 import {
   EditorMenuProps,
   ShouldShowProps,
@@ -94,7 +95,7 @@ export function ExcalidrawMenu({ editor }: EditorMenuProps) {
   );
 
   const getReferencedVirtualElement = useCallback(() => {
-    if (!editor) return;
+    if (!isEditorReady(editor)) return;
     const { selection } = editor.state;
     const predicate = (node: PMNode) => node.type.name === "excalidraw";
     const parent = findParentNode(predicate)(selection);

--- a/apps/client/src/features/editor/components/excalidraw/excalidraw-view-lazy.tsx
+++ b/apps/client/src/features/editor/components/excalidraw/excalidraw-view-lazy.tsx
@@ -1,0 +1,14 @@
+import { lazy, Suspense } from "react";
+import { NodeViewProps } from "@tiptap/react";
+
+const ExcalidrawView = lazy(
+  () => import("@/features/editor/components/excalidraw/excalidraw-view.tsx"),
+);
+
+export default function ExcalidrawViewLazy(props: NodeViewProps) {
+  return (
+    <Suspense fallback={null}>
+      <ExcalidrawView {...props} />
+    </Suspense>
+  );
+}

--- a/apps/client/src/features/editor/components/image/image-menu.tsx
+++ b/apps/client/src/features/editor/components/image/image-menu.tsx
@@ -2,6 +2,7 @@ import { BubbleMenu as BaseBubbleMenu } from "@tiptap/react/menus";
 import { findParentNode, posToDOMRect, useEditorState } from "@tiptap/react";
 import React, { useCallback, useRef } from "react";
 import { Node as PMNode } from "@tiptap/pm/model";
+import { isEditorReady } from "@docmost/editor-ext";
 import {
   EditorMenuProps,
   ShouldShowProps,
@@ -56,7 +57,7 @@ export function ImageMenu({ editor }: EditorMenuProps) {
   );
 
   const getReferencedVirtualElement = useCallback(() => {
-    if (!editor) return;
+    if (!isEditorReady(editor)) return;
     const { selection } = editor.state;
     const predicate = (node: PMNode) => node.type.name === "image";
     const parent = findParentNode(predicate)(selection);

--- a/apps/client/src/features/editor/components/pdf/pdf-menu.tsx
+++ b/apps/client/src/features/editor/components/pdf/pdf-menu.tsx
@@ -2,6 +2,7 @@ import { BubbleMenu as BaseBubbleMenu } from "@tiptap/react/menus";
 import { findParentNode, posToDOMRect, useEditorState } from "@tiptap/react";
 import { useCallback } from "react";
 import { Node as PMNode } from "@tiptap/pm/model";
+import { isEditorReady } from "@docmost/editor-ext";
 import {
   EditorMenuProps,
   ShouldShowProps,
@@ -37,9 +38,8 @@ export function PdfMenu({ editor }: EditorMenuProps) {
 
   const shouldShow = useCallback(
     ({ state }: ShouldShowProps) => {
-      if (!state || !editor.isActive("pdf")) {
-        return false;
-      }
+      if (!state || !isEditorReady(editor)) return false;
+      if (!editor.isActive("pdf")) return false;
 
       const { selection } = state;
       const dom = editor.view.nodeDOM(selection.from) as HTMLElement | null;
@@ -51,7 +51,7 @@ export function PdfMenu({ editor }: EditorMenuProps) {
   );
 
   const getReferencedVirtualElement = useCallback(() => {
-    if (!editor) return;
+    if (!isEditorReady(editor)) return;
     const { selection } = editor.state;
     const predicate = (node: PMNode) => node.type.name === "pdf";
     const parent = findParentNode(predicate)(selection);

--- a/apps/client/src/features/editor/components/subpages/subpages-menu.tsx
+++ b/apps/client/src/features/editor/components/subpages/subpages-menu.tsx
@@ -6,6 +6,7 @@ import { ActionIcon, Tooltip } from "@mantine/core";
 import { IconTrash } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
 import { Editor } from "@tiptap/core";
+import { isEditorReady } from "@docmost/editor-ext";
 
 interface SubpagesMenuProps {
   editor: Editor;
@@ -33,6 +34,7 @@ export const SubpagesMenu = React.memo(
     );
 
     const getReferenceClientRect = useCallback(() => {
+      if (!isEditorReady(editor)) return new DOMRect();
       const { selection } = editor.state;
       const predicate = (node: PMNode) => node.type.name === "subpages";
       const parent = findParentNode(predicate)(selection);

--- a/apps/client/src/features/editor/components/table/handle/column-handle.tsx
+++ b/apps/client/src/features/editor/components/table/handle/column-handle.tsx
@@ -31,7 +31,12 @@ export const ColumnHandle = React.memo(function ColumnHandle({
   // (the plugin re-emits `hoveringCell` with the mapped pos a tick later);
   // unmounting the source element here would make pragmatic-dnd silently
   // abort the active drag.
-  const lookupCellDom = editor.view.nodeDOM(anchorPos) as HTMLElement | null;
+  // `nodeDOM` is typed as `Node | null` — when `anchorPos` goes stale (e.g.
+  // an external drop reflows the doc before the plugin re-emits
+  // hoveringCell), it can resolve to a Text node, on which `.closest` is
+  // undefined. Filter to HTMLElement so downstream consumers stay safe.
+  const lookupDom = editor.view.nodeDOM(anchorPos);
+  const lookupCellDom = lookupDom instanceof HTMLElement ? lookupDom : null;
   const [cellDom, setCellDom] = useState<HTMLElement | null>(lookupCellDom);
   const lastCellDomRef = useRef<HTMLElement | null>(lookupCellDom);
   useEffect(() => {

--- a/apps/client/src/features/editor/components/table/handle/row-handle.tsx
+++ b/apps/client/src/features/editor/components/table/handle/row-handle.tsx
@@ -29,7 +29,12 @@ export const RowHandle = React.memo(function RowHandle({
   // See ColumnHandle for the rationale: keep the last valid cell DOM cached
   // so the handle div stays mounted across stale-anchor renders, otherwise
   // pragmatic-dnd silently aborts an in-flight drag.
-  const lookupCellDom = editor.view.nodeDOM(anchorPos) as HTMLElement | null;
+  // `nodeDOM` is typed as `Node | null` — when `anchorPos` goes stale (e.g.
+  // an external drop reflows the doc before the plugin re-emits
+  // hoveringCell), it can resolve to a Text node, on which `.closest` is
+  // undefined. Filter to HTMLElement so downstream consumers stay safe.
+  const lookupDom = editor.view.nodeDOM(anchorPos);
+  const lookupCellDom = lookupDom instanceof HTMLElement ? lookupDom : null;
   const [cellDom, setCellDom] = useState<HTMLElement | null>(lookupCellDom);
   const lastCellDomRef = useRef<HTMLElement | null>(lookupCellDom);
   useEffect(() => {

--- a/apps/client/src/features/editor/components/table/table-menu.tsx
+++ b/apps/client/src/features/editor/components/table/table-menu.tsx
@@ -18,7 +18,7 @@ import {
   IconTrashX,
 } from "@tabler/icons-react";
 import { BubbleMenu } from "@tiptap/react/menus";
-import { isCellSelection, isTextSelected } from "@docmost/editor-ext";
+import { isCellSelection, isEditorReady, isTextSelected } from "@docmost/editor-ext";
 import { useTranslation } from "react-i18next";
 import classes from "../common/toolbar-menu.module.css";
 
@@ -38,6 +38,7 @@ export const TableMenu = React.memo(
     );
 
     const getReferencedVirtualElement = useCallback(() => {
+      if (!isEditorReady(editor)) return;
       const { selection } = editor.state;
       const predicate = (node: PMNode) => node.type.name === "table";
       const parent = findParentNode(predicate)(selection);

--- a/apps/client/src/features/editor/components/video/video-menu.tsx
+++ b/apps/client/src/features/editor/components/video/video-menu.tsx
@@ -2,6 +2,7 @@ import { BubbleMenu as BaseBubbleMenu } from "@tiptap/react/menus";
 import { findParentNode, posToDOMRect, useEditorState } from "@tiptap/react";
 import { useCallback } from "react";
 import { Node as PMNode } from "@tiptap/pm/model";
+import { isEditorReady } from "@docmost/editor-ext";
 import {
   EditorMenuProps,
   ShouldShowProps,
@@ -53,7 +54,7 @@ export function VideoMenu({ editor }: EditorMenuProps) {
   );
 
   const getReferencedVirtualElement = useCallback(() => {
-    if (!editor) return;
+    if (!isEditorReady(editor)) return;
     const { selection } = editor.state;
     const predicate = (node: PMNode) => node.type.name === "video";
     const parent = findParentNode(predicate)(selection);

--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -85,7 +85,7 @@ import AudioView from "@/features/editor/components/audio/audio-view.tsx";
 import AttachmentView from "@/features/editor/components/attachment/attachment-view.tsx";
 import CodeBlockView from "@/features/editor/components/code-block/code-block-view.tsx";
 import DrawioView from "../components/drawio/drawio-view";
-import ExcalidrawView from "@/features/editor/components/excalidraw/excalidraw-view.tsx";
+import ExcalidrawView from "@/features/editor/components/excalidraw/excalidraw-view-lazy.tsx";
 import EmbedView from "@/features/editor/components/embed/embed-view.tsx";
 import PdfView from "@/features/editor/components/pdf/pdf-view.tsx";
 import SubpagesView from "@/features/editor/components/subpages/subpages-view.tsx";

--- a/apps/client/src/features/editor/page-editor.tsx
+++ b/apps/client/src/features/editor/page-editor.tsx
@@ -55,7 +55,7 @@ import {
   handleFileDrop,
   handlePaste,
 } from "@/features/editor/components/common/editor-paste-handler.tsx";
-import ExcalidrawMenu from "./components/excalidraw/excalidraw-menu";
+import ExcalidrawMenu from "./components/excalidraw/excalidraw-menu-lazy";
 import DrawioMenu from "./components/drawio/drawio-menu";
 import { useCollabToken } from "@/features/auth/queries/auth-query.tsx";
 import SearchAndReplaceDialog from "@/features/editor/components/search-and-replace/search-and-replace-dialog.tsx";

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -38,12 +38,12 @@ export default defineConfig(({ mode }) => {
     build: {
       rolldownOptions: {
         output: {
-          codeSplitting: {
+          advancedChunks: {
             groups: [
-              { name: "vendor-mantine", test: /@mantine/ },
-              { name: "vendor-mermaid", test: /mermaid|cytoscape|elkjs/ },
-              { name: "vendor-excalidraw", test: /excalidraw/ },
-              { name: "vendor-katex", test: /katex/ },
+              {
+                name: "vendor-mantine",
+                test: /[\\/]node_modules[\\/]@mantine[\\/]/,
+              },
             ],
           },
         },

--- a/apps/server/src/collaboration/extensions/persistence.extension.ts
+++ b/apps/server/src/collaboration/extensions/persistence.extension.ts
@@ -33,6 +33,8 @@ import {
   HISTORY_INTERVAL,
 } from '../constants';
 import { TransclusionService } from '../../core/page/transclusion/transclusion.service';
+import { WebhookDispatcher } from '@docmost/ee/webhook/services/webhook-dispatcher.service';
+import { WebhookEvent } from '@docmost/ee/webhook/constants';
 
 @Injectable()
 export class PersistenceExtension implements Extension {
@@ -47,6 +49,7 @@ export class PersistenceExtension implements Extension {
     @InjectQueue(QueueName.NOTIFICATION_QUEUE) private notificationQueue: Queue,
     private readonly collabHistory: CollabHistoryService,
     private readonly transclusionService: TransclusionService,
+    private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
 
   async onLoadDocument(data: onLoadDocumentPayload) {
@@ -199,6 +202,19 @@ export class PersistenceExtension implements Extension {
       });
 
       await this.enqueuePageHistory(page);
+
+      this.webhookDispatcher.dispatch(
+        page.workspaceId,
+        WebhookEvent.PageUpdated,
+        {
+          id: page.id,
+          slugId: page.slugId,
+          title: page.title,
+          spaceId: page.spaceId,
+          workspaceId: page.workspaceId,
+          updatedAt: page.updatedAt,
+        },
+      );
     }
   }
 

--- a/apps/server/src/common/features.ts
+++ b/apps/server/src/common/features.ts
@@ -20,6 +20,7 @@ export const Feature = {
   VIEWER_COMMENTS: 'comment:viewer',
   TEMPLATES: 'templates',
   PDF_EXPORT: 'export:pdf',
+  WEBHOOKS: 'webhooks',
 } as const;
 
 export type FeatureKey = (typeof Feature)[keyof typeof Feature];

--- a/apps/server/src/core/attachment/services/attachment.service.ts
+++ b/apps/server/src/core/attachment/services/attachment.service.ts
@@ -27,6 +27,8 @@ import { InjectQueue } from '@nestjs/bullmq';
 import { QueueJob, QueueName } from '../../../integrations/queue/constants';
 import { Queue } from 'bullmq';
 import { createByteCountingStream } from '../../../common/helpers/utils';
+import { WebhookDispatcher } from '@docmost/ee/webhook/services/webhook-dispatcher.service';
+import { WebhookEvent } from '@docmost/ee/webhook/constants';
 
 @Injectable()
 export class AttachmentService {
@@ -39,6 +41,7 @@ export class AttachmentService {
     private readonly spaceRepo: SpaceRepo,
     @InjectKysely() private readonly db: KyselyDB,
     @InjectQueue(QueueName.ATTACHMENT_QUEUE) private attachmentQueue: Queue,
+    private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
 
   async uploadFile(opts: {
@@ -271,7 +274,7 @@ export class AttachmentService {
       spaceId,
       trx,
     } = opts;
-    return this.attachmentRepo.insertAttachment(
+    const attachment = await this.attachmentRepo.insertAttachment(
       {
         id: attachmentId,
         type: type,
@@ -287,6 +290,23 @@ export class AttachmentService {
       },
       trx,
     );
+
+    this.webhookDispatcher.dispatch(
+      workspaceId,
+      WebhookEvent.AttachmentUploaded,
+      {
+        id: attachment.id,
+        fileName: attachment.fileName,
+        mimeType: attachment.mimeType,
+        fileSize: attachment.fileSize,
+        pageId: attachment.pageId,
+        spaceId: attachment.spaceId,
+        workspaceId: attachment.workspaceId,
+        creatorId: attachment.creatorId,
+      },
+    );
+
+    return attachment;
   }
 
   async handleDeleteAiChatAttachments(aiChatId: string) {

--- a/apps/server/src/core/casl/abilities/workspace-ability.factory.ts
+++ b/apps/server/src/core/casl/abilities/workspace-ability.factory.ts
@@ -42,6 +42,7 @@ function buildWorkspaceOwnerAbility() {
   can(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Attachment);
   can(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.API);
   can(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Audit);
+  can(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Webhook);
 
   return build();
 }
@@ -58,6 +59,7 @@ function buildWorkspaceAdminAbility() {
   can(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Member);
   can(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Attachment);
   can(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.API);
+  can(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Webhook);
 
   return build();
 }

--- a/apps/server/src/core/casl/interfaces/workspace-ability.type.ts
+++ b/apps/server/src/core/casl/interfaces/workspace-ability.type.ts
@@ -13,6 +13,7 @@ export enum WorkspaceCaslSubject {
   Attachment = 'attachment',
   API = 'api_key',
   Audit = 'audit',
+  Webhook = 'webhook',
 }
 
 export type IWorkspaceAbility =
@@ -22,4 +23,5 @@ export type IWorkspaceAbility =
   | [WorkspaceCaslAction, WorkspaceCaslSubject.Group]
   | [WorkspaceCaslAction, WorkspaceCaslSubject.Attachment]
   | [WorkspaceCaslAction, WorkspaceCaslSubject.API]
-  | [WorkspaceCaslAction, WorkspaceCaslSubject.Audit];
+  | [WorkspaceCaslAction, WorkspaceCaslSubject.Audit]
+  | [WorkspaceCaslAction, WorkspaceCaslSubject.Webhook];

--- a/apps/server/src/core/comment/comment.controller.ts
+++ b/apps/server/src/core/comment/comment.controller.ts
@@ -32,6 +32,8 @@ import {
   IAuditService,
 } from '../../integrations/audit/audit.service';
 import { WsService } from '../../ws/ws.service';
+import { WebhookDispatcher } from '@docmost/ee/webhook/services/webhook-dispatcher.service';
+import { WebhookEvent } from '@docmost/ee/webhook/constants';
 
 @UseGuards(JwtAuthGuard)
 @Controller('comments')
@@ -44,6 +46,7 @@ export class CommentController {
     private readonly pageAccessService: PageAccessService,
     private readonly wsService: WsService,
     @Inject(AUDIT_SERVICE) private readonly auditService: IAuditService,
+    private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
 
   @HttpCode(HttpStatus.OK)
@@ -192,5 +195,16 @@ export class CommentController {
         },
       },
     });
+
+    this.webhookDispatcher.dispatch(
+      comment.workspaceId,
+      WebhookEvent.CommentDeleted,
+      {
+        id: comment.id,
+        pageId: comment.pageId,
+        spaceId: comment.spaceId,
+        workspaceId: comment.workspaceId,
+      },
+    );
   }
 }

--- a/apps/server/src/core/comment/comment.service.ts
+++ b/apps/server/src/core/comment/comment.service.ts
@@ -19,6 +19,8 @@ import { QueueJob, QueueName } from '../../integrations/queue/constants';
 import { extractUserMentionIdsFromJson } from '../../common/helpers/prosemirror/utils';
 import { ICommentNotificationJob } from '../../integrations/queue/constants/queue.interface';
 import { WsService } from '../../ws/ws.service';
+import { WebhookDispatcher } from '@docmost/ee/webhook/services/webhook-dispatcher.service';
+import { WebhookEvent } from '@docmost/ee/webhook/constants';
 
 @Injectable()
 export class CommentService {
@@ -33,6 +35,7 @@ export class CommentService {
     private generalQueue: Queue,
     @InjectQueue(QueueName.NOTIFICATION_QUEUE)
     private notificationQueue: Queue,
+    private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
 
   async findById(commentId: string) {
@@ -142,6 +145,21 @@ export class CommentService {
       comment,
     });
 
+    this.webhookDispatcher.dispatch(
+      workspaceId,
+      WebhookEvent.CommentCreated,
+      {
+        id: comment.id,
+        pageId: comment.pageId,
+        spaceId: comment.spaceId,
+        workspaceId: comment.workspaceId,
+        type: comment.type,
+        content: comment.content,
+        creatorId: comment.creatorId,
+        createdAt: comment.createdAt,
+      },
+    );
+
     return comment;
   }
 
@@ -202,6 +220,22 @@ export class CommentService {
       pageId: comment.pageId,
       comment,
     });
+
+    this.webhookDispatcher.dispatch(
+      comment.workspaceId,
+      WebhookEvent.CommentUpdated,
+      {
+        id: comment.id,
+        pageId: comment.pageId,
+        spaceId: comment.spaceId,
+        workspaceId: comment.workspaceId,
+        type: comment.type,
+        content: comment.content,
+        creatorId: comment.creatorId,
+        createdAt: comment.createdAt,
+        updatedAt: comment.updatedAt,
+      },
+    );
 
     return comment;
   }

--- a/apps/server/src/core/page/page.controller.ts
+++ b/apps/server/src/core/page/page.controller.ts
@@ -52,6 +52,8 @@ import {
   IAuditService,
 } from '../../integrations/audit/audit.service';
 import { getPageTitle } from '../../common/helpers';
+import { WebhookDispatcher } from '@docmost/ee/webhook/services/webhook-dispatcher.service';
+import { WebhookEvent } from '@docmost/ee/webhook/constants';
 
 @UseGuards(JwtAuthGuard)
 @Controller('pages')
@@ -65,6 +67,7 @@ export class PageController {
     private readonly backlinkService: BacklinkService,
     private readonly labelService: LabelService,
     @Inject(AUDIT_SERVICE) private readonly auditService: IAuditService,
+    private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
 
   @HttpCode(HttpStatus.OK)
@@ -366,6 +369,18 @@ export class PageController {
           },
         },
       });
+
+      this.webhookDispatcher.dispatch(
+        workspace.id,
+        WebhookEvent.PageDeleted,
+        {
+          id: page.id,
+          slugId: page.slugId,
+          title: page.title,
+          spaceId: page.spaceId,
+          workspaceId: workspace.id,
+        },
+      );
     }
   }
 
@@ -405,6 +420,18 @@ export class PageController {
         },
       },
     });
+
+    this.webhookDispatcher.dispatch(
+      workspace.id,
+      WebhookEvent.PageRestored,
+      {
+        id: page.id,
+        slugId: page.slugId,
+        title: page.title,
+        spaceId: page.spaceId,
+        workspaceId: workspace.id,
+      },
+    );
 
     return this.pageRepo.findById(pageIdDto.pageId, {
       includeHasChildren: true,

--- a/apps/server/src/core/page/services/page.service.ts
+++ b/apps/server/src/core/page/services/page.service.ts
@@ -55,6 +55,8 @@ import { markdownToHtml } from '@docmost/editor-ext';
 import { WatcherService } from '../../watcher/watcher.service';
 import { sql } from 'kysely';
 import { TransclusionService } from '../transclusion/transclusion.service';
+import { WebhookDispatcher } from '@docmost/ee/webhook/services/webhook-dispatcher.service';
+import { WebhookEvent } from '@docmost/ee/webhook/constants';
 
 @Injectable()
 export class PageService {
@@ -73,6 +75,7 @@ export class PageService {
     private collaborationGateway: CollaborationGateway,
     private readonly watcherService: WatcherService,
     private readonly transclusionService: TransclusionService,
+    private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
 
   async findById(
@@ -156,7 +159,28 @@ export class PageService {
         this.logger.warn(`Failed to queue add-page-watchers: ${err.message}`),
       );
 
+    this.webhookDispatcher.dispatch(
+      page.workspaceId,
+      WebhookEvent.PageCreated,
+      this.toWebhookPagePayload(page),
+    );
+
     return page;
+  }
+
+  private toWebhookPagePayload(page: Page) {
+    return {
+      id: page.id,
+      slugId: page.slugId,
+      title: page.title,
+      icon: page.icon,
+      parentPageId: page.parentPageId,
+      spaceId: page.spaceId,
+      workspaceId: page.workspaceId,
+      creatorId: page.creatorId,
+      createdAt: page.createdAt,
+      updatedAt: page.updatedAt,
+    };
   }
 
   async nextPagePosition(spaceId: string, parentPageId?: string) {
@@ -245,13 +269,21 @@ export class PageService {
       );
     }
 
-    return await this.pageRepo.findById(page.id, {
+    const updatedPage = await this.pageRepo.findById(page.id, {
       includeSpace: true,
       includeContent: true,
       includeCreator: true,
       includeLastUpdatedBy: true,
       includeContributors: true,
     });
+
+    this.webhookDispatcher.dispatch(
+      updatedPage.workspaceId,
+      WebhookEvent.PageUpdated,
+      this.toWebhookPagePayload(updatedPage),
+    );
+
+    return updatedPage;
   }
 
   async updatePageContent(
@@ -486,6 +518,18 @@ export class PageService {
         });
       }
     });
+
+    this.webhookDispatcher.dispatch(
+      rootPage.workspaceId,
+      WebhookEvent.PageMoved,
+      {
+        id: rootPage.id,
+        slugId: rootPage.slugId,
+        fromSpaceId: rootPage.spaceId,
+        toSpaceId: spaceId,
+        workspaceId: rootPage.workspaceId,
+      },
+    );
 
     return { childPageIds };
   }
@@ -1015,6 +1059,14 @@ export class PageService {
         pageIds: pageIds,
         workspaceId,
       });
+
+      for (const id of pageIds) {
+        this.webhookDispatcher.dispatch(
+          workspaceId,
+          WebhookEvent.PageDeleted,
+          { id, workspaceId },
+        );
+      }
     }
   }
 

--- a/apps/server/src/core/space/services/space.service.ts
+++ b/apps/server/src/core/space/services/space.service.ts
@@ -29,6 +29,8 @@ import {
   AUDIT_SERVICE,
   IAuditService,
 } from '../../../integrations/audit/audit.service';
+import { WebhookDispatcher } from '@docmost/ee/webhook/services/webhook-dispatcher.service';
+import { WebhookEvent } from '@docmost/ee/webhook/constants';
 
 @Injectable()
 export class SpaceService {
@@ -41,6 +43,7 @@ export class SpaceService {
     @InjectKysely() private readonly db: KyselyDB,
     @InjectQueue(QueueName.ATTACHMENT_QUEUE) private attachmentQueue: Queue,
     @Inject(AUDIT_SERVICE) private readonly auditService: IAuditService,
+    private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
 
   async createSpace(
@@ -84,6 +87,17 @@ export class SpaceService {
         },
       },
     });
+
+    this.webhookDispatcher.dispatch(
+      workspaceId,
+      WebhookEvent.SpaceCreated,
+      {
+        id: space.id,
+        name: space.name,
+        slug: space.slug,
+        workspaceId,
+      },
+    );
 
     return { ...space, memberCount: 1 };
   }
@@ -244,6 +258,17 @@ export class SpaceService {
         spaceId: updateSpaceDto.spaceId,
         changes: { before, after },
       });
+
+      this.webhookDispatcher.dispatch(
+        workspaceId,
+        WebhookEvent.SpaceUpdated,
+        {
+          id: updatedSpace.id,
+          name: updatedSpace.name,
+          slug: updatedSpace.slug,
+          workspaceId,
+        },
+      );
     }
 
     return updatedSpace;
@@ -289,5 +314,15 @@ export class SpaceService {
         },
       },
     });
+
+    this.webhookDispatcher.dispatch(
+      workspaceId,
+      WebhookEvent.SpaceDeleted,
+      {
+        id: spaceId,
+        name: space.name,
+        workspaceId,
+      },
+    );
   }
 }

--- a/apps/server/src/core/workspace/services/workspace-invitation.service.ts
+++ b/apps/server/src/core/workspace/services/workspace-invitation.service.ts
@@ -40,6 +40,8 @@ import {
   AUDIT_SERVICE,
   IAuditService,
 } from '../../../integrations/audit/audit.service';
+import { WebhookDispatcher } from '@docmost/ee/webhook/services/webhook-dispatcher.service';
+import { WebhookEvent } from '@docmost/ee/webhook/constants';
 
 @Injectable()
 export class WorkspaceInvitationService {
@@ -55,6 +57,7 @@ export class WorkspaceInvitationService {
     @InjectQueue(QueueName.BILLING_QUEUE) private billingQueue: Queue,
     private readonly environmentService: EnvironmentService,
     @Inject(AUDIT_SERVICE) private readonly auditService: IAuditService,
+    private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
 
   async getInvitations(workspaceId: string, pagination: PaginationOptions) {
@@ -303,6 +306,18 @@ export class WorkspaceInvitationService {
     if (!newUser) {
       return;
     }
+
+    this.webhookDispatcher.dispatch(
+      workspace.id,
+      WebhookEvent.UserCreated,
+      {
+        id: newUser.id,
+        name: newUser.name,
+        email: newUser.email,
+        role: newUser.role,
+        workspaceId: workspace.id,
+      },
+    );
 
     // notify the inviter
     const invitedByUser = await this.userRepo.findById(

--- a/apps/server/src/core/workspace/services/workspace.service.ts
+++ b/apps/server/src/core/workspace/services/workspace.service.ts
@@ -48,6 +48,8 @@ import {
   AUDIT_SERVICE,
   IAuditService,
 } from '../../../integrations/audit/audit.service';
+import { WebhookDispatcher } from '@docmost/ee/webhook/services/webhook-dispatcher.service';
+import { WebhookEvent } from '@docmost/ee/webhook/constants';
 
 @Injectable()
 export class WorkspaceService {
@@ -72,6 +74,7 @@ export class WorkspaceService {
     @InjectQueue(QueueName.AI_QUEUE) private aiQueue: Queue,
     @Inject(AUDIT_SERVICE) private readonly auditService: IAuditService,
     private userSessionRepo: UserSessionRepo,
+    private readonly webhookDispatcher: WebhookDispatcher,
   ) {}
 
   async findById(workspaceId: string) {
@@ -736,6 +739,17 @@ export class WorkspaceService {
         },
       },
     });
+
+    this.webhookDispatcher.dispatch(
+      workspaceId,
+      WebhookEvent.UserDeactivated,
+      {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        workspaceId,
+      },
+    );
   }
 
   async activateUser(

--- a/apps/server/src/database/migrations/20260515T120000-webhooks.ts
+++ b/apps/server/src/database/migrations/20260515T120000-webhooks.ts
@@ -1,0 +1,93 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable('webhooks')
+    .ifNotExists()
+    .addColumn('id', 'uuid', (col) =>
+      col.primaryKey().defaultTo(sql`gen_uuid_v7()`),
+    )
+    .addColumn('workspace_id', 'uuid', (col) =>
+      col.notNull().references('workspaces.id').onDelete('cascade'),
+    )
+    .addColumn('name', 'varchar', (col) => col.notNull())
+    .addColumn('url', 'text', (col) => col.notNull())
+    .addColumn('signing_secret', 'text', (col) => col.notNull())
+    .addColumn('subscribed_events', 'jsonb', (col) =>
+      col.notNull().defaultTo(sql`'[]'::jsonb`),
+    )
+    .addColumn('is_active', 'boolean', (col) =>
+      col.notNull().defaultTo(true),
+    )
+    .addColumn('consecutive_failure_count', 'integer', (col) =>
+      col.notNull().defaultTo(0),
+    )
+    .addColumn('disabled_at', 'timestamptz')
+    .addColumn('creator_id', 'uuid', (col) =>
+      col.references('users.id').onDelete('set null'),
+    )
+    .addColumn('created_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn('updated_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex('idx_webhooks_workspace_id')
+    .ifNotExists()
+    .on('webhooks')
+    .columns(['workspace_id', 'id desc'])
+    .execute();
+
+  await db.schema
+    .createIndex('idx_webhooks_subscribed_events')
+    .ifNotExists()
+    .on('webhooks')
+    .using('gin')
+    .column('subscribed_events')
+    .execute();
+
+  await db.schema
+    .createTable('webhook_deliveries')
+    .ifNotExists()
+    .addColumn('id', 'uuid', (col) =>
+      col.primaryKey().defaultTo(sql`gen_uuid_v7()`),
+    )
+    .addColumn('webhook_id', 'uuid', (col) =>
+      col.notNull().references('webhooks.id').onDelete('cascade'),
+    )
+    .addColumn('workspace_id', 'uuid', (col) =>
+      col.notNull().references('workspaces.id').onDelete('cascade'),
+    )
+    .addColumn('event', 'varchar', (col) => col.notNull())
+    .addColumn('payload', 'jsonb', (col) => col.notNull())
+    .addColumn('status', 'varchar', (col) =>
+      col.notNull().defaultTo('pending'),
+    )
+    .addColumn('http_status', 'integer')
+    .addColumn('response_body', 'text')
+    .addColumn('error_message', 'text')
+    .addColumn('attempt_count', 'integer', (col) =>
+      col.notNull().defaultTo(0),
+    )
+    .addColumn('duration_ms', 'integer')
+    .addColumn('delivered_at', 'timestamptz')
+    .addColumn('created_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex('idx_webhook_deliveries_webhook_id')
+    .ifNotExists()
+    .on('webhook_deliveries')
+    .columns(['webhook_id', 'id desc'])
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable('webhook_deliveries').execute();
+  await db.schema.dropTable('webhooks').execute();
+}

--- a/apps/server/src/database/types/db.d.ts
+++ b/apps/server/src/database/types/db.d.ts
@@ -589,6 +589,37 @@ export interface UserSessions {
   createdAt: Generated<Timestamp>;
 }
 
+export interface Webhooks {
+  id: Generated<string>;
+  workspaceId: string;
+  name: string;
+  url: string;
+  signingSecret: string;
+  subscribedEvents: Generated<Json>;
+  isActive: Generated<boolean>;
+  consecutiveFailureCount: Generated<number>;
+  disabledAt: Timestamp | null;
+  creatorId: string | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+}
+
+export interface WebhookDeliveries {
+  id: Generated<string>;
+  webhookId: string;
+  workspaceId: string;
+  event: string;
+  payload: Json;
+  status: Generated<string>;
+  httpStatus: number | null;
+  responseBody: string | null;
+  errorMessage: string | null;
+  attemptCount: Generated<number>;
+  durationMs: number | null;
+  deliveredAt: Timestamp | null;
+  createdAt: Generated<Timestamp>;
+}
+
 export interface DB {
   aiChats: AiChats;
   aiChatMessages: AiChatMessages;
@@ -625,6 +656,8 @@ export interface DB {
   userSessions: UserSessions;
   userTokens: UserTokens;
   watchers: Watchers;
+  webhooks: Webhooks;
+  webhookDeliveries: WebhookDeliveries;
   workspaceInvitations: WorkspaceInvitations;
   workspaces: Workspaces;
 }

--- a/apps/server/src/database/types/entity.types.ts
+++ b/apps/server/src/database/types/entity.types.ts
@@ -37,6 +37,8 @@ import {
   Watchers,
   Audit as _Audit,
   Templates,
+  Webhooks,
+  WebhookDeliveries,
 } from './db';
 import { PageEmbeddings } from '@docmost/db/types/embeddings.types';
 
@@ -238,3 +240,13 @@ export type UpdatableAudit = Updateable<Omit<_Audit, 'id'>>;
 export type Template = Selectable<Templates>;
 export type InsertableTemplate = Insertable<Templates>;
 export type UpdatableTemplate = Updateable<Omit<Templates, 'id'>>;
+
+// Webhook
+export type Webhook = Selectable<Webhooks>;
+export type InsertableWebhook = Insertable<Webhooks>;
+export type UpdatableWebhook = Updateable<Omit<Webhooks, 'id'>>;
+
+// Webhook delivery
+export type WebhookDelivery = Selectable<WebhookDeliveries>;
+export type InsertableWebhookDelivery = Insertable<WebhookDeliveries>;
+export type UpdatableWebhookDelivery = Updateable<Omit<WebhookDeliveries, 'id'>>;

--- a/apps/server/src/integrations/queue/constants/queue.constants.ts
+++ b/apps/server/src/integrations/queue/constants/queue.constants.ts
@@ -9,6 +9,7 @@ export enum QueueName {
   HISTORY_QUEUE = '{history-queue}',
   NOTIFICATION_QUEUE = '{notification-queue}',
   AUDIT_QUEUE = '{audit-queue}',
+  WEBHOOK_QUEUE = '{webhook-queue}',
 }
 
 export enum QueueJob {
@@ -83,4 +84,7 @@ export enum QueueJob {
 
   PDF_EXPORT_TASK = 'pdf-export-task',
   PDF_EXPORT_CLEANUP = 'pdf-export-cleanup',
+
+  WEBHOOK_DELIVERY = 'webhook-delivery',
+  WEBHOOK_DELIVERY_CLEANUP = 'webhook-delivery-cleanup',
 }

--- a/apps/server/src/integrations/queue/queue.module.ts
+++ b/apps/server/src/integrations/queue/queue.module.ts
@@ -92,6 +92,18 @@ import { GeneralQueueProcessor } from './processors/general-queue.processor';
         attempts: 3,
       },
     }),
+    BullModule.registerQueue({
+      name: QueueName.WEBHOOK_QUEUE,
+      defaultJobOptions: {
+        attempts: 5,
+        backoff: {
+          type: 'exponential',
+          delay: 10 * 1000,
+        },
+        removeOnComplete: { count: 200 },
+        removeOnFail: { count: 200 },
+      },
+    }),
   ],
   exports: [BullModule],
   providers: [GeneralQueueProcessor],

--- a/apps/server/src/integrations/transactional/emails/webhook-disabled-email.tsx
+++ b/apps/server/src/integrations/transactional/emails/webhook-disabled-email.tsx
@@ -1,0 +1,38 @@
+import { Section, Text } from 'react-email';
+import * as React from 'react';
+import { content, paragraph } from '../css/styles';
+import { EmailButton, MailBody, getGreetingName } from '../partials/partials';
+
+interface Props {
+  recipientName?: string;
+  webhookName: string;
+  webhookUrl: string;
+  settingsUrl: string;
+}
+
+export const WebhookDisabledEmail = ({
+  recipientName,
+  webhookName,
+  webhookUrl,
+  settingsUrl,
+}: Props) => {
+  return (
+    <MailBody>
+      <Section style={content}>
+        <Text style={paragraph}>Hi {getGreetingName(recipientName)},</Text>
+        <Text style={paragraph}>
+          Your webhook <strong>{webhookName}</strong> to{' '}
+          <strong>{webhookUrl}</strong> has been disabled after too many
+          consecutive delivery failures.
+        </Text>
+        <Text style={paragraph}>
+          Re-enable it in your workspace settings once the receiving endpoint
+          is healthy again.
+        </Text>
+      </Section>
+      <EmailButton href={settingsUrl}>Open webhook settings</EmailButton>
+    </MailBody>
+  );
+};
+
+export default WebhookDisabledEmail;

--- a/packages/editor-ext/src/lib/custom-code-block/custom-code-block.ts
+++ b/packages/editor-ext/src/lib/custom-code-block/custom-code-block.ts
@@ -1,5 +1,7 @@
 import type { CodeBlockOptions } from '@tiptap/extension-code-block';
 import CodeBlock from '@tiptap/extension-code-block';
+import { Plugin, Selection, TextSelection } from '@tiptap/pm/state';
+import { GapCursor } from '@tiptap/pm/gapcursor';
 
 import { LowlightPlugin } from './lowlight-plugin.js';
 import { ReactNodeViewRenderer } from '@tiptap/react';
@@ -19,7 +21,11 @@ const TAB_CHAR = '\u00A0\u00A0';
  * @see https://tiptap.dev/api/nodes/code-block-lowlight
  */
 export const CustomCodeBlock = CodeBlock.extend<CodeBlockLowlightOptions>({
+  // Run ahead of Gapcursor (100) so the mermaid arrow-into-source plugin
+  // can intercept before gapcursor takes over.
+  priority: 101,
   selectable: true,
+  isolating: true,
 
   addOptions() {
     return {
@@ -35,8 +41,86 @@ export const CustomCodeBlock = CodeBlock.extend<CodeBlockLowlightOptions>({
   },
 
   addKeyboardShortcuts() {
+    const isMermaid = (node: any) =>
+      node?.type === this.type && node.attrs.language === 'mermaid';
+
     return {
       ...this.parent?.(),
+      // Stop at the gap (or enter mermaid source) instead of jumping
+      // straight into the next block, so the user can place a cursor
+      // between two adjacent isolating blocks.
+      ArrowDown: ({ editor }) => {
+        const { state } = editor;
+        const { selection, doc } = state;
+        const { $from, empty } = selection;
+
+        if (!empty || $from.parent.type !== this.type) return false;
+        if ($from.parentOffset !== $from.parent.nodeSize - 2) return false;
+
+        const after = $from.after();
+        if (after >= doc.content.size) {
+          return editor.commands.exitCode();
+        }
+
+        const $after = doc.resolve(after);
+        const nodeAfter = $after.nodeAfter;
+
+        if (isMermaid(nodeAfter)) {
+          return editor.commands.command(({ tr }) => {
+            tr.setSelection(TextSelection.create(tr.doc, after + 1));
+            return true;
+          });
+        }
+
+        if (
+          nodeAfter?.type.spec.isolating &&
+          !nodeAfter.type.spec.atom
+        ) {
+          return editor.commands.command(({ tr }) => {
+            tr.setSelection(new GapCursor(tr.doc.resolve(after)));
+            return true;
+          });
+        }
+
+        return editor.commands.command(({ tr }) => {
+          tr.setSelection(Selection.near(tr.doc.resolve(after)));
+          return true;
+        });
+      },
+      // Mirror of ArrowDown; upstream has no ArrowUp handler.
+      ArrowUp: ({ editor }) => {
+        const { state } = editor;
+        const { selection, doc } = state;
+        const { $from, empty } = selection;
+
+        if (!empty || $from.parent.type !== this.type) return false;
+        if ($from.parentOffset !== 0) return false;
+
+        const before = $from.before();
+        if (before <= 0) return false;
+
+        const $before = doc.resolve(before);
+        const nodeBefore = $before.nodeBefore;
+
+        if (isMermaid(nodeBefore)) {
+          return editor.commands.command(({ tr }) => {
+            tr.setSelection(TextSelection.create(tr.doc, before - 1));
+            return true;
+          });
+        }
+
+        if (
+          nodeBefore?.type.spec.isolating &&
+          !nodeBefore.type.spec.atom
+        ) {
+          return editor.commands.command(({ tr }) => {
+            tr.setSelection(new GapCursor(tr.doc.resolve(before)));
+            return true;
+          });
+        }
+
+        return false;
+      },
       'Mod-a': () => {
         if (this.editor.isActive('codeBlock')) {
           const { state } = this.editor;
@@ -84,12 +168,67 @@ export const CustomCodeBlock = CodeBlock.extend<CodeBlockLowlightOptions>({
   },
 
   addProseMirrorPlugins() {
+    const codeBlockType = this.type;
     return [
       ...(this.parent?.() || []),
       LowlightPlugin({
         name: this.name,
         lowlight: this.options.lowlight,
         defaultLanguage: this.options.defaultLanguage,
+      }),
+      // Mermaid hides its <pre> when unselected, so the browser's native
+      // vertical caret movement skips past it. Land the cursor inside the
+      // source explicitly.
+      new Plugin({
+        props: {
+          handleKeyDown: (view, event) => {
+            if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
+              return false;
+            }
+            const { state } = view;
+            const { selection } = state;
+            if (
+              !selection.empty ||
+              !(selection instanceof TextSelection)
+            ) {
+              return false;
+            }
+            const { $from } = selection;
+            if ($from.depth === 0 || $from.parent.type === codeBlockType) {
+              return false;
+            }
+            const dir = event.key === 'ArrowUp' ? 'up' : 'down';
+            if (!view.endOfTextblock(dir)) return false;
+
+            const isMermaid = (node: any) =>
+              node?.type === codeBlockType && node.attrs.language === 'mermaid';
+
+            if (event.key === 'ArrowUp') {
+              if ($from.parentOffset !== 0) return false;
+              const beforePos = $from.before();
+              const prev = state.doc.resolve(beforePos).nodeBefore;
+              if (!isMermaid(prev)) return false;
+              const endPos = beforePos - 1;
+              view.dispatch(
+                state.tr.setSelection(
+                  TextSelection.create(state.doc, endPos),
+                ),
+              );
+              return true;
+            }
+            if ($from.parentOffset !== $from.parent.nodeSize - 2) return false;
+            const afterPos = $from.after();
+            const next = state.doc.resolve(afterPos).nodeAfter;
+            if (!isMermaid(next)) return false;
+            const startPos = afterPos + 1;
+            view.dispatch(
+              state.tr.setSelection(
+                TextSelection.create(state.doc, startPos),
+              ),
+            );
+            return true;
+          },
+        },
       }),
     ];
   },

--- a/packages/editor-ext/src/lib/utils.ts
+++ b/packages/editor-ext/src/lib/utils.ts
@@ -338,6 +338,15 @@ export const isRowGripSelected = ({
   return !!gripRow;
 };
 
+// TipTap's `editor.view` proxy throws if accessed before mount or after destroy.
+// Guard floating-menu callbacks (getReferencedVirtualElement, shouldShow) with
+// this before touching `editor.view.nodeDOM(...)`.
+export function isEditorReady(
+  editor: Editor | null | undefined,
+): editor is Editor {
+  return !!editor && editor.isInitialized;
+}
+
 export function isTextSelected(editor: Editor) {
   const {
     state: {


### PR DESCRIPTION
## Summary

Adds the core + frontend halves of the new Webhooks feature. Workspace admins can register outbound HTTP subscribers that receive signed JSON payloads when chosen domain events occur. Pairs with EE submodule PR [docmost/ee#46](https://github.com/docmost/ee/pull/46).

### Highlights

- New `webhooks` and `webhook_deliveries` tables with GIN-indexed `subscribed_events` for fast subscriber lookup.
- `WEBHOOK_QUEUE` registered with 5 attempts and 10s exponential backoff.
- New `WorkspaceCaslSubject.Webhook` (owner + admin can manage).
- 15 events wired across page, comment, space, attachment, and member lifecycles. `page.updated` fires from the collab autosave flush as well as from metadata-only updates.
- New admin UI under `/settings/webhooks`:
  - List page with name, URL (truncated, full URL in tooltip), event count, status, created, action menu.
  - Create modal with name / URL / grouped event multi-select / active switch. Signing secret revealed once after creation in a separate modal.
  - Edit modal with rotate-secret and send-test-event actions.
  - Delivery drawer with event, status badge, HTTP, duration, timestamp, redeliver button on failed/skipped rows, expandable JSON payload preview.
- New email template `webhook-disabled-email.tsx` sent to the creator after auto-disable.

### Out of scope for v1

- Per-space scoping (workspace-wide only).
- Payload customization, custom headers, retry-policy overrides.
- Subscriber endpoint URL verification challenge.
- Encryption at rest for `signing_secret` (treated like other outbound credentials).

## Test plan

- [ ] `pnpm nx run server:build` and `pnpm nx run client:build` are clean.
- [ ] Run `pnpm migration:up` then visit `/settings/webhooks`. Create a webhook subscribing to `page.created`. Confirm the signing-secret reveal modal appears once.
- [ ] Edit a page; verify subscriber receives a signed POST with the expected payload envelope and headers.
- [ ] Toggle a webhook off; events stop arriving.
- [ ] Run through every event in the catalog and verify the subscriber receives the right `event` and `data` shape:
  - page.created / updated / moved / deleted / restored
  - comment.created / updated / deleted / resolved
  - space.created / updated / deleted
  - attachment.uploaded
  - user.created (invite accept) / user.deactivated
- [ ] Verify `page.updated` fires only once per debounced collab save burst.
- [ ] Verify the deliveries drawer shows rows with correct status colors, payload preview, and redeliver works.
- [ ] Verify the 10-webhook-per-workspace limit returns a 400 with a clear error.
- [ ] Verify members (non-admin) cannot see the webhooks sidebar entry or hit the endpoints.