### PR TITLE
fix: export filenames with Chinese/Unicode characters now download correctly

### DIFF
--- a/apps/client/src/features/page/services/page-service.ts
+++ b/apps/client/src/features/page/services/page-service.ts
@@ -10,7 +10,6 @@ import {
 } from '@/features/page/types/page.types';
 import { QueryParams } from "@/lib/types";
 import { IPagination } from "@/lib/types.ts";
-import { saveAs } from "file-saver";
 import { InfiniteData } from "@tanstack/react-query";
 import { IFileTask } from '@/features/file-task/types/file-task.types.ts';
 import { IAttachment } from '@/features/attachments/types/attachment.types.ts';
@@ -118,18 +117,30 @@ export async function exportPage(data: IExportPageParams): Promise<void> {
     responseType: "blob",
   });
 
-  const fileName = req?.headers["content-disposition"]
-    .split("filename=")[1]
-    .replace(/"/g, "");
+  const contentDisposition = req?.headers?.["content-disposition"] as string | undefined;
+  let fileName = `export.${data.format || "html"}`;
 
-  let decodedFileName = fileName;
-  try {
-    decodedFileName = decodeURIComponent(fileName);
-  } catch (err) {
-    // fallback to raw filename
+  if (contentDisposition) {
+    const rfcMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/);
+    const fallbackMatch = contentDisposition.match(/filename="([^"]+)"/);
+    const raw = rfcMatch?.[1] || fallbackMatch?.[1];
+    if (raw) {
+      try {
+        fileName = decodeURIComponent(raw);
+      } catch {
+        fileName = raw;
+      }
+    }
   }
 
-  saveAs(req.data, decodedFileName);
+  const blobUrl = URL.createObjectURL(req.data);
+  const a = document.createElement("a");
+  a.href = blobUrl;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(blobUrl);
 }
 
 export async function importPage(file: File, spaceId: string) {

--- a/apps/client/src/features/space/services/space-service.ts
+++ b/apps/client/src/features/space/services/space-service.ts
@@ -8,7 +8,6 @@ import {
   ISpaceMember,
 } from "@/features/space/types/space.types";
 import { IPagination, QueryParams } from "@/lib/types.ts";
-import { saveAs } from "file-saver";
 
 export async function getSpaces(
   params?: QueryParams,
@@ -65,16 +64,28 @@ export async function exportSpace(data: IExportSpaceParams): Promise<void> {
     responseType: "blob",
   });
 
-  const fileName = req?.headers["content-disposition"]
-    .split("filename=")[1]
-    .replace(/"/g, "");
+  const contentDisposition = req?.headers?.["content-disposition"] as string | undefined;
+  let fileName = `export.${data.format || "html"}`;
 
-  let decodedFileName = fileName;
-  try {
-    decodedFileName = decodeURIComponent(fileName);
-  } catch (err) {
-    // fallback to raw filename
+  if (contentDisposition) {
+    const rfcMatch = contentDisposition.match(/filename\*=UTF-8''([^;]+)/);
+    const fallbackMatch = contentDisposition.match(/filename="([^"]+)"/);
+    const raw = rfcMatch?.[1] || fallbackMatch?.[1];
+    if (raw) {
+      try {
+        fileName = decodeURIComponent(raw);
+      } catch {
+        fileName = raw;
+      }
+    }
   }
 
-  saveAs(req.data, decodedFileName);
+  const blobUrl = URL.createObjectURL(req.data);
+  const a = document.createElement("a");
+  a.href = blobUrl;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(blobUrl);
 }

--- a/apps/server/src/core/attachment/attachment.controller.ts
+++ b/apps/server/src/core/attachment/attachment.controller.ts
@@ -481,9 +481,10 @@ export class AttachmentController {
     );
 
     if (!inlineFileExtensions.includes(attachment.fileExt)) {
+      const fallbackName = `attachment${attachment.fileExt}`;
       res.header(
         'Content-Disposition',
-        `attachment; filename="${encodeURIComponent(attachment.fileName)}"`,
+        `attachment; filename="${fallbackName}"; filename*=UTF-8''${encodeURIComponent(attachment.fileName)}`,
       );
     }
 

--- a/apps/server/src/integrations/export/export.controller.ts
+++ b/apps/server/src/integrations/export/export.controller.ts
@@ -96,7 +96,7 @@ export class ExportController {
       res.headers({
         'Content-Type': contentType,
         'Content-Disposition':
-          'attachment; filename="' + encodeURIComponent(fileName) + '"',
+          `attachment; filename="export${ext}"; filename*=UTF-8''${encodeURIComponent(fileName)}`,
       });
 
       res.send(result.content);
@@ -108,7 +108,7 @@ export class ExportController {
       res.headers({
         'Content-Type': 'application/zip',
         'Content-Disposition':
-          'attachment; filename="' + encodeURIComponent(fileName) + '"',
+          `attachment; filename="export.zip"; filename*=UTF-8''${encodeURIComponent(fileName)}`,
       });
 
       res.send(result.stream);
@@ -150,11 +150,9 @@ export class ExportController {
     res.headers({
       'Content-Type': 'application/zip',
       'Content-Disposition':
-        'attachment; filename="' +
-        encodeURIComponent(
+        `attachment; filename="export.zip"; filename*=UTF-8''${encodeURIComponent(
           sanitizeFileName(exportFile.fileName, { preserveSpaces: true }),
-        ) +
-        '"',
+        )}`,
     });
 
     res.send(exportFile.fileStream);


### PR DESCRIPTION
## Problem

Export/download filenames containing Chinese or other non-ASCII characters produce garbled names. The download either uses the raw percent-encoded string (e.g., `%E4%B8%AD%E6%96%87.html`) or fails entirely.

## Root cause

Two issues:

1. **Server-side**: The `Content-Disposition` header uses the `filename` parameter with percent-encoded values. Per RFC 6266, `filename` should contain only ASCII. Non-ASCII filenames must use the `filename*` parameter with RFC 5987 encoding.

2. **Client-side**: `file-saver` 2.0.5's `saveAs()` has known issues with non-ASCII filenames in some browsers. Additionally, the Content-Disposition parsing used naive `.split("filename=")[1]` which is fragile.

## Fix

### Server — RFC 5987 compliant headers

All three Content-Disposition paths now send:
- `filename="export.html"` — pure ASCII fallback for old clients
- `filename*=UTF-8''%E4%B8%AD%E6%96%87.html` — proper Unicode name via RFC 5987

Changed files:
- `export.controller.ts` — page export, page ZIP export, space export
- `attachment.controller.ts` — attachment download

### Client — native `<a download>` with robust header parsing

Replaced `file-saver`'s `saveAs()` with manual `<a download>` approach:
- Creates a blob URL and triggers download via native `<a>` element
- The `download` attribute has supported Unicode for over a decade in all major browsers
- Parses Content-Disposition with regex, preferring `filename*` (RFC 5987) over `filename`

Changed files:
- `page-service.ts` — replaced saveAs with `<a download>`
- `space-service.ts` — same

### Verification

- Server builds cleanly: `pnpm --filter server run build`
- No new dependencies — removes `file-saver` dependency from the download path

Fixes #1894