### PR TITLE
fix: constrain table width in print/PDF to prevent overflow clipping

### DIFF
--- a/apps/client/src/features/editor/styles/print.css
+++ b/apps/client/src/features/editor/styles/print.css
@@ -20,4 +20,15 @@
   .tableWrapper {
     overflow: hidden !important;
   }
+
+  .tableWrapper table {
+    width: 100% !important;
+    min-width: 0 !important;
+  }
+
+  .tableWrapper table td,
+  .tableWrapper table th {
+    word-break: break-word;
+    overflow-wrap: break-word;
+  }
 }


### PR DESCRIPTION
## Description

In print/PDF mode, wide tables were clipped by `overflow: hidden` on the table wrapper, making overflowing content invisible.

### Root cause

Three interacting layers caused table overflow in PDF:
1. `table-view.ts` sets an inline `min-width` on `<table>` based on total column widths (easily exceeding PDF content width)
2. `table.css` adds `min-width: 700px !important`
3. `print.css` sets `overflow: hidden !important` on the wrapper — this **clips** the table in print/PDF mode

### Fix

Add rules to `print.css` that override table dimensions and cell wrapping during print:

- `width: 100% !important; min-width: 0 !important` on the table — overrides both the JS inline style and CSS `!important` to force the table to fill its container
- `word-break: break-word; overflow-wrap: break-word` on cells — ensures long content wraps within available column space

### Verification

CSS-only change. The table now respects the PDF page width instead of overflowing.

### Trade-off

Columns may be narrower and content may wrap more aggressively than in the editor view. This is correct for print — readability in a constrained page width is better than silently clipped data.

Fixes #1801