### PR TITLE
fix: Page details updated timestamp desync

### DIFF
--- a/apps/client/src/features/editor/page-editor.tsx
+++ b/apps/client/src/features/editor/page-editor.tsx
@@ -318,7 +318,6 @@ export default function PageEditor({
       queryClient.setQueryData(["pages", slugId], {
         ...pageData,
         content: newContent,
-        updatedAt: new Date(),
       });
     }
   }, 3000);


### PR DESCRIPTION
## Description
This fixes a UI cache inconsistency where opening a page could make the Details sidebar show a fresh “Last updated” timestamp even when the page had not actually been edited. The issue was caused by the editor updating the local page cache with a synthetic updatedAt during content sync.

The change removes that client-side updatedAt override and leaves timestamp updates to the real backend/websocket update flow. This keeps the Details sidebar metadata consistent with the dashboard/recent changes view and prevents “0 seconds ago” from appearing on page open without an actual edit.

## Related Issues

Fixes: #2226 

## Steps to Test

1. Create a Page
2. Open the page. Don't make any changes and click on `i` next to the author name.
3. On right side you'll see the timestamp to be 0 sec even without any edits.

## Before Changes
<img width="438" height="396" alt="image" src="https://github.com/user-attachments/assets/a99d2809-20f1-43be-bc09-80d47515fc0e" />

## After Changes
<img width="435" height="388" alt="image" src="https://github.com/user-attachments/assets/f5ed7fbb-46c9-4199-9d7b-e926a10b2b7a" />

## Checklist

- [X] I have tested these changes
- [X] I have made corresponding changes to the codebase
- [X] My changes generate no new warnings or errors
- [X] The title of my pull request is clear and descriptive