### PR TITLE
feat: configurable default user locale via DEFAULT_LOCALE env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ APP_SECRET=REPLACE_WITH_LONG_SECRET
 
 JWT_TOKEN_EXPIRES_IN=30d
 
+# Default locale assigned to new users, e.g. en-US | fr-FR | es-ES | de-DE (default: en-US)
+DEFAULT_LOCALE=en-US
+
 DATABASE_URL="postgresql://postgres:password@localhost:5432/docmost?schema=public"
 REDIS_URL=redis://127.0.0.1:6379
 

--- a/apps/server/src/database/repos/user/user.repo.ts
+++ b/apps/server/src/database/repos/user/user.repo.ts
@@ -14,10 +14,14 @@ import { executeWithCursorPagination } from '@docmost/db/pagination/cursor-pagin
 import { ExpressionBuilder, sql } from 'kysely';
 import { jsonObjectFrom } from 'kysely/helpers/postgres';
 import { NotificationSettingKey } from '../../../core/notification/notification.constants';
+import { EnvironmentService } from '../../../integrations/environment/environment.service';
 
 @Injectable()
 export class UserRepo {
-  constructor(@InjectKysely() private readonly db: KyselyDB) {}
+  constructor(
+    @InjectKysely() private readonly db: KyselyDB,
+    private readonly environmentService: EnvironmentService,
+  ) {}
 
   public baseFields: Array<keyof Users> = [
     'id',
@@ -118,7 +122,7 @@ export class UserRepo {
         insertableUser.name || insertableUser.email.split('@')[0].toLowerCase(),
       email: insertableUser.email.toLowerCase(),
       password: await hashPassword(insertableUser.password),
-      locale: 'en-US',
+      locale: this.environmentService.getDefaultLocale(),
       role: insertableUser?.role,
       lastLoginAt: new Date(),
     };

--- a/apps/server/src/integrations/environment/environment.service.ts
+++ b/apps/server/src/integrations/environment/environment.service.ts
@@ -10,6 +10,10 @@ export class EnvironmentService {
     return this.configService.get<string>('NODE_ENV', 'development');
   }
 
+  getDefaultLocale(): string {
+    return this.configService.get<string>('DEFAULT_LOCALE', 'en-US');
+  }
+
   isDevelopment(): boolean {
     return this.getNodeEnv() === 'development';
   }


### PR DESCRIPTION
Based on https://github.com/docmost/docmost/issues/1945.

Adds a DEFAULT_LOCALE env variable to set the locale for newly created users. The locale was hardcoded to en-US in UserRepo.insertUser(), forcing every new user (signup, setup, invitation) into English regardless of the instance's audience.