### PR TITLE
fix(auth): sanitize null IP address to prevent inet type error

### DIFF
--- a/apps/server/src/common/middlewares/audit-context.middleware.ts
+++ b/apps/server/src/common/middlewares/audit-context.middleware.ts
@@ -19,7 +19,8 @@ export class AuditContextMiddleware implements NestMiddleware {
   use(req: FastifyRequest['raw'], res: FastifyReply['raw'], next: () => void) {
     const workspaceId = (req as any).workspaceId ?? null;
 
-    const ipAddress = (req as any).ip ?? (req as any).socket?.remoteAddress ?? null;
+    const rawIp = (req as any).ip ?? (req as any).socket?.remoteAddress ?? null;
+    const ipAddress = rawIp && rawIp !== '(null)' ? rawIp : null;
 
     const userAgent =
       (req.headers['user-agent'] as string) ?? null;


### PR DESCRIPTION
Fixes #2197
## Root Cause:

Behind a reverse `proxy, req.ip` returns the string `(null)` instead of actual null
This string gets passed directly into `PostgreSQL's` inet column
PostgreSQL rejects "(null)" as invalid inet syntax → Internal server error on login

## Fix:

Sanitize the raw IP value in `audit-context.middleware.ts`
If IP is "(null)" or falsy, fall back to null before storing