### PR TITLE
fix: Table jitter on edit/read toggle

### DIFF
--- a/apps/client/src/features/editor/styles/table.css
+++ b/apps/client/src/features/editor/styles/table.css
@@ -204,10 +204,6 @@
   opacity: 1;
 }
 
-.ProseMirror table th:has(.tableReadonlySortChevron) {
-  padding-right: 30px;
-}
-
 .tableReadonlySortChevron:hover {
   background: light-dark(
     rgba(55, 53, 47, 0.16),


### PR DESCRIPTION
Fix for the sorting chevron behaving differently in Read vs Edit which resulted in different table header text-wrap layout such that Edit was not WYSIWG.  Personally I'd like to support tight tables instead of dedicating invisible padding for an only visible on hover chevron control. 

Video demonstrating the existing behavior and the fixed table behavior on this branch.

https://github.com/user-attachments/assets/90861a81-0851-4030-bd32-ed4463ddb84a


