### PR TITLE
fix(editor): allow code block language to be reset to auto

### DIFF
--- a/apps/client/src/features/editor/components/code-block/code-block-view.tsx
+++ b/apps/client/src/features/editor/components/code-block/code-block-view.tsx
@@ -38,7 +38,7 @@ export default function CodeBlockView(props: NodeViewProps) {
     };
   }, [editor, getPos(), node.nodeSize]);
 
-  function changeLanguage(language: string) {
+  function changeLanguage(language: string | null) {
     setLanguageValue(language);
     updateAttributes({
       language: language,


### PR DESCRIPTION
Fixes #2263

## Root Cause:

changeLanguage function had `language: string type`
when user clears the dropdown, it receives null
null wasn't handled so old value persisted in node attributes

## Fix:

changed type to `string | null`
now clearing the dropdown correctly passes `null` to updateAttributes
language resets to auto-detect as expected