### PR TITLE
fix: increase workspace description visibility in space list

### DIFF
--- a/apps/client/src/features/space/components/space-list.tsx
+++ b/apps/client/src/features/space/components/space-list.tsx
@@ -68,7 +68,12 @@ export default function SpaceList() {
                       <AutoTooltipText fz="sm" fw={500} lineClamp={1}>
                         {space.name}
                       </AutoTooltipText>
-                      <Text fz="xs" c="dimmed" lineClamp={2}>
+                      <Text
+                        fz="xs"
+                        c="dimmed"
+                        lineClamp={4}
+                        title={space.description}
+                      >
                         {space.description}
                       </Text>
                     </div>

--- a/apps/client/src/features/space/components/spaces-page/all-spaces-list.tsx
+++ b/apps/client/src/features/space/components/spaces-page/all-spaces-list.tsx
@@ -159,7 +159,12 @@ export default function AllSpacesList({
                             {space.name}
                           </AutoTooltipText>
                           {space.description && (
-                            <Text fz="xs" c="dimmed" lineClamp={2}>
+                            <Text
+                              fz="xs"
+                              c="dimmed"
+                              lineClamp={4}
+                              title={space.description}
+                            >
                               {space.description}
                             </Text>
                           )}


### PR DESCRIPTION
## Problem

The space overview list truncates workspace descriptions at roughly 150 characters using `lineClamp={2}`, even though the description field accepts up to 250 characters. Users couldn't see the full description without opening settings.

## Fix

Changed `lineClamp` from 2 to 4 in both space list components, and added the `title` attribute with the full description text. This:

1. Shows more of the description inline (4 lines vs 2, covering ~250 chars at the current font size)
2. Provides a native browser tooltip with the complete text on hover via `title`

## Files changed

- `apps/client/src/features/space/components/space-list.tsx` — lineClamp 2 to 4, added title
- `apps/client/src/features/space/components/spaces-page/all-spaces-list.tsx` — lineClamp 2 to 4, added title

## Verification

lineClamp: 2 to 4 at fz=xs (~65 chars/line x 4 lines = ~260 chars, exceeds 250 limit)
title attribute shows full text on hover regardless of truncation

Fixes #1713