### PR TITLE
fix: internal link search shows blank on first keystroke

### DIFF
--- a/apps/client/src/features/search/queries/search-query.ts
+++ b/apps/client/src/features/search/queries/search-query.ts
@@ -28,7 +28,7 @@ export function useSearchSuggestionsQuery(
 ): UseQueryResult<ISuggestionResult, Error> {
   const { preload, ...queryParams } = params;
   return useQuery({
-    queryKey: ["search-suggestion", params.query],
+    queryKey: ["search-suggestion", params.includeUsers, params.includePages, params.spaceId],
     staleTime: 60 * 1000, // 1min
     queryFn: () => searchSuggestions(queryParams),
     enabled: preload || !!params.query,


### PR DESCRIPTION
## Problem

When opening the internal link menu (e.g., selecting text and clicking the link button), the page suggestions list appears empty on the first keystroke. Results only show after the second keystroke.

## Root cause

The `queryKey` in `useSearchSuggestionsQuery` included `params.query`:

```ts
queryKey: ["search-suggestion", params.query],
```

On every keystroke, `params.query` changes → React Query creates a **brand new cache entry** → `placeholderData: keepPreviousData` has no previous data to bridge from → `suggestion?.pages` is `undefined` → the suggestions list is empty.

The server is fine — it returns results correctly for any query. The issue is purely client-side caching.

## Fix

Remove `params.query` from the `queryKey`. Keep only the stable params (`includeUsers`, `includePages`, `spaceId`) that distinguish different search contexts (LinkEditorPanel vs MentionList).

```ts
queryKey: ["search-suggestion", params.includeUsers, params.includePages, params.spaceId],
```

With a **stable key**, React Query reuses the same cache entry across keystrokes. `keepPreviousData` now correctly shows the previous query's results while the new query fetches in the background.

## Files changed

- `apps/client/src/features/search/queries/search-query.ts` — 1 line changed

## Verification

Not much to test here without a running browser — but the fix follows standard React Query patterns:
- Stable keys + `keepPreviousData` = instant previous data while fetching
- Server queryFn closure still passes the correct `queryParams.query` on every render
- `enabled: preload || !!params.query` still prevents unnecessary fetches on empty query

Fixes #2164