### PR TITLE
fix: markdown export converts <br> to space instead of preserving line breaks

### DIFF
--- a/packages/editor-ext/src/lib/markdown/utils/turndown.utils.ts
+++ b/packages/editor-ext/src/lib/markdown/utils/turndown.utils.ts
@@ -35,7 +35,7 @@ export function htmlToMarkdown(html: string): string {
     image,
     video,
   ]);
-  return turndownService.turndown(html).replaceAll('<br>', ' ');
+  return turndownService.turndown(html);
 }
 
 function listParagraph(turndownService: _TurndownService) {


### PR DESCRIPTION
## Problem

When exporting pages to Markdown, soft line breaks (`<br>` elements within paragraphs) are converted to spaces instead of being preserved as Markdown hard breaks. This causes loss of intentional line breaks in the content.

For example, a paragraph with two lines:
```
This is line one.
This is line two.
```

After export → re-import becomes:
```
This is line one. This is line two.
```

## Root cause

In `htmlToMarkdown()`, after turndown processes the HTML into Markdown, a post-processing step replaces ALL `<br>` strings with spaces:

```ts
return turndownService.turndown(html).replaceAll('<br>', ' ');
```

This is both redundant and harmful:
- Turndown's GFM plugin already converts `<br>` to proper Markdown hard breaks (`  \n`), so the post-processing catches nothing from standard elements
- For preserved HTML blocks (e.g., `<details>` which export as raw HTML), this actively destroys `<br>` tags, corrupting the preserved content

## Fix

Remove the `.replaceAll('<br>', ' ')` post-processing step entirely.

```ts
// Before:
return turndownService.turndown(html).replaceAll('<br>', ' ');

// After:
return turndownService.turndown(html);
```

## Files changed

- `packages/editor-ext/src/lib/markdown/utils/turndown.utils.ts` — 1 line changed

Fixes #2125