### PR TITLE
fix: store table colwidth as string to prevent unnecessary y-prosemirror sync

### DIFF
--- a/packages/editor-ext/src/lib/table/cell.ts
+++ b/packages/editor-ext/src/lib/table/cell.ts
@@ -8,6 +8,19 @@ export const TableCell = TiptapTableCell.extend({
   addAttributes() {
     return {
       ...this.parent?.(),
+
+      colwidth: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('colwidth') || null,
+        renderHTML: (attributes) => {
+          if (!attributes.colwidth) return {};
+          if (typeof attributes.colwidth === 'string') {
+            return { colwidth: attributes.colwidth };
+          }
+          return { colwidth: (attributes.colwidth as number[]).join(',') };
+        },
+      },
+
       backgroundColor: {
         default: null,
         parseHTML: (element) =>

--- a/packages/editor-ext/src/lib/table/table-view.ts
+++ b/packages/editor-ext/src/lib/table/table-view.ts
@@ -2,6 +2,15 @@ import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import type { NodeView, ViewMutationRecord } from '@tiptap/pm/view';
 import { getColStyleDeclaration } from './utils/col-style';
 
+function parseColwidth(colwidth: unknown): number[] | null {
+  if (!colwidth) return null;
+  if (typeof colwidth === 'string') {
+    return colwidth.split(',').map(Number);
+  }
+  if (Array.isArray(colwidth)) return colwidth;
+  return null;
+}
+
 export function updateColumns(
   node: ProseMirrorNode,
   colgroup: HTMLElement,
@@ -18,12 +27,13 @@ export function updateColumns(
   if (row !== null) {
     for (let i = 0, col = 0; i < row.childCount; i += 1) {
       const { colspan, colwidth } = row.child(i).attrs;
+      const colwidthArr = parseColwidth(colwidth);
 
       for (let j = 0; j < colspan; j += 1, col += 1) {
         const hasWidth =
           overrideCol === col
             ? overrideValue
-            : ((colwidth && colwidth[j]) as number | undefined);
+            : ((colwidthArr?.[j]) as number | undefined);
         const cssWidth = hasWidth ? `${hasWidth}px` : '';
 
         totalWidth += hasWidth || cellMinWidth;


### PR DESCRIPTION
## Problem

Table column widths (`colwidth`) are stored as `number[]` arrays. When using Yjs collaboration (via `y-prosemirror`), the sync plugin compares attributes with `!==` reference equality. Since arrays are always different references, `colwidth` is flagged as "changed" on EVERY sync cycle, triggering unnecessary `setAttribute()` calls. This causes:

- Extra sync traffic amplified across all collaborators
- Potential visual flickering as the table re-renders
- Undo history pollution from spurious attribute changes

## Root cause

In `y-prosemirror`'s `updateYFragment()`:

```js
if (yDomAttrs[key] !== pAttrs[key] && key !== 'ychange') {
  yDomFragment.setAttribute(key, pAttrs[key])
}
```

When `key = "colwidth"`:
- `yDomAttrs["colwidth"]` is a Y.Array or freshly reconstructed array from Yjs storage
- `pAttrs["colwidth"]` is the ProseMirror node's `number[]`
- `!==` always returns `true` (different references)

## Fix

Store `colwidth` as a **comma-separated string** (`"100,200"`) instead of `number[]` (`[100, 200]`). Strings compare correctly with `!==`.

### cell.ts

Override `colwidth` attribute:
- `parseHTML`: Keep the raw `colwidth` attribute value as a string (don't split to array)
- `renderHTML`: If attribute is a string, pass through; if an array (backward compat), join to string

### table-view.ts

Add `parseColwidth()` helper that handles both string and array formats, ensuring backward compatibility with existing documents and column resize operations.

## Files changed

- `packages/editor-ext/src/lib/table/cell.ts` — colwidth attribute override (+13 lines)
- `packages/editor-ext/src/lib/table/table-view.ts` — parseColwidth() helper, updated usage (+11/-1 lines)

## Verification

- `pnpm --filter @docmost/editor-ext build` passes cleanly
- Backward compatible: existing documents with array colwidth work via `parseColwidth()`
- Column resize operations (which create arrays in prosemirror-tables) are handled gracefully

Fixes #1863