### PR TITLE
feat: Windshift integration provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,17 @@ DEBUG_DB=false
 
 # Log http requests
 LOG_HTTP=false
+
+# Integration egress hardening. By default, integration OAuth connections may
+# point at loopback/private/internal addresses (typical for self-hosted
+# deployments that run providers on the same network). Set to false to block
+# integration traffic to loopback, link-local (incl. cloud metadata),
+# RFC1918/CGNAT, and IPv6 unique-local destinations — recommended whenever
+# workspace admins are less trusted than the deployment operator.
+INTEGRATION_ALLOW_LOCAL_CONNECTIONS=true
+
+# Integration egress limits. Every integration request (token exchange and
+# resource calls) is subject to a per-request deadline and a cap on the
+# response bytes read into memory.
+INTEGRATION_REQUEST_TIMEOUT_MS=15000
+INTEGRATION_MAX_RESPONSE_BYTES=5242880

--- a/.env.example
+++ b/.env.example
@@ -83,12 +83,11 @@ INTEGRATION_ALLOW_LOCAL_CONNECTIONS=true
 INTEGRATION_REQUEST_TIMEOUT_MS=15000
 INTEGRATION_MAX_RESPONSE_BYTES=5242880
 
-# Windshift integration — optional deployment-level defaults for the workspace
-# admin setup screen. Admins can also configure these in Docmost under
-# Settings → Workspace integrations. These values do not grant shared access;
-# each Docmost user still connects their own Windshift account via OAuth.
-# Register the redirect URI shown in the admin connection form in the matching
-# Windshift OAuth client.
+# Windshift integration — optional deployment-level defaults. Workspace admins
+# only need the base URL when configuring Windshift in Docmost; Docmost
+# automatically registers a public OAuth client and every user authorizes their
+# own Windshift account. The client ID/secret remain available for legacy
+# environment-based configuration.
 WINDSHIFT_BASE_URL=
 WINDSHIFT_OAUTH_CLIENT_ID=
 WINDSHIFT_OAUTH_CLIENT_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -82,3 +82,13 @@ INTEGRATION_ALLOW_LOCAL_CONNECTIONS=true
 # response bytes read into memory.
 INTEGRATION_REQUEST_TIMEOUT_MS=15000
 INTEGRATION_MAX_RESPONSE_BYTES=5242880
+
+# Windshift integration — optional deployment-level defaults for the workspace
+# admin setup screen. Admins can also configure these in Docmost under
+# Settings → Workspace integrations. These values do not grant shared access;
+# each Docmost user still connects their own Windshift account via OAuth.
+# Register the redirect URI shown in the admin connection form in the matching
+# Windshift OAuth client.
+WINDSHIFT_BASE_URL=
+WINDSHIFT_OAUTH_CLIENT_ID=
+WINDSHIFT_OAUTH_CLIENT_SECRET=

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -6,11 +6,13 @@ import Page from "@/pages/page/page";
 import AccountSettings from "@/pages/settings/account/account-settings";
 import WorkspaceMembers from "@/pages/settings/workspace/workspace-members";
 import WorkspaceSettings from "@/pages/settings/workspace/workspace-settings";
+import WorkspaceIntegrations from "@/pages/settings/workspace/workspace-integrations";
 import Groups from "@/pages/settings/group/groups";
 import GroupInfo from "./pages/settings/group/group-info";
 import Spaces from "@/pages/settings/space/spaces.tsx";
 import { Error404 } from "@/components/ui/error-404.tsx";
 import AccountPreferences from "@/pages/settings/account/account-preferences.tsx";
+import AccountIntegrations from "@/pages/settings/account/integrations.tsx";
 import SpaceHome from "@/pages/space/space-home.tsx";
 import PageRedirect from "@/pages/page/page-redirect.tsx";
 import Layout from "@/components/layouts/global/layout.tsx";
@@ -96,16 +98,10 @@ export default function App() {
           <Route path={"/favorites"} element={<FavoritesPage />} />
           <Route path={"/labels/:labelName"} element={<LabelPage />} />
           <Route path={"/templates"} element={<TemplateList />} />
-          <Route
-            path={"/templates/:templateId"}
-            element={<TemplateEditor />}
-          />
+          <Route path={"/templates/:templateId"} element={<TemplateEditor />} />
           <Route path={"/s/:spaceSlug"} element={<SpaceHome />} />
           <Route path={"/s/:spaceSlug/trash"} element={<SpaceTrash />} />
-          <Route
-            path={"/s/:spaceSlug/p/:pageSlug"}
-            element={<Page />}
-          />
+          <Route path={"/s/:spaceSlug/p/:pageSlug"} element={<Page />} />
 
           <Route path={"/base/:pageId"} element={<BasePage />} />
 
@@ -116,7 +112,15 @@ export default function App() {
               element={<AccountPreferences />}
             />
             <Route path={"account/api-keys"} element={<UserApiKeys />} />
+            <Route
+              path={"account/integrations"}
+              element={<AccountIntegrations />}
+            />
             <Route path={"workspace"} element={<WorkspaceSettings />} />
+            <Route
+              path={"workspace-integrations"}
+              element={<WorkspaceIntegrations />}
+            />
             <Route path={"members"} element={<WorkspaceMembers />} />
             <Route path={"api-keys"} element={<WorkspaceApiKeys />} />
             <Route path={"groups"} element={<Groups />} />

--- a/apps/client/src/components/layouts/global/layout.tsx
+++ b/apps/client/src/components/layouts/global/layout.tsx
@@ -6,10 +6,12 @@ import { isCloud } from "@/lib/config.ts";
 import { SearchSpotlight } from "@/features/search/components/search-spotlight.tsx";
 import React from "react";
 import { useGetSpaceBySlugQuery } from "@/features/space/queries/space-query.ts";
+import { useSyncRegisteredIntegrations } from "@/features/integrations/hooks/use-sync-registered-integrations.ts";
 
 export default function Layout() {
   const { spaceSlug } = useParams();
   const { data: space } = useGetSpaceBySlugQuery(spaceSlug);
+  useSyncRegisteredIntegrations();
 
   return (
     <UserProvider>

--- a/apps/client/src/components/settings/settings-sidebar.tsx
+++ b/apps/client/src/components/settings/settings-sidebar.tsx
@@ -15,6 +15,7 @@ import {
   IconSparkles,
   IconHistory,
   IconShieldCheck,
+  IconPlug,
 } from "@tabler/icons-react";
 import { Link, useLocation } from "react-router-dom";
 import classes from "./settings.module.css";
@@ -74,12 +75,23 @@ const groupedData: DataGroup[] = [
         path: "/settings/account/api-keys",
         feature: Feature.API_KEYS,
       },
+      {
+        label: "Integrations",
+        icon: IconPlug,
+        path: "/settings/account/integrations",
+      },
     ],
   },
   {
     heading: "Workspace",
     items: [
       { label: "General", icon: IconSettings, path: "/settings/workspace" },
+      {
+        label: "Workspace integrations",
+        icon: IconPlug,
+        path: "/settings/workspace-integrations",
+        role: "admin",
+      },
       { label: "Members", icon: IconUsers, path: "/settings/members" },
       {
         label: "Billing",
@@ -168,6 +180,10 @@ export default function SettingsSidebar() {
   const isItemDisabled = (item: DataItem) => {
     if (!item.feature) return false;
     return !hasFeature(item.feature);
+  };
+
+  const isActiveItem = (item: DataItem) => {
+    return active === item.path || active.startsWith(`${item.path}/`);
   };
 
   const menuItems = groupedData.map((group) => {
@@ -261,7 +277,7 @@ export default function SettingsSidebar() {
             <Link
               onMouseEnter={prefetchHandler}
               className={classes.link}
-              data-active={active.startsWith(item.path) || undefined}
+              data-active={isActiveItem(item) || undefined}
               key={item.label}
               to={item.path}
               onClick={() => {

--- a/apps/client/src/features/editor/components/integrations/integration-embed-view.module.css
+++ b/apps/client/src/features/editor/components/integrations/integration-embed-view.module.css
@@ -1,0 +1,20 @@
+/* Anchors inside editor content are repainted by the global `.ProseMirror a`
+   rule; embed links opt out and always present as clickable. The !important
+   color overrides follow the same approach as mention.module.css. */
+.link {
+  text-decoration: none !important;
+  border-bottom: none !important;
+  cursor: pointer;
+}
+
+/* Badges rendered as anchors keep the Mantine badge palette. */
+.badgeLink {
+  composes: link;
+  color: var(--badge-color) !important;
+}
+
+/* Links that should read as regular text (row/card titles). */
+.quietLink {
+  composes: link;
+  color: inherit !important;
+}

--- a/apps/client/src/features/editor/components/integrations/integration-embed-view.tsx
+++ b/apps/client/src/features/editor/components/integrations/integration-embed-view.tsx
@@ -1,0 +1,644 @@
+import {
+  ActionIcon,
+  Anchor,
+  Badge,
+  Button,
+  Card,
+  Group,
+  Loader,
+  Popover,
+  Skeleton,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  Tooltip,
+  UnstyledButton,
+} from "@mantine/core";
+import { useDebouncedValue } from "@mantine/hooks";
+import { NodeViewProps, NodeViewWrapper } from "@tiptap/react";
+import { IconAlertCircle, IconEdit, IconRefresh } from "@tabler/icons-react";
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import {
+  useResolveIntegrationResourceQuery,
+  useSearchIntegrationResourceQuery,
+} from "@/features/integrations/queries/integration-resource-query";
+import {
+  IntegrationItemCardPayload,
+  IntegrationResourceSearchResult,
+  IntegrationTableReportPayload,
+  IntegrationTableReportRow,
+  resolveIntegrationResource,
+} from "@/features/integrations/services/integration-resource-service";
+import { findRegisteredIntegrationResource } from "@/features/integrations/integration-resource-registry";
+import classes from "./integration-embed-view.module.css";
+
+interface IntegrationEmbedAttrs {
+  integrationId?: string;
+  resourceId?: string;
+  resourceKey?: string;
+  labelAtInsert?: string;
+  renderKind?: string;
+  params?: Record<string, unknown> | null;
+}
+
+export default function IntegrationEmbedView(props: NodeViewProps) {
+  const attrs = props.node.attrs as IntegrationEmbedAttrs;
+  const integrationId = attrs.integrationId ?? "";
+  const resourceId = attrs.resourceId ?? "";
+  const manifest = findRegisteredIntegrationResource(integrationId, resourceId);
+
+  if (!integrationId || !resourceId) {
+    return <Unavailable message="Integration resource is not configured" />;
+  }
+
+  if (!attrs.resourceKey) {
+    if (!props.editor.isEditable) {
+      return <Unavailable message="Integration embed is not configured" />;
+    }
+    return (
+      <EmptyState
+        integrationId={integrationId}
+        resourceId={resourceId}
+        title={manifest?.title ?? "Integration embed"}
+        placeholder={manifest?.picker?.placeholder}
+        emptyLabel={manifest?.picker?.emptyLabel}
+        searchOnEmpty={manifest?.picker?.searchOnEmpty}
+        renderKind={manifest?.renderKind ?? attrs.renderKind}
+        updateAttributes={props.updateAttributes}
+      />
+    );
+  }
+
+  return (
+    <ResolvedState
+      integrationId={integrationId}
+      resourceId={resourceId}
+      resourceKey={attrs.resourceKey}
+      labelAtInsert={attrs.labelAtInsert}
+      params={attrs.params}
+      renderKind={manifest?.renderKind ?? attrs.renderKind}
+      editable={props.editor.isEditable}
+      updateAttributes={props.updateAttributes}
+    />
+  );
+}
+
+function ResourcePickerForm(props: {
+  integrationId: string;
+  resourceId: string;
+  placeholder?: string;
+  emptyLabel?: string;
+  searchOnEmpty?: boolean;
+  onPick: (result: IntegrationResourceSearchResult) => void;
+}) {
+  const { t } = useTranslation();
+  const [value, setValue] = useState("");
+  const [debouncedQuery] = useDebouncedValue(value.trim(), 200);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const search = useSearchIntegrationResourceQuery({
+    integrationId: props.integrationId,
+    resourceId: props.resourceId,
+    q: debouncedQuery,
+    searchOnEmpty: props.searchOnEmpty,
+  });
+
+  // Focus without scrolling: a native autoFocus fires while a portalled
+  // popover is still unpositioned, yanking the viewport to the top.
+  useEffect(() => {
+    inputRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  const onSubmit = (e?: React.FormEvent) => {
+    e?.preventDefault();
+    const first = search.data?.[0];
+    if (first) props.onPick(first);
+  };
+
+  return (
+    <form onSubmit={onSubmit}>
+      <Stack gap="xs">
+        <TextInput
+          ref={inputRef}
+          value={value}
+          onChange={(e) => setValue(e.currentTarget.value)}
+          placeholder={props.placeholder ?? t("Search…")}
+          rightSection={search.isFetching ? <Loader size="xs" /> : null}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") onSubmit(e);
+          }}
+        />
+        <SearchResultList
+          results={search.data ?? []}
+          isLoading={search.isFetching && !search.data}
+          query={debouncedQuery}
+          searchOnEmpty={props.searchOnEmpty}
+          emptyLabel={props.emptyLabel}
+          onPick={props.onPick}
+        />
+      </Stack>
+    </form>
+  );
+}
+
+function EmptyState(props: {
+  integrationId: string;
+  resourceId: string;
+  title: string;
+  placeholder?: string;
+  emptyLabel?: string;
+  searchOnEmpty?: boolean;
+  renderKind?: string;
+  updateAttributes: NodeViewProps["updateAttributes"];
+}) {
+  const { t } = useTranslation();
+  return (
+    <NodeViewWrapper>
+      <Card withBorder padding="md" radius="md">
+        <Stack gap="xs">
+          <Text size="sm" fw={500}>
+            {t("Embed {{title}}", { title: props.title })}
+          </Text>
+          <ResourcePickerForm
+            integrationId={props.integrationId}
+            resourceId={props.resourceId}
+            placeholder={props.placeholder}
+            emptyLabel={props.emptyLabel}
+            searchOnEmpty={props.searchOnEmpty}
+            onPick={(result) =>
+              props.updateAttributes({
+                resourceKey: result.key,
+                labelAtInsert: result.title,
+                renderKind: props.renderKind,
+                params: null,
+              })
+            }
+          />
+        </Stack>
+      </Card>
+    </NodeViewWrapper>
+  );
+}
+
+/** Edit-pencil popover to retarget a placed embed — mirrors the stock embed
+    component's edit affordance. */
+function EditResourceControl(props: {
+  integrationId: string;
+  resourceId: string;
+  updateAttributes: NodeViewProps["updateAttributes"];
+}) {
+  const { t } = useTranslation();
+  const [opened, setOpened] = useState(false);
+  const manifest = findRegisteredIntegrationResource(props.integrationId, props.resourceId);
+  return (
+    <Popover opened={opened} onChange={setOpened} width={320} position="bottom-end" withArrow hideDetached={false}>
+      <Popover.Target>
+        <ActionIcon
+          variant="subtle"
+          onClick={() => setOpened(true)}
+          aria-label={t("Change linked resource")}
+        >
+          <IconEdit size={16} />
+        </ActionIcon>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <ResourcePickerForm
+          integrationId={props.integrationId}
+          resourceId={props.resourceId}
+          placeholder={manifest?.picker?.placeholder}
+          emptyLabel={manifest?.picker?.emptyLabel}
+          searchOnEmpty={manifest?.picker?.searchOnEmpty}
+          onPick={(result) => {
+            props.updateAttributes({
+              resourceKey: result.key,
+              labelAtInsert: result.title,
+              params: null,
+            });
+            setOpened(false);
+          }}
+        />
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
+
+function SearchResultList(props: {
+  results: IntegrationResourceSearchResult[];
+  isLoading: boolean;
+  query: string;
+  searchOnEmpty?: boolean;
+  emptyLabel?: string;
+  onPick: (result: IntegrationResourceSearchResult) => void;
+}) {
+  const { t } = useTranslation();
+  if (!props.searchOnEmpty && props.query.length === 0) return null;
+  if (props.isLoading) {
+    return (
+      <Text size="xs" c="dimmed">
+        {t("Searching…")}
+      </Text>
+    );
+  }
+  if (props.results.length === 0) {
+    return (
+      <Text size="xs" c="dimmed">
+        {props.emptyLabel ? t(props.emptyLabel) : t("No matching resources")}
+      </Text>
+    );
+  }
+  return (
+    <Stack gap={4}>
+      {props.results.map((result) => (
+        <UnstyledButton
+          key={result.key}
+          onClick={() => props.onPick(result)}
+          style={{ padding: "6px 8px", borderRadius: 4, display: "block", width: "100%" }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.backgroundColor = "var(--mantine-color-gray-1)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = "transparent";
+          }}
+        >
+          <Group gap="xs" wrap="nowrap">
+            {result.badge && (
+              <Badge color="blue" variant="filled" size="sm">
+                {result.badge}
+              </Badge>
+            )}
+            <Text size="sm" lineClamp={1} style={{ flex: 1 }}>
+              {result.title}
+            </Text>
+            {result.subtitle && (
+              <Badge variant="default" size="xs">
+                {result.subtitle}
+              </Badge>
+            )}
+          </Group>
+        </UnstyledButton>
+      ))}
+    </Stack>
+  );
+}
+
+function ResolvedState(props: {
+  integrationId: string;
+  resourceId: string;
+  resourceKey: string;
+  labelAtInsert?: string;
+  params?: Record<string, unknown> | null;
+  renderKind?: string;
+  editable?: boolean;
+  updateAttributes: NodeViewProps["updateAttributes"];
+}) {
+  const { t } = useTranslation();
+  const query = useResolveIntegrationResourceQuery({
+    integrationId: props.integrationId,
+    resourceId: props.resourceId,
+    resourceKey: props.resourceKey,
+    params: props.params,
+  });
+
+  useEffect(() => {
+    const onVis = () => {
+      if (document.visibilityState === "visible") query.refetch();
+    };
+    document.addEventListener("visibilitychange", onVis);
+    return () => document.removeEventListener("visibilitychange", onVis);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (query.data?.kind === "item-card" && query.data.key && query.data.key !== props.resourceKey) {
+      props.updateAttributes({ resourceKey: query.data.key, labelAtInsert: query.data.title, params: null });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query.data]);
+
+  if (query.isLoading) {
+    if (props.renderKind === "table-report") {
+      return (
+        <NodeViewWrapper>
+          <Card withBorder padding="md" radius="md">
+            <Skeleton height={20} width="40%" mb="sm" />
+            <Stack gap={6}>
+              <Skeleton height={28} />
+              <Skeleton height={28} />
+              <Skeleton height={28} />
+            </Stack>
+          </Card>
+        </NodeViewWrapper>
+      );
+    }
+    return (
+      <NodeViewWrapper>
+        <Card withBorder padding="md" radius="md">
+          <Skeleton height={20} width="60%" mb="xs" />
+          <Skeleton height={14} width="40%" />
+        </Card>
+      </NodeViewWrapper>
+    );
+  }
+
+  if (query.isError) {
+    return <ErrorState error={query.error} fallbackLabel={props.labelAtInsert || props.resourceKey} refetch={() => query.refetch()} />;
+  }
+
+  const editControl = props.editable ? (
+    <EditResourceControl
+      integrationId={props.integrationId}
+      resourceId={props.resourceId}
+      updateAttributes={props.updateAttributes}
+    />
+  ) : null;
+
+  if (query.data?.kind === "item-card") {
+    return (
+      <ItemCard
+        payload={query.data}
+        refetch={() => query.refetch()}
+        isFetching={query.isFetching}
+        editControl={editControl}
+      />
+    );
+  }
+  if (query.data?.kind === "table-report") {
+    return (
+      <TableReport
+        payload={query.data}
+        integrationId={props.integrationId}
+        resourceId={props.resourceId}
+        resourceKey={props.resourceKey}
+        dataUpdatedAt={query.dataUpdatedAt}
+        refetch={() => query.refetch()}
+        isFetching={query.isFetching}
+        editControl={editControl}
+      />
+    );
+  }
+  return <Unavailable message={t("Unsupported integration resource")} />;
+}
+
+function ErrorState(props: { error: Error; fallbackLabel: string; refetch: () => void }) {
+  const { t } = useTranslation();
+  const status = (props.error as Error & { response?: { status?: number; data?: { code?: string } } })?.response?.status;
+  const code = (props.error as Error & { response?: { data?: { code?: string } } })?.response?.data?.code;
+
+  if (status === 409 && (code === "INTEGRATION_NOT_CONNECTED" || code === "INTEGRATION_RECONNECT_REQUIRED")) {
+    return (
+      <NodeViewWrapper>
+        <Card withBorder padding="md" radius="md">
+          <Group gap="xs">
+            <Text size="sm" c="dimmed">
+              {code === "INTEGRATION_NOT_CONNECTED"
+                ? t("Integration not connected")
+                : t("Reconnect integration to refresh")}
+            </Text>
+            <Anchor component={Link} to="/settings/account/integrations" size="sm">
+              {t("Connect integration")}
+            </Anchor>
+          </Group>
+        </Card>
+      </NodeViewWrapper>
+    );
+  }
+
+  if (status && status >= 400 && status < 500) {
+    return (
+      <NodeViewWrapper>
+        <Card withBorder padding="md" radius="md">
+          <Group gap="xs">
+            <Badge color="gray" variant="light">
+              {props.fallbackLabel}
+            </Badge>
+            <Text size="sm" c="dimmed">
+              {t("Resource unavailable")}
+            </Text>
+          </Group>
+        </Card>
+      </NodeViewWrapper>
+    );
+  }
+
+  return (
+    <NodeViewWrapper>
+      <Card withBorder padding="md" radius="md">
+        <Group gap="xs">
+          <IconAlertCircle size={16} />
+          <Text size="sm">{t("Failed to load")}</Text>
+          <ActionIcon variant="subtle" onClick={props.refetch} aria-label={t("Refresh")}>
+            <IconRefresh size={16} />
+          </ActionIcon>
+        </Group>
+      </Card>
+    </NodeViewWrapper>
+  );
+}
+
+function ItemCard(props: {
+  payload: IntegrationItemCardPayload;
+  refetch: () => void;
+  isFetching: boolean;
+  editControl?: React.ReactNode;
+}) {
+  const { t } = useTranslation();
+  return (
+    <NodeViewWrapper>
+      <Card withBorder padding="sm" radius="md">
+        <Group justify="space-between" wrap="nowrap" gap="xs">
+          <Group gap="xs" wrap="nowrap" style={{ flex: 1, minWidth: 0 }}>
+            {props.payload.url ? (
+              <Badge component="a" href={props.payload.url} target="_blank" rel="noreferrer" color="blue" variant="filled" size="sm" className={classes.badgeLink}>
+                {props.payload.key}
+              </Badge>
+            ) : (
+              <Badge color="blue" variant="filled" size="sm">{props.payload.key}</Badge>
+            )}
+            {props.payload.url ? (
+              <Text component="a" href={props.payload.url} target="_blank" rel="noreferrer" size="sm" fw={500} truncate className={classes.quietLink} style={{ minWidth: 0 }}>
+                {props.payload.title}
+              </Text>
+            ) : (
+              <Text size="sm" fw={500} truncate style={{ minWidth: 0 }}>
+                {props.payload.title}
+              </Text>
+            )}
+            {props.payload.assignee && (
+              <Text size="xs" c="dimmed" style={{ whiteSpace: "nowrap" }}>
+                {props.payload.assignee}
+              </Text>
+            )}
+          </Group>
+          <Group gap="xs" wrap="nowrap">
+            {props.payload.priority && (
+              <Badge variant="default" size="sm">
+                {props.payload.priority}
+              </Badge>
+            )}
+            {props.payload.status && (
+              <Badge variant="light" size="sm">
+                {props.payload.status}
+              </Badge>
+            )}
+            <Group gap={4} wrap="nowrap">
+              {props.editControl}
+              <ActionIcon variant="subtle" onClick={props.refetch} aria-label={t("Refresh")} loading={props.isFetching}>
+                <IconRefresh size={16} />
+              </ActionIcon>
+            </Group>
+          </Group>
+        </Group>
+      </Card>
+    </NodeViewWrapper>
+  );
+}
+
+function TableReport(props: {
+  payload: IntegrationTableReportPayload;
+  integrationId: string;
+  resourceId: string;
+  resourceKey: string;
+  dataUpdatedAt: number;
+  refetch: () => void;
+  isFetching: boolean;
+  editControl?: React.ReactNode;
+}) {
+  const { t } = useTranslation();
+  const [extraRows, setExtraRows] = useState<IntegrationTableReportRow[]>([]);
+  const [nextPage, setNextPage] = useState<number | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadMoreFailed, setLoadMoreFailed] = useState(false);
+
+  // A fresh base payload (initial load or the refresh button) restarts paging.
+  useEffect(() => {
+    setExtraRows([]);
+    setLoadingMore(false);
+    setLoadMoreFailed(false);
+    setNextPage(props.payload.hasMore ? (props.payload.page ?? 1) + 1 : null);
+  }, [props.dataUpdatedAt]);
+
+  const rows = [...props.payload.rows, ...extraRows];
+
+  const loadMore = async () => {
+    if (!nextPage || loadingMore) return;
+    setLoadingMore(true);
+    setLoadMoreFailed(false);
+    try {
+      const result = await resolveIntegrationResource({
+        integrationId: props.integrationId,
+        resourceId: props.resourceId,
+        resourceKey: props.resourceKey,
+        params: { page: nextPage },
+      });
+      if (result.kind !== "table-report") {
+        setNextPage(null);
+        return;
+      }
+      // Concurrent edits can shift rows between pages; drop ids already shown.
+      setExtraRows((prev) => {
+        const seen = new Set([...props.payload.rows, ...prev].map((r) => r.id));
+        return [...prev, ...result.rows.filter((r) => !seen.has(r.id))];
+      });
+      setNextPage(result.hasMore ? (result.page ?? nextPage) + 1 : null);
+    } catch {
+      setLoadMoreFailed(true);
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  return (
+    <NodeViewWrapper>
+      <Card withBorder padding="md" radius="md">
+        <Group justify="space-between" mb="sm">
+          <Stack gap={2}>
+            <Text fw={600}>{props.payload.title}</Text>
+            {props.payload.description && (
+              <Text size="xs" c="dimmed">{props.payload.description}</Text>
+            )}
+          </Stack>
+          <Group gap={4}>
+            {props.payload.total != null && <Badge variant="default" size="sm">{t("{{ n }} items", { n: props.payload.total })}</Badge>}
+            {props.editControl}
+            <ActionIcon variant="subtle" onClick={props.refetch} loading={props.isFetching} aria-label={t("Refresh")}>
+              <IconRefresh size={16} />
+            </ActionIcon>
+          </Group>
+        </Group>
+        {rows.length === 0 ? (
+          <Text size="sm" c="dimmed">{t("No rows to display.")}</Text>
+        ) : (
+          <Table withTableBorder withColumnBorders highlightOnHover>
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>{t("Key")}</Table.Th>
+                <Table.Th>{t("Title")}</Table.Th>
+                <Table.Th>{t("Status")}</Table.Th>
+                <Table.Th>{t("Assignee")}</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {rows.map((row) => (
+                <Table.Tr key={row.id}>
+                  <Table.Td>
+                    {row.key && row.url ? (
+                      <Tooltip label={t("Open")} withArrow openDelay={300}>
+                        <Badge component="a" href={row.url} target="_blank" rel="noreferrer" color="blue" variant="filled" size="sm" className={classes.badgeLink}>
+                          {row.key}
+                        </Badge>
+                      </Tooltip>
+                    ) : row.key ? (
+                      <Badge color="blue" variant="filled" size="sm">{row.key}</Badge>
+                    ) : (
+                      "—"
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    {row.url ? (
+                      <a href={row.url} target="_blank" rel="noreferrer" className={classes.quietLink}>{row.title}</a>
+                    ) : (
+                      row.title
+                    )}
+                  </Table.Td>
+                  <Table.Td>{row.status ?? "—"}</Table.Td>
+                  <Table.Td>{row.assignee ?? "—"}</Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        )}
+        {(nextPage || props.payload.total != null) && rows.length > 0 && (
+          <Group justify="space-between" mt="sm">
+            <Text size="xs" c="dimmed">
+              {props.payload.total != null
+                ? t("Showing {{ shown }} of {{ total }}", { shown: rows.length, total: props.payload.total })
+                : null}
+            </Text>
+            <Group gap="xs">
+              {loadMoreFailed && (
+                <Text size="xs" c="red">{t("Failed to load more rows")}</Text>
+              )}
+              {nextPage && (
+                <Button variant="default" size="compact-xs" onClick={loadMore} loading={loadingMore}>
+                  {t("Load more")}
+                </Button>
+              )}
+            </Group>
+          </Group>
+        )}
+      </Card>
+    </NodeViewWrapper>
+  );
+}
+
+function Unavailable(props: { message: string }) {
+  return (
+    <NodeViewWrapper>
+      <Card withBorder padding="md" radius="md">
+        <Text size="sm" c="dimmed">{props.message}</Text>
+      </Card>
+    </NodeViewWrapper>
+  );
+}

--- a/apps/client/src/features/editor/components/slash-menu/menu-items.ts
+++ b/apps/client/src/features/editor/components/slash-menu/menu-items.ts
@@ -18,6 +18,7 @@ import {
   IconFileTypePdf,
   IconPhoto,
   IconTable,
+  IconLink,
   IconTypography,
   IconMenu4,
   IconPageBreak,
@@ -59,6 +60,7 @@ import {
   YoutubeIcon,
 } from "@/components/icons";
 import { insertBaseEmbedBlock } from "@/features/editor/components/base-embed/insert-base-embed";
+import { getRegisteredIntegrationResources } from "@/features/integrations/integration-resource-registry";
 
 const CommandGroups: SlashMenuGroupedItemsType = {
   basic: [
@@ -786,6 +788,38 @@ const CommandGroups: SlashMenuGroupedItemsType = {
   ],
 };
 
+// Module-scoped (not React context) because the slash-menu suggestion
+// plugin runs outside React. Populated by useSyncRegisteredIntegrations.
+let registeredIntegrations: Set<string> = new Set();
+
+export function setRegisteredIntegrations(ids: Iterable<string>): void {
+  registeredIntegrations = new Set(ids);
+}
+
+function getIntegrationResourceItems() {
+  const iconByName = { link: IconLink, table: IconTable } as const;
+  return getRegisteredIntegrationResources()
+    .filter((resource) => resource.menu)
+    .map((resource) => ({
+      title: resource.menu?.title ?? resource.title,
+      description: resource.menu?.description ?? resource.description ?? "Embed integration resource",
+      searchTerms: resource.menu?.searchTerms ?? resource.searchTerms,
+      icon: iconByName[resource.menu?.icon ?? "link"] ?? IconLink,
+      command: ({ editor, range }: CommandProps) => {
+        editor
+          .chain()
+          .focus()
+          .deleteRange(range)
+          .setIntegrationEmbed({
+            integrationId: resource.integrationId,
+            resourceId: resource.id,
+            renderKind: resource.renderKind,
+          })
+          .run();
+      },
+    }));
+}
+
 export const getSuggestionItems = ({
   query,
   excludeItems,
@@ -795,6 +829,10 @@ export const getSuggestionItems = ({
 }): SlashMenuGroupedItemsType => {
   const search = query.toLowerCase();
   const filteredGroups: SlashMenuGroupedItemsType = {};
+  const commandGroups: SlashMenuGroupedItemsType = {
+    ...CommandGroups,
+    embed: [...(CommandGroups.embed ?? []), ...getIntegrationResourceItems()],
+  };
 
   const fuzzyMatch = (query: string, target: string) => {
     let queryIndex = 0;
@@ -806,11 +844,16 @@ export const getSuggestionItems = ({
     return false;
   };
 
-  for (const [group, items] of Object.entries(CommandGroups)) {
+  for (const [group, items] of Object.entries(commandGroups)) {
     const filteredItems = items.filter((item) => {
       if (excludeItems?.has(item.title)) return false;
       const translatedTitle = i18n.t(item.title);
       const translatedDescription = i18n.t(item.description);
+      if (
+        item.requiresIntegration &&
+        !registeredIntegrations.has(item.requiresIntegration)
+      )
+        return false;
       return (
         fuzzyMatch(search, item.title) ||
         fuzzyMatch(search, translatedTitle) ||

--- a/apps/client/src/features/editor/components/slash-menu/types.ts
+++ b/apps/client/src/features/editor/components/slash-menu/types.ts
@@ -22,6 +22,13 @@ export type SlashMenuItemType = {
   command: (props: CommandProps) => void;
   disable?: (editor: ReturnType<typeof useEditor>) => boolean;
   requiresBases?: true;
+  /**
+   * Hide the entry until the given third-party integration is registered
+   * (i.e. its manifest is in IntegrationOAuthRegistry server-side, which
+   * happens when its env config is present). Doesn't gate on the user
+   * having connected — clicking the entry is the discovery + connect path.
+   */
+  requiresIntegration?: string;
 };
 
 export type SlashMenuGroupedItemsType = {

--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -62,6 +62,7 @@ import {
   TransclusionReference,
   TableView,
   BaseEmbed as BaseEmbedNode,
+  IntegrationEmbed,
 } from "@docmost/editor-ext";
 import {
   randomElement,
@@ -88,6 +89,8 @@ import CodeBlockView from "@/features/editor/components/code-block/code-block-vi
 import DrawioView from "../components/drawio/drawio-view";
 import ExcalidrawView from "@/features/editor/components/excalidraw/excalidraw-view-lazy.tsx";
 import EmbedView from "@/features/editor/components/embed/embed-view.tsx";
+import IntegrationEmbedView from "@/features/editor/components/integrations/integration-embed-view.tsx";
+import { matchIntegrationEmbedText } from "@/features/integrations/integration-resource-registry";
 import PdfView from "@/features/editor/components/pdf/pdf-view.tsx";
 import SubpagesView from "@/features/editor/components/subpages/subpages-view.tsx";
 import TransclusionView from "@/features/editor/components/transclusion/transclusion-view.tsx";
@@ -367,6 +370,18 @@ export const mainExtensions = [
   }),
   Embed.configure({
     view: EmbedView,
+  }),
+  IntegrationEmbed.configure({
+    view: IntegrationEmbedView,
+    // One dynamic rule backed by the registered-integration catalog: pasted
+    // provider URLs convert to embeds for whatever integrations the server
+    // exposes, with zero provider-specific code in the editor bundle.
+    inputRules: [
+      {
+        find: (text) => matchIntegrationEmbedText(text),
+        getAttributes: (match) => match.data ?? {},
+      },
+    ],
   }),
   TiptapPdf.configure({
     view: PdfView,

--- a/apps/client/src/features/integrations/components/admin-integration-connections.tsx
+++ b/apps/client/src/features/integrations/components/admin-integration-connections.tsx
@@ -1,0 +1,446 @@
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Code,
+  CopyButton,
+  Group,
+  Loader,
+  Modal,
+  PasswordInput,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { IconAlertCircle, IconPlug } from "@tabler/icons-react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  useGetIntegrationConnectionsQuery,
+  useSaveIntegrationConnectionMutation,
+} from "@/features/integrations/queries/integration-oauth-query";
+import { IntegrationOAuthConnection } from "@/features/integrations/types/integration.types";
+
+export default function AdminIntegrationConnections() {
+  const { t } = useTranslation();
+  const { data, isLoading, error } = useGetIntegrationConnectionsQuery();
+  const [addOpened, setAddOpened] = useState(false);
+
+  const providers = useMemo(() => {
+    const byProvider = new Map<string, IntegrationOAuthConnection>();
+    for (const connection of data ?? []) {
+      const providerId = connection.providerId ?? connection.integrationId;
+      if (!byProvider.has(providerId)) {
+        byProvider.set(providerId, { ...connection, providerId });
+      }
+    }
+    return [...byProvider.values()];
+  }, [data]);
+
+  if (isLoading) {
+    return (
+      <Group justify="center" py="xl">
+        <Loader />
+      </Group>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert color="red" icon={<IconAlertCircle />}>
+        {t("Failed to load integration connections")}
+      </Alert>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <Alert color="gray" icon={<IconPlug />}>
+        {t("No integration providers are available in this deployment.")}
+      </Alert>
+    );
+  }
+
+  const openAddIntegration = () => {
+    setAddOpened(true);
+  };
+
+  const closeAdd = () => {
+    setAddOpened(false);
+  };
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between" align="flex-start">
+        <Text size="sm" c="dimmed" style={{ flex: 1 }}>
+          {t(
+            "Configure base connections for integrations available in this Docmost workspace. This registers provider details only; each member still connects their own account from Account → Integrations.",
+          )}
+        </Text>
+        <Button size="sm" onClick={openAddIntegration}>
+          {t("Add integration")}
+        </Button>
+      </Group>
+
+      {data.map((connection) => (
+        <AdminIntegrationConnectionCard
+          key={connection.integrationId}
+          connection={connection}
+          providers={providers}
+        />
+      ))}
+
+      <Modal
+        opened={addOpened}
+        onClose={closeAdd}
+        title={t("Add integration")}
+        size="lg"
+      >
+        <AdminIntegrationConnectionForm
+          mode="add"
+          connection={null}
+          providers={providers}
+          onSaved={closeAdd}
+        />
+      </Modal>
+    </Stack>
+  );
+}
+
+function AdminIntegrationConnectionCard({
+  connection,
+  providers,
+}: {
+  connection: IntegrationOAuthConnection;
+  providers: IntegrationOAuthConnection[];
+}) {
+  const { t } = useTranslation();
+  const [configureOpened, setConfigureOpened] = useState(false);
+
+  return (
+    <>
+      <Card withBorder padding="lg" radius="md">
+        <Group justify="space-between" align="flex-start">
+          <Stack gap="xs" style={{ flex: 1 }}>
+            <Group gap="sm" align="center">
+              <Text fw={600}>{connection.name}</Text>
+              {connection.configured ? (
+                <Badge
+                  color={connection.enabled ? "green" : "gray"}
+                  variant="light"
+                >
+                  {connection.enabled ? t("Enabled") : t("Disabled")}
+                </Badge>
+              ) : (
+                <Badge color="orange" variant="light">
+                  {t("Not configured")}
+                </Badge>
+              )}
+              {connection.source === "env" && (
+                <Badge variant="default">{t("Env default")}</Badge>
+              )}
+            </Group>
+
+            {connection.description && (
+              <Text size="sm" c="dimmed">
+                {connection.description}
+              </Text>
+            )}
+
+            {connection.configured && (
+              <Group gap="xs">
+                {connection.baseUrl && (
+                  <Text size="sm" c="dimmed">
+                    {connection.baseUrl}
+                  </Text>
+                )}
+                {connection.settingsFields
+                  .filter((field) => connection.settings?.[field.key])
+                  .map((field) => (
+                    <Badge key={field.key} variant="default" size="xs">
+                      {field.label}: {connection.settings?.[field.key]}
+                    </Badge>
+                  ))}
+              </Group>
+            )}
+
+            {connection.scopes.length > 0 && (
+              <Group gap={4} mt={4}>
+                {connection.scopes.map((scope) => (
+                  <Badge key={scope} variant="default" size="xs">
+                    {scope}
+                  </Badge>
+                ))}
+              </Group>
+            )}
+          </Stack>
+
+          <Button variant="default" onClick={() => setConfigureOpened(true)}>
+            {connection.configured ? t("Edit") : t("Configure")}
+          </Button>
+        </Group>
+      </Card>
+
+      <Modal
+        opened={configureOpened}
+        onClose={() => setConfigureOpened(false)}
+        title={t("Configure integration")}
+        size="lg"
+      >
+        <AdminIntegrationConnectionForm
+          mode="edit"
+          connection={connection}
+          providers={providers}
+          onSaved={() => setConfigureOpened(false)}
+        />
+      </Modal>
+    </>
+  );
+}
+
+function AdminIntegrationConnectionForm({
+  mode,
+  connection,
+  providers,
+  onSaved,
+}: {
+  mode: "add" | "edit";
+  connection: IntegrationOAuthConnection | null;
+  providers: IntegrationOAuthConnection[];
+  onSaved: () => void;
+}) {
+  const { t } = useTranslation();
+  const save = useSaveIntegrationConnectionMutation();
+  const isEdit = mode === "edit";
+  const [selectedProviderId, setSelectedProviderId] = useState(
+    connection?.providerId ?? "",
+  );
+  const [integrationId, setIntegrationId] = useState(
+    connection?.integrationId ?? "",
+  );
+  const [enabled, setEnabled] = useState(connection?.enabled ?? true);
+  const [baseUrl, setBaseUrl] = useState(connection?.baseUrl ?? "");
+  const [oauthClientId, setOauthClientId] = useState(
+    connection?.oauthClientId ?? "",
+  );
+  const [oauthClientSecret, setOauthClientSecret] = useState("");
+  const [settings, setSettings] = useState<Record<string, string>>(
+    connection?.settings ?? {},
+  );
+
+  const selectedProvider = useMemo(() => {
+    return (
+      providers.find(
+        (provider) => provider.providerId === selectedProviderId,
+      ) ?? (connection?.providerId === selectedProviderId ? connection : null)
+    );
+  }, [connection, providers, selectedProviderId]);
+
+  const providerOptions = useMemo(() => {
+    const options = providers.map((provider) => ({
+      value: provider.providerId,
+      label: provider.name,
+    }));
+    if (
+      connection?.providerId &&
+      !options.some((option) => option.value === connection.providerId)
+    ) {
+      options.push({ value: connection.providerId, label: connection.name });
+    }
+    return options;
+  }, [connection, providers]);
+
+  useEffect(() => {
+    setSelectedProviderId(connection?.providerId ?? "");
+    setIntegrationId(connection?.integrationId ?? "");
+    setEnabled(connection?.enabled ?? true);
+    setBaseUrl(connection?.baseUrl ?? "");
+    setOauthClientId(connection?.oauthClientId ?? "");
+    setOauthClientSecret("");
+    setSettings(connection?.settings ?? {});
+  }, [connection]);
+
+  const onProviderChange = (providerId: string | null) => {
+    setSelectedProviderId(providerId ?? "");
+    setIntegrationId(providerId ? newIntegrationId(providerId) : "");
+    setEnabled(true);
+    setBaseUrl("");
+    setOauthClientId("");
+    setOauthClientSecret("");
+    setSettings({});
+  };
+
+  const onSave = () => {
+    if (!selectedProvider || !integrationId) return;
+    save.mutate(
+      {
+        integrationId,
+        input: {
+          enabled,
+          baseUrl,
+          oauthClientId,
+          oauthClientSecret:
+            oauthClientSecret.length > 0 ? oauthClientSecret : undefined,
+          settings,
+        },
+      },
+      { onSuccess: onSaved },
+    );
+  };
+
+  const settingsFields = selectedProvider?.settingsFields ?? [];
+  const missingRequiredSetting = settingsFields.some(
+    (field) => field.required && !settings[field.key]?.trim(),
+  );
+  const redirectUri = selectedProvider
+    ? callbackUrlFor(selectedProvider.redirectUri, integrationId)
+    : "";
+
+  return (
+    <Stack gap="md">
+      <Select
+        label={t("Integration type")}
+        placeholder={t("Select an integration type")}
+        data={providerOptions}
+        value={selectedProviderId || null}
+        onChange={onProviderChange}
+        disabled={isEdit}
+        required
+      />
+
+      {!selectedProvider ? (
+        <Text size="sm" c="dimmed">
+          {t(
+            "Choose an integration type to configure its provider-specific settings.",
+          )}
+        </Text>
+      ) : (
+        <>
+          <Group justify="space-between" align="flex-start">
+            <Stack gap={4} style={{ flex: 1 }}>
+              <Text fw={600}>{selectedProvider.name}</Text>
+              {selectedProvider.description && (
+                <Text size="sm" c="dimmed">
+                  {selectedProvider.description}
+                </Text>
+              )}
+            </Stack>
+            <Switch
+              checked={enabled}
+              onChange={(event) => setEnabled(event.currentTarget.checked)}
+              label={t("Enabled")}
+            />
+          </Group>
+
+          <TextInput
+            label={t("Base URL")}
+            placeholder={selectedProvider.baseUrlPlaceholder ?? "https://"}
+            value={baseUrl}
+            onChange={(event) => setBaseUrl(event.currentTarget.value)}
+            required
+          />
+          <TextInput
+            label={t("OAuth client ID")}
+            value={oauthClientId}
+            onChange={(event) => setOauthClientId(event.currentTarget.value)}
+            required
+          />
+          <PasswordInput
+            label={t("OAuth client secret")}
+            description={
+              isEdit && connection?.hasClientSecret
+                ? t("Leave blank to keep the stored secret.")
+                : undefined
+            }
+            value={oauthClientSecret}
+            onChange={(event) =>
+              setOauthClientSecret(event.currentTarget.value)
+            }
+          />
+          {settingsFields.map((field) => (
+            <TextInput
+              key={field.key}
+              label={t(field.label)}
+              description={field.description ? t(field.description) : undefined}
+              placeholder={field.placeholder}
+              value={settings[field.key] ?? ""}
+              onChange={(event) =>
+                setSettings({
+                  ...settings,
+                  [field.key]: event.currentTarget.value,
+                })
+              }
+              required={field.required}
+            />
+          ))}
+
+          <Stack gap={4}>
+            <Text size="sm" fw={500}>
+              {t("Redirect URI")}
+            </Text>
+            <Group gap="xs" align="center">
+              <Code>{redirectUri}</Code>
+              <CopyButton value={redirectUri}>
+                {({ copy, copied }) => (
+                  <Button size="xs" variant="default" onClick={copy}>
+                    {copied ? t("Copied") : t("Copy")}
+                  </Button>
+                )}
+              </CopyButton>
+            </Group>
+          </Stack>
+
+          <Group gap={4}>
+            {selectedProvider.scopes.map((scope) => (
+              <Badge key={scope} variant="default" size="xs">
+                {scope}
+              </Badge>
+            ))}
+          </Group>
+        </>
+      )}
+
+      <Group justify="flex-end">
+        <Button variant="default" onClick={onSaved} disabled={save.isPending}>
+          {t("Cancel")}
+        </Button>
+        <Button
+          onClick={onSave}
+          loading={save.isPending}
+          disabled={
+            !selectedProvider ||
+            !integrationId ||
+            !baseUrl.trim() ||
+            !oauthClientId.trim() ||
+            missingRequiredSetting
+          }
+        >
+          {t("Save configuration")}
+        </Button>
+      </Group>
+    </Stack>
+  );
+}
+
+function newIntegrationId(providerId: string): string {
+  return `${providerId}:${crypto.randomUUID()}`;
+}
+
+function callbackUrlFor(template: string, integrationId: string): string {
+  try {
+    const url = new URL(template);
+    const parts = url.pathname.split("/");
+    const callbackIndex = parts.lastIndexOf("callback");
+    if (callbackIndex > 0) {
+      parts[callbackIndex - 1] = encodeURIComponent(integrationId);
+      url.pathname = parts.join("/");
+      return url.toString();
+    }
+  } catch {
+    // fall through to origin-relative construction below
+  }
+  return `${window.location.origin}/api/integrations/oauth/${encodeURIComponent(integrationId)}/callback`;
+}

--- a/apps/client/src/features/integrations/components/admin-integration-connections.tsx
+++ b/apps/client/src/features/integrations/components/admin-integration-connections.tsx
@@ -281,9 +281,14 @@ function AdminIntegrationConnectionForm({
         input: {
           enabled,
           baseUrl,
-          oauthClientId,
-          oauthClientSecret:
-            oauthClientSecret.length > 0 ? oauthClientSecret : undefined,
+          oauthClientId: selectedProvider.automaticClientRegistration
+            ? undefined
+            : oauthClientId,
+          oauthClientSecret: selectedProvider.automaticClientRegistration
+            ? undefined
+            : oauthClientSecret.length > 0
+              ? oauthClientSecret
+              : undefined,
           settings,
         },
       },
@@ -342,24 +347,36 @@ function AdminIntegrationConnectionForm({
             onChange={(event) => setBaseUrl(event.currentTarget.value)}
             required
           />
-          <TextInput
-            label={t("OAuth client ID")}
-            value={oauthClientId}
-            onChange={(event) => setOauthClientId(event.currentTarget.value)}
-            required
-          />
-          <PasswordInput
-            label={t("OAuth client secret")}
-            description={
-              isEdit && connection?.hasClientSecret
-                ? t("Leave blank to keep the stored secret.")
-                : undefined
-            }
-            value={oauthClientSecret}
-            onChange={(event) =>
-              setOauthClientSecret(event.currentTarget.value)
-            }
-          />
+          {selectedProvider.automaticClientRegistration ? (
+            <Alert color="blue">
+              {t(
+                "Docmost will register a public OAuth client automatically. Each member still authorizes their own account.",
+              )}
+            </Alert>
+          ) : (
+            <>
+              <TextInput
+                label={t("OAuth client ID")}
+                value={oauthClientId}
+                onChange={(event) =>
+                  setOauthClientId(event.currentTarget.value)
+                }
+                required
+              />
+              <PasswordInput
+                label={t("OAuth client secret")}
+                description={
+                  isEdit && connection?.hasClientSecret
+                    ? t("Leave blank to keep the stored secret.")
+                    : undefined
+                }
+                value={oauthClientSecret}
+                onChange={(event) =>
+                  setOauthClientSecret(event.currentTarget.value)
+                }
+              />
+            </>
+          )}
           {settingsFields.map((field) => (
             <TextInput
               key={field.key}
@@ -414,7 +431,8 @@ function AdminIntegrationConnectionForm({
             !selectedProvider ||
             !integrationId ||
             !baseUrl.trim() ||
-            !oauthClientId.trim() ||
+            (!selectedProvider.automaticClientRegistration &&
+              !oauthClientId.trim()) ||
             missingRequiredSetting
           }
         >

--- a/apps/client/src/features/integrations/components/integrations-list.tsx
+++ b/apps/client/src/features/integrations/components/integrations-list.tsx
@@ -1,0 +1,138 @@
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Group,
+  Loader,
+  Stack,
+  Text,
+} from "@mantine/core";
+import { IconAlertCircle, IconPlug } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+import {
+  useDisconnectIntegrationMutation,
+  useGetIntegrationsQuery,
+} from "@/features/integrations/queries/integration-oauth-query";
+import { authorizeUrl } from "@/features/integrations/services/integration-oauth-service";
+import { IntegrationListItem } from "@/features/integrations/types/integration.types";
+
+export default function IntegrationsList() {
+  const { t } = useTranslation();
+  const { data, isLoading, error } = useGetIntegrationsQuery();
+
+  if (isLoading) {
+    return (
+      <Group justify="center" py="xl">
+        <Loader />
+      </Group>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert color="red" icon={<IconAlertCircle />}>
+        {t("Failed to load integrations")}
+      </Alert>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <Alert color="gray" icon={<IconPlug />}>
+        {t(
+          "No integrations are configured for this workspace. Ask an administrator to enable one.",
+        )}
+      </Alert>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      {data.map((integration) => (
+        <IntegrationCard key={integration.id} integration={integration} />
+      ))}
+    </Stack>
+  );
+}
+
+function IntegrationCard({
+  integration,
+}: {
+  integration: IntegrationListItem;
+}) {
+  const { t } = useTranslation();
+  const disconnect = useDisconnectIntegrationMutation();
+
+  const onConnect = () => {
+    // Top-level navigation — provider redirects back into our window.
+    window.location.href = authorizeUrl(
+      integration.id,
+      "/settings/account/integrations",
+    );
+  };
+
+  const onDisconnect = () => {
+    disconnect.mutate({ integrationId: integration.id });
+  };
+
+  const connectLabel = t("Connect your {{integration}} account", {
+    integration: integration.name,
+  });
+
+  return (
+    <Card withBorder padding="lg" radius="md">
+      <Group justify="space-between" align="flex-start">
+        <Stack gap={4} style={{ flex: 1 }}>
+          <Group gap="sm" align="center">
+            <Text fw={600}>{integration.name}</Text>
+            {integration.connected && !integration.needsReconnect && (
+              <Badge color="green" variant="light">
+                {t("Connected")}
+              </Badge>
+            )}
+            {integration.needsReconnect && (
+              <Badge color="orange" variant="light">
+                {t("Reconnect required")}
+              </Badge>
+            )}
+          </Group>
+          {integration.description && (
+            <Text size="sm" c="dimmed">
+              {integration.description}
+            </Text>
+          )}
+          {integration.scopes.length > 0 && (
+            <Group gap={4} mt={4}>
+              {integration.scopes.map((scope) => (
+                <Badge key={scope} variant="default" size="xs">
+                  {scope}
+                </Badge>
+              ))}
+            </Group>
+          )}
+        </Stack>
+        <Group gap="xs">
+          {integration.connected ? (
+            <>
+              {integration.needsReconnect && (
+                <Button onClick={onConnect} variant="filled" color="orange">
+                  {t("Reconnect")}
+                </Button>
+              )}
+              <Button
+                onClick={onDisconnect}
+                variant="default"
+                loading={disconnect.isPending}
+              >
+                {t("Disconnect")}
+              </Button>
+            </>
+          ) : (
+            <Button onClick={onConnect}>{connectLabel}</Button>
+          )}
+        </Group>
+      </Group>
+    </Card>
+  );
+}

--- a/apps/client/src/features/integrations/hooks/use-sync-registered-integrations.ts
+++ b/apps/client/src/features/integrations/hooks/use-sync-registered-integrations.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { useGetIntegrationsQuery } from "@/features/integrations/queries/integration-oauth-query";
+import { setRegisteredIntegrations } from "@/features/editor/components/slash-menu/menu-items";
+import { setRegisteredIntegrationCatalog } from "@/features/integrations/integration-resource-registry";
+
+/**
+ * Mirrors the server's registered-integrations list into the slash-menu's
+ * static gate so items tagged `requiresIntegration` hide when the server
+ * has no manifest for that id. Mounted once in the global layout.
+ */
+export function useSyncRegisteredIntegrations(): void {
+  const { data } = useGetIntegrationsQuery();
+
+  useEffect(() => {
+    if (!Array.isArray(data)) return;
+    setRegisteredIntegrationCatalog(data);
+    setRegisteredIntegrations(data.map((i) => i.id));
+  }, [data]);
+}

--- a/apps/client/src/features/integrations/integration-resource-registry.test.ts
+++ b/apps/client/src/features/integrations/integration-resource-registry.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  findRegisteredIntegrationResource,
+  getRegisteredIntegrationIds,
+  getRegisteredIntegrationResources,
+  matchIntegrationEmbedText,
+  setRegisteredIntegrationCatalog,
+} from "./integration-resource-registry";
+import { IntegrationListItem } from "@/features/integrations/types/integration.types";
+
+function catalog(overrides: Partial<IntegrationListItem> = {}): IntegrationListItem[] {
+  return [
+    {
+      id: "windshift:1111",
+      name: "Windshift",
+      baseUrl: "https://ws.example.com/",
+      resources: [
+        {
+          id: "item",
+          title: "Windshift item",
+          renderKind: "item-card",
+          searchTerms: [],
+          urlPatterns: [
+            {
+              pattern: "/workspaces/\\d+/items/(?<id>\\d+)",
+              resourceKey: "id:{id}",
+            },
+          ],
+        },
+      ],
+      ...overrides,
+    } as IntegrationListItem,
+  ];
+}
+
+afterEach(() => {
+  setRegisteredIntegrationCatalog([]);
+});
+
+describe("integration resource registry", () => {
+  it("flattens resources with their integration identity", () => {
+    setRegisteredIntegrationCatalog(catalog());
+    expect([...getRegisteredIntegrationIds()]).toEqual(["windshift:1111"]);
+    const resources = getRegisteredIntegrationResources();
+    expect(resources).toHaveLength(1);
+    expect(resources[0]).toMatchObject({
+      id: "item",
+      integrationId: "windshift:1111",
+      integrationName: "Windshift",
+    });
+    expect(findRegisteredIntegrationResource("windshift:1111", "item")?.title).toBe(
+      "Windshift item",
+    );
+    expect(findRegisteredIntegrationResource("windshift:1111", "nope")).toBeUndefined();
+  });
+});
+
+describe("matchIntegrationEmbedText", () => {
+  it("converts a pasted provider URL (plus trailing space) into embed attrs", () => {
+    setRegisteredIntegrationCatalog(catalog());
+    const match = matchIntegrationEmbedText(
+      "https://ws.example.com/workspaces/2/items/7 ",
+    );
+    expect(match).not.toBeNull();
+    expect(match!.data).toEqual({
+      integrationId: "windshift:1111",
+      resourceId: "item",
+      resourceKey: "id:7",
+      renderKind: "item-card",
+    });
+    expect(match!.text).toBe("https://ws.example.com/workspaces/2/items/7 ");
+  });
+
+  it("requires the trailing-space paste trigger", () => {
+    setRegisteredIntegrationCatalog(catalog());
+    expect(
+      matchIntegrationEmbedText("https://ws.example.com/workspaces/2/items/7"),
+    ).toBeNull();
+  });
+
+  it("ignores URLs from other hosts", () => {
+    setRegisteredIntegrationCatalog(catalog());
+    expect(
+      matchIntegrationEmbedText("https://evil.example.com/workspaces/2/items/7 "),
+    ).toBeNull();
+  });
+
+  it("does not let the base URL act as a regex", () => {
+    setRegisteredIntegrationCatalog(catalog({ baseUrl: "https://ws.example.com" }));
+    expect(
+      matchIntegrationEmbedText("https://wsXexampleYcom/workspaces/2/items/7 "),
+    ).toBeNull();
+  });
+
+  it("skips integrations without a base URL and returns null when nothing matches", () => {
+    setRegisteredIntegrationCatalog(catalog({ baseUrl: undefined }));
+    expect(
+      matchIntegrationEmbedText("https://ws.example.com/workspaces/2/items/7 "),
+    ).toBeNull();
+    setRegisteredIntegrationCatalog([]);
+    expect(matchIntegrationEmbedText("anything ")).toBeNull();
+  });
+});

--- a/apps/client/src/features/integrations/integration-resource-registry.ts
+++ b/apps/client/src/features/integrations/integration-resource-registry.ts
@@ -1,0 +1,94 @@
+import { IntegrationListItem, IntegrationResourceManifest } from "@/features/integrations/types/integration.types";
+
+export interface RegisteredIntegrationResource extends IntegrationResourceManifest {
+  integrationId: string;
+  integrationName: string;
+}
+
+let integrations: IntegrationListItem[] = [];
+
+export function setRegisteredIntegrationCatalog(items: IntegrationListItem[]): void {
+  integrations = items;
+}
+
+export function getRegisteredIntegrationIds(): Set<string> {
+  return new Set(integrations.map((i) => i.id));
+}
+
+export function getRegisteredIntegrationResources(): RegisteredIntegrationResource[] {
+  return integrations.flatMap((integration) =>
+    (integration.resources ?? []).map((resource) => ({
+      ...resource,
+      integrationId: integration.id,
+      integrationName: integration.name,
+    })),
+  );
+}
+
+export function findRegisteredIntegrationResource(
+  integrationId: string,
+  resourceId: string,
+): RegisteredIntegrationResource | undefined {
+  return getRegisteredIntegrationResources().find(
+    (resource) => resource.integrationId === integrationId && resource.id === resourceId,
+  );
+}
+
+export interface IntegrationEmbedTextMatch {
+  index: number;
+  text: string;
+  data: {
+    integrationId: string;
+    resourceId: string;
+    resourceKey: string;
+    renderKind: string;
+  };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Matches editor text against the url patterns declared by registered
+ * integration resources (base URL + manifest pattern + a trailing space, the
+ * paste-to-embed trigger). Returns the first match as embed node attributes.
+ * Backs the editor's generic integration input rule, so embeds keep working
+ * for whatever providers the server has registered — nothing provider-specific
+ * ships in the editor bundle.
+ */
+export function matchIntegrationEmbedText(
+  text: string,
+): IntegrationEmbedTextMatch | null {
+  for (const integration of integrations) {
+    const base = (integration.baseUrl ?? "").replace(/\/+$/, "");
+    if (!base) continue;
+    for (const resource of integration.resources ?? []) {
+      for (const urlPattern of resource.urlPatterns ?? []) {
+        let find: RegExp;
+        try {
+          find = new RegExp(`${escapeRegExp(base)}${urlPattern.pattern}\\s$`);
+        } catch {
+          continue;
+        }
+        const match = find.exec(text);
+        if (!match) continue;
+        const resourceKey = urlPattern.resourceKey.replace(
+          /\{(\w+)\}/g,
+          (_, group) => match.groups?.[group] ?? "",
+        );
+        return {
+          index: match.index,
+          text: match[0],
+          data: {
+            integrationId: integration.id,
+            resourceId: resource.id,
+            resourceKey,
+            renderKind: resource.renderKind,
+          },
+        };
+      }
+    }
+  }
+  return null;
+}

--- a/apps/client/src/features/integrations/queries/integration-oauth-query.ts
+++ b/apps/client/src/features/integrations/queries/integration-oauth-query.ts
@@ -1,0 +1,86 @@
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  UseQueryResult,
+} from "@tanstack/react-query";
+import {
+  disconnectIntegration,
+  listIntegrationConnections,
+  listIntegrations,
+  saveIntegrationConnection,
+} from "@/features/integrations/services/integration-oauth-service";
+import {
+  IntegrationListItem,
+  IntegrationOAuthConnection,
+  SaveIntegrationOAuthConnectionInput,
+} from "@/features/integrations/types/integration.types";
+import { notifications } from "@mantine/notifications";
+import { useTranslation } from "react-i18next";
+
+const INTEGRATIONS_QUERY_KEY = ["integration-oauth-list"];
+const INTEGRATION_CONNECTIONS_QUERY_KEY = [
+  "integration-oauth-admin-connections",
+];
+
+export function useGetIntegrationsQuery(): UseQueryResult<
+  IntegrationListItem[],
+  Error
+> {
+  return useQuery({
+    queryKey: INTEGRATIONS_QUERY_KEY,
+    queryFn: () => listIntegrations(),
+  });
+}
+
+export function useGetIntegrationConnectionsQuery(): UseQueryResult<
+  IntegrationOAuthConnection[],
+  Error
+> {
+  return useQuery({
+    queryKey: INTEGRATION_CONNECTIONS_QUERY_KEY,
+    queryFn: () => listIntegrationConnections(),
+  });
+}
+
+export function useSaveIntegrationConnectionMutation() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation<
+    IntegrationOAuthConnection,
+    Error,
+    { integrationId: string; input: SaveIntegrationOAuthConnectionInput }
+  >({
+    mutationFn: ({ integrationId, input }) =>
+      saveIntegrationConnection(integrationId, input),
+    onSuccess: () => {
+      notifications.show({ message: t("Integration configuration saved") });
+      queryClient.invalidateQueries({
+        queryKey: INTEGRATION_CONNECTIONS_QUERY_KEY,
+      });
+      queryClient.invalidateQueries({ queryKey: INTEGRATIONS_QUERY_KEY });
+    },
+    onError: (error) => {
+      const errorMessage = error["response"]?.data?.message;
+      notifications.show({ message: errorMessage, color: "red" });
+    },
+  });
+}
+
+export function useDisconnectIntegrationMutation() {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation<void, Error, { integrationId: string }>({
+    mutationFn: ({ integrationId }) => disconnectIntegration(integrationId),
+    onSuccess: () => {
+      notifications.show({ message: t("Integration disconnected") });
+      queryClient.invalidateQueries({ queryKey: INTEGRATIONS_QUERY_KEY });
+    },
+    onError: (error) => {
+      const errorMessage = error["response"]?.data?.message;
+      notifications.show({ message: errorMessage, color: "red" });
+    },
+  });
+}

--- a/apps/client/src/features/integrations/queries/integration-resource-query.ts
+++ b/apps/client/src/features/integrations/queries/integration-resource-query.ts
@@ -1,0 +1,71 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import {
+  IntegrationResolvedResource,
+  IntegrationResourceSearchResult,
+  resolveIntegrationResource,
+  searchIntegrationResource,
+} from "@/features/integrations/services/integration-resource-service";
+
+function noRetryOnClientError(failureCount: number, error: Error): boolean {
+  const status = (error as Error & { response?: { status?: number } })?.response?.status;
+  if (status && status >= 400 && status < 500) return false;
+  return failureCount < 1;
+}
+
+export function useSearchIntegrationResourceQuery(args: {
+  integrationId: string;
+  resourceId: string;
+  q?: string;
+  enabled?: boolean;
+  searchOnEmpty?: boolean;
+}): UseQueryResult<IntegrationResourceSearchResult[], Error> {
+  const q = args.q ?? "";
+  return useQuery({
+    queryKey: ["integration-resource", "search", args.integrationId, args.resourceId, q],
+    queryFn: () =>
+      searchIntegrationResource({
+        integrationId: args.integrationId,
+        resourceId: args.resourceId,
+        q,
+        limit: 10,
+      }),
+    enabled:
+      args.enabled !== false &&
+      !!args.integrationId &&
+      !!args.resourceId &&
+      (args.searchOnEmpty === true || q.trim().length > 1),
+    staleTime: 30_000,
+    retry: noRetryOnClientError,
+  });
+}
+
+export function useResolveIntegrationResourceQuery(args: {
+  integrationId: string;
+  resourceId: string;
+  resourceKey: string;
+  params?: Record<string, unknown> | null;
+  enabled?: boolean;
+}): UseQueryResult<IntegrationResolvedResource, Error> {
+  return useQuery({
+    queryKey: [
+      "integration-resource",
+      "resolve",
+      args.integrationId,
+      args.resourceId,
+      args.resourceKey,
+      args.params,
+    ],
+    queryFn: () =>
+      resolveIntegrationResource({
+        integrationId: args.integrationId,
+        resourceId: args.resourceId,
+        resourceKey: args.resourceKey,
+        params: args.params,
+      }),
+    enabled:
+      args.enabled !== false && !!args.integrationId && !!args.resourceId && !!args.resourceKey,
+    staleTime: 15_000,
+    refetchOnWindowFocus: true,
+    retry: noRetryOnClientError,
+  });
+}

--- a/apps/client/src/features/integrations/services/integration-oauth-service.ts
+++ b/apps/client/src/features/integrations/services/integration-oauth-service.ts
@@ -1,0 +1,49 @@
+import api from "@/lib/api-client";
+import {
+  IntegrationListItem,
+  IntegrationOAuthConnection,
+  SaveIntegrationOAuthConnectionInput,
+} from "@/features/integrations/types/integration.types";
+
+export async function listIntegrations(): Promise<IntegrationListItem[]> {
+  const req = await api.get<IntegrationListItem[]>("/integrations/oauth");
+  return req.data;
+}
+
+export async function disconnectIntegration(
+  integrationId: string,
+): Promise<void> {
+  await api.delete(
+    `/integrations/oauth/${encodeURIComponent(integrationId)}/connection`,
+  );
+}
+
+export async function listIntegrationConnections(): Promise<
+  IntegrationOAuthConnection[]
+> {
+  const req = await api.get<IntegrationOAuthConnection[]>(
+    "/integrations/oauth/admin/connections",
+  );
+  return req.data;
+}
+
+export async function saveIntegrationConnection(
+  integrationId: string,
+  input: SaveIntegrationOAuthConnectionInput,
+): Promise<IntegrationOAuthConnection> {
+  const req = await api.put<IntegrationOAuthConnection>(
+    `/integrations/oauth/admin/connections/${encodeURIComponent(integrationId)}`,
+    input,
+  );
+  return req.data;
+}
+
+/**
+ * Returns the authorize URL — caller does a top-level navigation so the
+ * provider's redirect comes back into our window. Same shape window.location
+ * expects, no JSON wrapping.
+ */
+export function authorizeUrl(integrationId: string, returnTo?: string): string {
+  const qs = returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : "";
+  return `/api/integrations/oauth/${encodeURIComponent(integrationId)}/authorize${qs}`;
+}

--- a/apps/client/src/features/integrations/services/integration-resource-service.ts
+++ b/apps/client/src/features/integrations/services/integration-resource-service.ts
@@ -1,0 +1,78 @@
+import api from "@/lib/api-client";
+
+export type IntegrationResourceRenderKind = "item-card" | "table-report";
+
+export interface IntegrationResourceSearchResult {
+  key: string;
+  title: string;
+  subtitle?: string;
+  badge?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntegrationItemCardPayload {
+  kind: "item-card";
+  key: string;
+  title: string;
+  url?: string;
+  status?: string;
+  priority?: string;
+  assignee?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntegrationTableReportRow {
+  id: string;
+  key?: string;
+  title: string;
+  url?: string;
+  status?: string;
+  assignee?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntegrationTableReportPayload {
+  kind: "table-report";
+  title: string;
+  description?: string;
+  total?: number;
+  rows: IntegrationTableReportRow[];
+  page?: number;
+  hasMore?: boolean;
+}
+
+export type IntegrationResolvedResource = IntegrationItemCardPayload | IntegrationTableReportPayload;
+
+function resourcePath(integrationId: string, resourceId: string, action: "search" | "resolve"): string {
+  return `/integrations/${encodeURIComponent(integrationId)}/resources/${encodeURIComponent(resourceId)}/${action}`;
+}
+
+export async function searchIntegrationResource(args: {
+  integrationId: string;
+  resourceId: string;
+  q?: string;
+  limit?: number;
+}): Promise<IntegrationResourceSearchResult[]> {
+  const params = new URLSearchParams();
+  if (args.q) params.set("q", args.q);
+  if (args.limit) params.set("limit", String(args.limit));
+  const qs = params.toString();
+  const req = await api.get<{ items?: IntegrationResourceSearchResult[] }>(
+    `${resourcePath(args.integrationId, args.resourceId, "search")}${qs ? `?${qs}` : ""}`,
+  );
+  return req.data.items ?? [];
+}
+
+export async function resolveIntegrationResource(args: {
+  integrationId: string;
+  resourceId: string;
+  resourceKey: string;
+  params?: Record<string, unknown> | null;
+}): Promise<IntegrationResolvedResource> {
+  const params = new URLSearchParams({ key: args.resourceKey });
+  if (args.params) params.set("params", JSON.stringify(args.params));
+  const req = await api.get<IntegrationResolvedResource>(
+    `${resourcePath(args.integrationId, args.resourceId, "resolve")}?${params.toString()}`,
+  );
+  return req.data;
+}

--- a/apps/client/src/features/integrations/types/integration.types.ts
+++ b/apps/client/src/features/integrations/types/integration.types.ts
@@ -1,0 +1,76 @@
+export interface IntegrationResourceUrlPattern {
+  /** Regex source matched after the connection base URL; named groups feed `resourceKey`. */
+  pattern: string;
+  /** Resource key template, e.g. 'id:{id}'. */
+  resourceKey: string;
+}
+
+export interface IntegrationResourceManifest {
+  id: string;
+  title: string;
+  description?: string;
+  renderKind: "item-card" | "table-report";
+  searchTerms: string[];
+  picker?: {
+    placeholder?: string;
+    emptyLabel?: string;
+    searchOnEmpty?: boolean;
+  };
+  menu?: {
+    title: string;
+    description?: string;
+    searchTerms?: string[];
+    icon?: "link" | "table";
+  };
+  urlPatterns?: IntegrationResourceUrlPattern[];
+}
+
+export interface IntegrationConnectionSettingField {
+  key: string;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  required: boolean;
+}
+
+export interface IntegrationOAuthConnection {
+  integrationId: string;
+  providerId: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  enabled: boolean;
+  configured: boolean;
+  source?: "workspace" | "env";
+  baseUrl?: string;
+  baseUrlPlaceholder?: string;
+  oauthClientId?: string;
+  hasClientSecret: boolean;
+  settings?: Record<string, string>;
+  settingsFields: IntegrationConnectionSettingField[];
+  redirectUri: string;
+  scopes: string[];
+}
+
+export interface SaveIntegrationOAuthConnectionInput {
+  enabled?: boolean;
+  baseUrl: string;
+  oauthClientId: string;
+  oauthClientSecret?: string | null;
+  settings?: Record<string, string>;
+}
+
+export interface IntegrationListItem {
+  id: string;
+  providerId: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  baseUrl: string;
+  scopes: string[];
+  connected: boolean;
+  needsReconnect: boolean;
+  connectedAt?: string;
+  expiresAt?: string;
+  resources?: IntegrationResourceManifest[];
+}

--- a/apps/client/src/features/integrations/types/integration.types.ts
+++ b/apps/client/src/features/integrations/types/integration.types.ts
@@ -46,6 +46,7 @@ export interface IntegrationOAuthConnection {
   baseUrlPlaceholder?: string;
   oauthClientId?: string;
   hasClientSecret: boolean;
+  automaticClientRegistration: boolean;
   settings?: Record<string, string>;
   settingsFields: IntegrationConnectionSettingField[];
   redirectUri: string;
@@ -55,7 +56,7 @@ export interface IntegrationOAuthConnection {
 export interface SaveIntegrationOAuthConnectionInput {
   enabled?: boolean;
   baseUrl: string;
-  oauthClientId: string;
+  oauthClientId?: string;
   oauthClientSecret?: string | null;
   settings?: Record<string, string>;
 }

--- a/apps/client/src/pages/settings/account/integrations.tsx
+++ b/apps/client/src/pages/settings/account/integrations.tsx
@@ -1,0 +1,50 @@
+import { Helmet } from "react-helmet-async";
+import { useTranslation } from "react-i18next";
+import { getAppName } from "@/lib/config.ts";
+import SettingsTitle from "@/components/settings/settings-title.tsx";
+import IntegrationsList from "@/features/integrations/components/integrations-list";
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import { notifications } from "@mantine/notifications";
+
+export default function AccountIntegrations() {
+  const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Surface OAuth callback outcomes — controllers redirect back here on
+  // both success and error.
+  useEffect(() => {
+    const connected = searchParams.get("connected");
+    const error = searchParams.get("error");
+    if (connected === "true") {
+      notifications.show({
+        message: t("Integration connected"),
+        color: "green",
+      });
+    } else if (error) {
+      notifications.show({
+        message: t("Connection failed: ") + error,
+        color: "red",
+      });
+    }
+    if (connected || error) {
+      const next = new URLSearchParams(searchParams);
+      next.delete("connected");
+      next.delete("error");
+      setSearchParams(next, { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <Helmet>
+        <title>
+          {t("Integrations")} - {getAppName()}
+        </title>
+      </Helmet>
+      <SettingsTitle title={t("Integrations")} />
+      <IntegrationsList />
+    </>
+  );
+}

--- a/apps/client/src/pages/settings/workspace/workspace-integrations.tsx
+++ b/apps/client/src/pages/settings/workspace/workspace-integrations.tsx
@@ -1,0 +1,19 @@
+import SettingsTitle from "@/components/settings/settings-title.tsx";
+import AdminIntegrationConnections from "@/features/integrations/components/admin-integration-connections";
+import { getAppName } from "@/lib/config.ts";
+import { Helmet } from "react-helmet-async";
+import { useTranslation } from "react-i18next";
+
+export default function WorkspaceIntegrations() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Helmet>
+        <title>Workspace Integrations - {getAppName()}</title>
+      </Helmet>
+      <SettingsTitle title={t("Workspace integrations")} />
+      <AdminIntegrationConnections />
+    </>
+  );
+}

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -7,6 +7,7 @@ const envPath = path.resolve(process.cwd(), "..", "..");
 export default defineConfig(({ mode }) => {
   const {
     APP_URL,
+    BACKEND_URL,
     FILE_UPLOAD_SIZE_LIMIT,
     FILE_IMPORT_SIZE_LIMIT,
     DRAWIO_URL,
@@ -56,17 +57,21 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       proxy: {
+        // Falls back to APP_URL when BACKEND_URL isn't set so the upstream
+        // single-port dev workflow keeps working unchanged. Set BACKEND_URL
+        // explicitly when APP_URL points at the dev server's public origin
+        // (e.g. for OAuth-style flows that round-trip through the browser).
         "/api": {
-          target: APP_URL,
+          target: BACKEND_URL || APP_URL,
           changeOrigin: false,
         },
         "/socket.io": {
-          target: APP_URL,
+          target: BACKEND_URL || APP_URL,
           ws: true,
           rewriteWsOrigin: true,
         },
         "/collab": {
-          target: APP_URL,
+          target: BACKEND_URL || APP_URL,
           ws: true,
           rewriteWsOrigin: true,
         },

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -28,6 +28,7 @@ import { ClsModule } from 'nestjs-cls';
 import { NoopAuditModule } from './integrations/audit/audit.module';
 import { ThrottleModule } from './integrations/throttle/throttle.module';
 import { IntegrationOAuthModule } from './integrations/integration-oauth/integration-oauth.module';
+import { WindshiftModule } from './integrations/windshift/windshift.module';
 
 const enterpriseModules = [];
 try {
@@ -87,6 +88,7 @@ try {
     TelemetryModule,
     ThrottleModule,
     IntegrationOAuthModule,
+    WindshiftModule,
     ...enterpriseModules,
   ],
   controllers: [AppController],

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -27,6 +27,7 @@ import { LoggerModule } from './common/logger/logger.module';
 import { ClsModule } from 'nestjs-cls';
 import { NoopAuditModule } from './integrations/audit/audit.module';
 import { ThrottleModule } from './integrations/throttle/throttle.module';
+import { IntegrationOAuthModule } from './integrations/integration-oauth/integration-oauth.module';
 
 const enterpriseModules = [];
 try {
@@ -85,6 +86,7 @@ try {
     SecurityModule,
     TelemetryModule,
     ThrottleModule,
+    IntegrationOAuthModule,
     ...enterpriseModules,
   ],
   controllers: [AppController],

--- a/apps/server/src/collaboration/collaboration.util.ts
+++ b/apps/server/src/collaboration/collaboration.util.ts
@@ -40,6 +40,7 @@ import {
   Columns,
   Column,
   Status,
+  IntegrationEmbed,
   addUniqueIdsToDoc,
   htmlToMarkdown,
   TransclusionSource,
@@ -110,7 +111,8 @@ export const tiptapExtensions = [
   Status,
   TransclusionSource,
   TransclusionReference,
-  BaseEmbed
+  BaseEmbed,
+  IntegrationEmbed,
 ] as any;
 
 export function jsonToHtml(tiptapJson: any) {

--- a/apps/server/src/common/helpers/encryption.helper.spec.ts
+++ b/apps/server/src/common/helpers/encryption.helper.spec.ts
@@ -1,0 +1,75 @@
+import { decryptString, encryptString } from './encryption.helper';
+
+const SECRET = 'test-app-secret-do-not-use-in-prod';
+const INFO = 'integration-oauth-token-v1';
+
+describe('encryption.helper', () => {
+  describe('encryptString → decryptString', () => {
+    it('round-trips ASCII plaintext', () => {
+      const ct = encryptString('hello world', SECRET, INFO);
+      expect(decryptString(ct, SECRET, INFO)).toBe('hello world');
+    });
+
+    it('round-trips unicode plaintext', () => {
+      const ct = encryptString('héllo 🌍 résumé', SECRET, INFO);
+      expect(decryptString(ct, SECRET, INFO)).toBe('héllo 🌍 résumé');
+    });
+
+    it('round-trips long plaintext (>1KB)', () => {
+      const long = 'a'.repeat(4096);
+      const ct = encryptString(long, SECRET, INFO);
+      expect(decryptString(ct, SECRET, INFO)).toBe(long);
+    });
+
+    it('produces a different ciphertext for the same plaintext (random IV)', () => {
+      const a = encryptString('same', SECRET, INFO);
+      const b = encryptString('same', SECRET, INFO);
+      expect(a).not.toBe(b);
+      expect(decryptString(a, SECRET, INFO)).toBe('same');
+      expect(decryptString(b, SECRET, INFO)).toBe('same');
+    });
+
+    it('emits the v1: format prefix', () => {
+      const ct = encryptString('x', SECRET, INFO);
+      expect(ct.startsWith('v1:')).toBe(true);
+      expect(ct.split(':').length).toBe(4);
+    });
+  });
+
+  describe('decryptString failures', () => {
+    it('throws when the auth tag is wrong (tampering)', () => {
+      const ct = encryptString('hello', SECRET, INFO);
+      const parts = ct.split(':');
+      // Flip a bit in the auth tag.
+      const tampered = Buffer.from(parts[2], 'hex');
+      tampered[0] ^= 0xff;
+      const broken = [parts[0], parts[1], tampered.toString('hex'), parts[3]].join(':');
+      expect(() => decryptString(broken, SECRET, INFO)).toThrow();
+    });
+
+    it('throws when the secret is wrong', () => {
+      const ct = encryptString('hello', SECRET, INFO);
+      expect(() => decryptString(ct, 'different-secret', INFO)).toThrow();
+    });
+
+    it('throws when the info string is wrong (domain separation)', () => {
+      const ct = encryptString('hello', SECRET, INFO);
+      expect(() => decryptString(ct, SECRET, 'wrong-info')).toThrow();
+    });
+
+    it('throws on unrecognized blob format', () => {
+      expect(() => decryptString('not-a-blob', SECRET, INFO)).toThrow(/unrecognized blob format/);
+      expect(() => decryptString('v0:aa:bb:cc', SECRET, INFO)).toThrow(/unrecognized blob format/);
+    });
+
+    it('throws on empty blob', () => {
+      expect(() => decryptString('', SECRET, INFO)).toThrow(/empty/);
+    });
+  });
+
+  describe('encryptString failures', () => {
+    it('throws on empty secret', () => {
+      expect(() => encryptString('hello', '', INFO)).toThrow(/secret is required/);
+    });
+  });
+});

--- a/apps/server/src/common/helpers/encryption.helper.ts
+++ b/apps/server/src/common/helpers/encryption.helper.ts
@@ -1,0 +1,61 @@
+import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from 'node:crypto';
+
+/**
+ * AES-256-GCM symmetric encryption keyed off a caller-supplied secret. Used
+ * for at-rest encryption of OAuth tokens.
+ *
+ * Wire format: `v1:<iv>:<tag>:<ciphertext>` (hex). The version prefix leaves
+ * room to rotate KDF or cipher without a destructive migration.
+ *
+ * `info` is mixed into HKDF for domain separation — callers must pick a
+ * stable, per-use-case string so this key can't be confused with any other
+ * derivation of the same secret (JWT signing, HMAC, etc).
+ */
+
+const VERSION = 'v1';
+const KEY_LENGTH = 32;
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+const HKDF_SALT = Buffer.alloc(0);
+
+function deriveKey(secret: string, info: string): Buffer {
+  if (!secret) {
+    throw new Error('encryption: secret is required');
+  }
+  const out = hkdfSync('sha256', Buffer.from(secret), HKDF_SALT, info, KEY_LENGTH);
+  return Buffer.from(out);
+}
+
+export function encryptString(plaintext: string, secret: string, info: string): string {
+  const key = deriveKey(secret, info);
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [VERSION, iv.toString('hex'), tag.toString('hex'), ciphertext.toString('hex')].join(':');
+}
+
+export function decryptString(blob: string, secret: string, info: string): string {
+  if (!blob) {
+    throw new Error('encryption: ciphertext is empty');
+  }
+  const parts = blob.split(':');
+  if (parts.length !== 4 || parts[0] !== VERSION) {
+    throw new Error(`encryption: unrecognized blob format (expected ${VERSION}:iv:tag:ct)`);
+  }
+  const iv = Buffer.from(parts[1], 'hex');
+  const tag = Buffer.from(parts[2], 'hex');
+  const ciphertext = Buffer.from(parts[3], 'hex');
+  if (iv.length !== IV_LENGTH) {
+    throw new Error(`encryption: invalid iv length`);
+  }
+  if (tag.length !== TAG_LENGTH) {
+    throw new Error(`encryption: invalid auth tag length`);
+  }
+
+  const key = deriveKey(secret, info);
+  const decipher = createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString('utf8');
+}

--- a/apps/server/src/database/migrations/20260504T132908-integration-oauth-tokens.ts
+++ b/apps/server/src/database/migrations/20260504T132908-integration-oauth-tokens.ts
@@ -1,0 +1,53 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable('integration_oauth_tokens')
+    .addColumn('id', 'uuid', (col) =>
+      col.primaryKey().defaultTo(sql`gen_uuid_v7()`),
+    )
+    .addColumn('user_id', 'uuid', (col) =>
+      col.references('users.id').onDelete('cascade').notNull(),
+    )
+    // Stable identifier for the third-party integration (e.g. 'github',
+    // 'linear'). Matches IntegrationManifest.id.
+    .addColumn('integration_id', 'varchar', (col) => col.notNull())
+    .addColumn('access_token_encrypted', 'text', (col) => col.notNull())
+    .addColumn('refresh_token_encrypted', 'text')
+    .addColumn('expires_at', 'timestamptz')
+    // Space-separated list of granted OAuth scopes — what the provider
+    // actually granted at exchange time, not what was requested.
+    .addColumn('scopes', 'text', (col) => col.notNull().defaultTo(''))
+    // Set when refresh has hard-failed (refresh token revoked / expired);
+    // surfaces a "Reconnect" prompt in the settings UI.
+    .addColumn('needs_reconnect', 'boolean', (col) =>
+      col.notNull().defaultTo(false),
+    )
+    .addColumn('created_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn('updated_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .execute();
+
+  // One token row per user per integration — single-instance v1.
+  await db.schema
+    .createIndex('idx_integration_oauth_tokens_user_integration')
+    .ifNotExists()
+    .on('integration_oauth_tokens')
+    .columns(['user_id', 'integration_id'])
+    .unique()
+    .execute();
+
+  await db.schema
+    .createIndex('idx_integration_oauth_tokens_integration')
+    .ifNotExists()
+    .on('integration_oauth_tokens')
+    .column('integration_id')
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable('integration_oauth_tokens').execute();
+}

--- a/apps/server/src/database/migrations/20260608T101500-integration-oauth-connections.ts
+++ b/apps/server/src/database/migrations/20260608T101500-integration-oauth-connections.ts
@@ -1,0 +1,139 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable('integration_oauth_connections')
+    .addColumn('id', 'uuid', (col) =>
+      col.primaryKey().defaultTo(sql`gen_uuid_v7()`),
+    )
+    .addColumn('workspace_id', 'uuid', (col) =>
+      col.references('workspaces.id').onDelete('cascade').notNull(),
+    )
+    .addColumn('integration_id', 'varchar', (col) => col.notNull())
+    .addColumn('enabled', 'boolean', (col) => col.notNull().defaultTo(true))
+    .addColumn('base_url', 'text', (col) => col.notNull())
+    .addColumn('oauth_client_id', 'text', (col) => col.notNull())
+    .addColumn('oauth_client_secret_encrypted', 'text')
+    // Provider-defined connection settings declared by the manifest
+    // (IntegrationManifest.connectionSettings), validated at save time.
+    .addColumn('settings', 'jsonb', (col) =>
+      col.notNull().defaultTo(sql`'{}'::jsonb`),
+    )
+    .addColumn('created_by_id', 'uuid', (col) =>
+      col.references('users.id').onDelete('set null'),
+    )
+    .addColumn('updated_by_id', 'uuid', (col) =>
+      col.references('users.id').onDelete('set null'),
+    )
+    .addColumn('created_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .addColumn('updated_at', 'timestamptz', (col) =>
+      col.notNull().defaultTo(sql`now()`),
+    )
+    .execute();
+
+  await db.schema
+    .createIndex('idx_integration_oauth_connections_workspace_integration')
+    .ifNotExists()
+    .on('integration_oauth_connections')
+    .columns(['workspace_id', 'integration_id'])
+    .unique()
+    .execute();
+
+  await db.schema
+    .createIndex('idx_integration_oauth_connections_workspace')
+    .ifNotExists()
+    .on('integration_oauth_connections')
+    .column('workspace_id')
+    .execute();
+
+  await db.schema
+    .alterTable('integration_oauth_tokens')
+    .addColumn('workspace_id', 'uuid', (col) =>
+      col.references('workspaces.id').onDelete('cascade'),
+    )
+    .execute();
+
+  await db.executeQuery(
+    sql`
+    update integration_oauth_tokens t
+    set workspace_id = u.workspace_id
+    from users u
+    where t.user_id = u.id and t.workspace_id is null
+  `.compile(db),
+  );
+
+  await db.executeQuery(
+    sql`
+    delete from integration_oauth_tokens where workspace_id is null
+  `.compile(db),
+  );
+
+  await db.executeQuery(
+    sql`
+    alter table integration_oauth_tokens
+    alter column workspace_id set not null
+  `.compile(db),
+  );
+
+  await db.schema
+    .dropIndex('idx_integration_oauth_tokens_user_integration')
+    .ifExists()
+    .execute();
+
+  await db.schema
+    .createIndex('idx_integration_oauth_tokens_user_workspace_integration')
+    .ifNotExists()
+    .on('integration_oauth_tokens')
+    .columns(['user_id', 'workspace_id', 'integration_id'])
+    .unique()
+    .execute();
+
+  await db.schema
+    .createIndex('idx_integration_oauth_tokens_workspace')
+    .ifNotExists()
+    .on('integration_oauth_tokens')
+    .column('workspace_id')
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .dropIndex('idx_integration_oauth_tokens_workspace')
+    .ifExists()
+    .execute();
+
+  await db.schema
+    .dropIndex('idx_integration_oauth_tokens_user_workspace_integration')
+    .ifExists()
+    .execute();
+
+  // Collapsing back to a per-user unique key: when a user connected the same
+  // integration in several workspaces, keep only the most recent token so the
+  // unique index below can be recreated.
+  await db.executeQuery(
+    sql`
+    delete from integration_oauth_tokens t
+    using integration_oauth_tokens newer
+    where t.user_id = newer.user_id
+      and t.integration_id = newer.integration_id
+      and t.created_at < newer.created_at
+  `.compile(db),
+  );
+
+  await db.schema
+    .createIndex('idx_integration_oauth_tokens_user_integration')
+    .ifNotExists()
+    .on('integration_oauth_tokens')
+    .columns(['user_id', 'integration_id'])
+    .unique()
+    .execute();
+
+  await db.schema
+    .alterTable('integration_oauth_tokens')
+    .dropColumn('workspace_id')
+    .execute();
+
+  await db.schema.dropTable('integration_oauth_connections').execute();
+}

--- a/apps/server/src/database/types/db.d.ts
+++ b/apps/server/src/database/types/db.d.ts
@@ -494,6 +494,35 @@ export interface ScimTokens {
   workspaceId: string;
 }
 
+export interface IntegrationOauthConnections {
+  id: Generated<string>;
+  workspaceId: string;
+  integrationId: string;
+  enabled: Generated<boolean>;
+  baseUrl: string;
+  oauthClientId: string;
+  oauthClientSecretEncrypted: string | null;
+  settings: Generated<Json>;
+  createdById: string | null;
+  updatedById: string | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+}
+
+export interface IntegrationOauthTokens {
+  id: Generated<string>;
+  userId: string;
+  workspaceId: string;
+  integrationId: string;
+  accessTokenEncrypted: string;
+  refreshTokenEncrypted: string | null;
+  expiresAt: Timestamp | null;
+  scopes: Generated<string>;
+  needsReconnect: Generated<boolean>;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Generated<Timestamp>;
+}
+
 export interface Watchers {
   id: Generated<string>;
   userId: string;
@@ -666,6 +695,8 @@ export interface DB {
   pageVerifiers: PageVerifiers;
   pages: Pages;
   scimTokens: ScimTokens;
+  integrationOauthConnections: IntegrationOauthConnections;
+  integrationOauthTokens: IntegrationOauthTokens;
   shares: Shares;
   spaceMembers: SpaceMembers;
   spaces: Spaces;

--- a/apps/server/src/database/types/entity.types.ts
+++ b/apps/server/src/database/types/entity.types.ts
@@ -37,6 +37,8 @@ import {
   UserSessions,
   ApiKeys,
   ScimTokens,
+  IntegrationOauthConnections,
+  IntegrationOauthTokens,
   Watchers,
   Audit as _Audit,
   Templates,
@@ -53,10 +55,7 @@ export type UpdatableAiChat = Updateable<Omit<AiChats, 'id'>>;
 // full-text search. It is omitted from the public type so it never leaks
 // into HTTP responses or the chat history fed to the language model.
 export type AiChatMessage = Omit<Selectable<AiChatMessages>, 'tsv'>;
-export type InsertableAiChatMessage = Omit<
-  Insertable<AiChatMessages>,
-  'tsv'
->;
+export type InsertableAiChatMessage = Omit<Insertable<AiChatMessages>, 'tsv'>;
 
 // Workspace
 export type Workspace = Selectable<Workspaces>;
@@ -184,6 +183,23 @@ export type ScimToken = Selectable<ScimTokens>;
 export type InsertableScimToken = Insertable<ScimTokens>;
 export type UpdatableScimToken = Updateable<Omit<ScimTokens, 'id'>>;
 
+// Integration OAuth Connections
+export type IntegrationOauthConnection =
+  Selectable<IntegrationOauthConnections>;
+export type InsertableIntegrationOauthConnection =
+  Insertable<IntegrationOauthConnections>;
+export type UpdatableIntegrationOauthConnection = Updateable<
+  Omit<IntegrationOauthConnections, 'id'>
+>;
+
+// Integration OAuth Tokens
+export type IntegrationOauthToken = Selectable<IntegrationOauthTokens>;
+export type InsertableIntegrationOauthToken =
+  Insertable<IntegrationOauthTokens>;
+export type UpdatableIntegrationOauthToken = Updateable<
+  Omit<IntegrationOauthTokens, 'id'>
+>;
+
 // Page Embedding
 export type PageEmbedding = Selectable<PageEmbeddings>;
 export type InsertablePageEmbedding = Insertable<PageEmbeddings>;
@@ -221,7 +237,9 @@ export type UpdatablePagePermission = Updateable<Omit<_PagePermissions, 'id'>>;
 // Page Verification
 export type PageVerification = Selectable<_PageVerifications>;
 export type InsertablePageVerification = Insertable<_PageVerifications>;
-export type UpdatablePageVerification = Updateable<Omit<_PageVerifications, 'id'>>;
+export type UpdatablePageVerification = Updateable<
+  Omit<_PageVerifications, 'id'>
+>;
 
 // Page Verifier
 export type PageVerifier = Selectable<_PageVerifiers>;

--- a/apps/server/src/integrations/integration-oauth/dto/save-integration-oauth-connection.dto.ts
+++ b/apps/server/src/integrations/integration-oauth/dto/save-integration-oauth-connection.dto.ts
@@ -1,0 +1,34 @@
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { SaveIntegrationOAuthConnectionInput } from '../integration-oauth-connection.service';
+
+export class SaveIntegrationOAuthConnectionDto
+  implements SaveIntegrationOAuthConnectionInput
+{
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+
+  @IsString()
+  @IsNotEmpty()
+  baseUrl: string;
+
+  @IsString()
+  @IsNotEmpty()
+  oauthClientId: string;
+
+  /** Omit to keep the stored secret; empty string clears it. */
+  @IsOptional()
+  @IsString()
+  oauthClientSecret?: string;
+
+  /** Validated per-field against the manifest's connectionSettings. */
+  @IsOptional()
+  @IsObject()
+  settings?: Record<string, unknown>;
+}

--- a/apps/server/src/integrations/integration-oauth/dto/save-integration-oauth-connection.dto.ts
+++ b/apps/server/src/integrations/integration-oauth/dto/save-integration-oauth-connection.dto.ts
@@ -7,9 +7,7 @@ import {
 } from 'class-validator';
 import { SaveIntegrationOAuthConnectionInput } from '../integration-oauth-connection.service';
 
-export class SaveIntegrationOAuthConnectionDto
-  implements SaveIntegrationOAuthConnectionInput
-{
+export class SaveIntegrationOAuthConnectionDto implements SaveIntegrationOAuthConnectionInput {
   @IsOptional()
   @IsBoolean()
   enabled?: boolean;
@@ -18,9 +16,10 @@ export class SaveIntegrationOAuthConnectionDto
   @IsNotEmpty()
   baseUrl: string;
 
+  /** Required unless the provider registers a public client automatically. */
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  oauthClientId: string;
+  oauthClientId?: string;
 
   /** Omit to keep the stored secret; empty string clears it. */
   @IsOptional()

--- a/apps/server/src/integrations/integration-oauth/integration-oauth-admin.controller.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth-admin.controller.ts
@@ -1,0 +1,72 @@
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  NotFoundException,
+  Param,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { AuthUser } from '../../common/decorators/auth-user.decorator';
+import { AuthWorkspace } from '../../common/decorators/auth-workspace.decorator';
+import { User, Workspace } from '@docmost/db/types/entity.types';
+import WorkspaceAbilityFactory from '../../core/casl/abilities/workspace-ability.factory';
+import {
+  WorkspaceCaslAction,
+  WorkspaceCaslSubject,
+} from '../../core/casl/interfaces/workspace-ability.type';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import {
+  IntegrationOAuthConnectionService,
+  PublicIntegrationOAuthConnection,
+} from './integration-oauth-connection.service';
+import { SaveIntegrationOAuthConnectionDto } from './dto/save-integration-oauth-connection.dto';
+
+@Controller('integrations/oauth/admin/connections')
+@UseGuards(JwtAuthGuard)
+export class IntegrationOAuthAdminController {
+  constructor(
+    private readonly registry: IntegrationOAuthRegistry,
+    private readonly connectionService: IntegrationOAuthConnectionService,
+    private readonly workspaceAbility: WorkspaceAbilityFactory,
+  ) {}
+
+  @Get()
+  async list(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ): Promise<PublicIntegrationOAuthConnection[]> {
+    this.requireAdmin(user, workspace);
+    return this.connectionService.listAdmin(workspace.id);
+  }
+
+  @Put(':integrationId')
+  async save(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+    @Param('integrationId') integrationId: string,
+    @Body() body: SaveIntegrationOAuthConnectionDto,
+  ): Promise<PublicIntegrationOAuthConnection> {
+    this.requireAdmin(user, workspace);
+    if (!this.registry.getForIntegrationId(integrationId)) {
+      throw new NotFoundException(`Unknown integration: ${integrationId}`);
+    }
+    return this.connectionService.save(
+      workspace.id,
+      integrationId,
+      user.id,
+      body,
+    );
+  }
+
+  private requireAdmin(user: User, workspace: Workspace): void {
+    const ability = this.workspaceAbility.createForUser(user, workspace);
+    if (
+      ability.cannot(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Settings)
+    ) {
+      throw new ForbiddenException();
+    }
+  }
+}

--- a/apps/server/src/integrations/integration-oauth/integration-oauth-client.service.spec.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth-client.service.spec.ts
@@ -1,0 +1,210 @@
+import {
+  IntegrationNotConfiguredError,
+  IntegrationNotConnectedError,
+  IntegrationOAuthClientService,
+  IntegrationReconnectRequiredError,
+} from './integration-oauth-client.service';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import { IntegrationManifest } from './manifest.types';
+import { DecryptedTokens, IntegrationOAuthService } from './integration-oauth.service';
+import { IntegrationOAuthConnectionService } from './integration-oauth-connection.service';
+import { outboundFetch, OutboundResponse } from './outbound-url-guard';
+
+jest.mock('./outbound-url-guard', () => {
+  const actual = jest.requireActual('./outbound-url-guard');
+  return {
+    ...actual,
+    outboundFetch: jest.fn(),
+    readOutboundBody: jest.fn((resp: { __body?: string }) =>
+      Promise.resolve(resp.__body ?? ''),
+    ),
+  };
+});
+
+const INTEGRATION_ID = 'alpha:1111';
+const WS = 'ws-1';
+const UID = 'user-1';
+
+const outboundFetchMock = outboundFetch as jest.MockedFunction<typeof outboundFetch>;
+
+function fakeResponse(status: number, body: unknown): OutboundResponse {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: () => 'application/json' },
+    __body: JSON.stringify(body),
+  } as unknown as OutboundResponse;
+}
+
+function tokens(overrides: Partial<DecryptedTokens> = {}): DecryptedTokens {
+  return {
+    accessToken: 'access-1',
+    refreshToken: 'refresh-1',
+    scopes: 'read',
+    needsReconnect: false,
+    ...overrides,
+  };
+}
+
+describe('IntegrationOAuthClientService', () => {
+  let registry: IntegrationOAuthRegistry;
+  let oauthService: jest.Mocked<
+    Pick<IntegrationOAuthService, 'getTokens' | 'refreshTokens' | 'markNeedsReconnect'>
+  >;
+  let connectionService: jest.Mocked<Pick<IntegrationOAuthConnectionService, 'requireEnabled'>>;
+  let service: IntegrationOAuthClientService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registry = new IntegrationOAuthRegistry();
+    registry.register({
+      id: 'alpha',
+      name: 'Alpha',
+      baseUrl: () => 'https://provider.example.com',
+      authorizePath: '/oauth/authorize',
+      tokenPath: '/oauth/token',
+      scopes: ['read'],
+      clientIdEnv: 'TEST_CLIENT_ID',
+      clientSecretEnv: 'TEST_CLIENT_SECRET',
+    } as IntegrationManifest);
+
+    oauthService = {
+      getTokens: jest.fn().mockResolvedValue(tokens()),
+      refreshTokens: jest.fn().mockResolvedValue(tokens({ accessToken: 'access-2' })),
+      markNeedsReconnect: jest.fn().mockResolvedValue(undefined),
+    };
+    connectionService = {
+      requireEnabled: jest.fn().mockResolvedValue({
+        baseUrl: 'https://provider.example.com',
+        settings: {},
+      }),
+    };
+    service = new IntegrationOAuthClientService(
+      registry,
+      oauthService as unknown as IntegrationOAuthService,
+      connectionService as unknown as IntegrationOAuthConnectionService,
+    );
+  });
+
+  it('performs an authenticated GET and parses the JSON body', async () => {
+    outboundFetchMock.mockResolvedValue(fakeResponse(200, { hello: 'world' }));
+    const body = await service.get(INTEGRATION_ID, WS, UID, '/api/things', { q: 'x' });
+    expect(body).toEqual({ hello: 'world' });
+    const [url, init] = outboundFetchMock.mock.calls[0];
+    expect(url).toBe('https://provider.example.com/api/things?q=x');
+    expect((init!.headers as Record<string, string>).Authorization).toBe('Bearer access-1');
+  });
+
+  it('throws NotConfigured when no enabled connection exists', async () => {
+    connectionService.requireEnabled.mockRejectedValue(new Error('disabled'));
+    await expect(service.get(INTEGRATION_ID, WS, UID, '/api/things')).rejects.toBeInstanceOf(
+      IntegrationNotConfiguredError,
+    );
+    expect(outboundFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws NotConnected when the user has no tokens', async () => {
+    oauthService.getTokens.mockResolvedValue(null as unknown as DecryptedTokens);
+    await expect(service.get(INTEGRATION_ID, WS, UID, '/api/things')).rejects.toBeInstanceOf(
+      IntegrationNotConnectedError,
+    );
+  });
+
+  it('throws ReconnectRequired when tokens are flagged', async () => {
+    oauthService.getTokens.mockResolvedValue(tokens({ needsReconnect: true }));
+    await expect(service.get(INTEGRATION_ID, WS, UID, '/api/things')).rejects.toBeInstanceOf(
+      IntegrationReconnectRequiredError,
+    );
+  });
+
+  it('proactively refreshes expired tokens before the request', async () => {
+    oauthService.getTokens.mockResolvedValue(
+      tokens({ expiresAt: new Date(Date.now() - 1000) }),
+    );
+    outboundFetchMock.mockResolvedValue(fakeResponse(200, {}));
+    await service.get(INTEGRATION_ID, WS, UID, '/api/things');
+    expect(oauthService.refreshTokens).toHaveBeenCalledTimes(1);
+    const [, init] = outboundFetchMock.mock.calls[0];
+    expect((init!.headers as Record<string, string>).Authorization).toBe('Bearer access-2');
+  });
+
+  it('refreshes once on a 401 and retries with the new token', async () => {
+    outboundFetchMock
+      .mockResolvedValueOnce(fakeResponse(401, {}))
+      .mockResolvedValueOnce(fakeResponse(200, { ok: true }));
+    const body = await service.get(INTEGRATION_ID, WS, UID, '/api/things');
+    expect(body).toEqual({ ok: true });
+    expect(oauthService.refreshTokens).toHaveBeenCalledTimes(1);
+    const [, retryInit] = outboundFetchMock.mock.calls[1];
+    expect((retryInit!.headers as Record<string, string>).Authorization).toBe('Bearer access-2');
+  });
+
+  it('marks reconnect when the retry also 401s', async () => {
+    outboundFetchMock.mockResolvedValue(fakeResponse(401, {}));
+    await expect(service.get(INTEGRATION_ID, WS, UID, '/api/things')).rejects.toBeInstanceOf(
+      IntegrationReconnectRequiredError,
+    );
+    expect(oauthService.markNeedsReconnect).toHaveBeenCalledWith(UID, WS, INTEGRATION_ID);
+  });
+
+  it('marks reconnect when refresh itself fails', async () => {
+    outboundFetchMock.mockResolvedValue(fakeResponse(401, {}));
+    oauthService.refreshTokens.mockRejectedValue(new Error('refresh denied'));
+    await expect(service.get(INTEGRATION_ID, WS, UID, '/api/things')).rejects.toBeInstanceOf(
+      IntegrationReconnectRequiredError,
+    );
+    expect(oauthService.markNeedsReconnect).toHaveBeenCalled();
+  });
+
+  it('surfaces provider errors with their status', async () => {
+    outboundFetchMock.mockResolvedValue(fakeResponse(404, { error: 'nope' }));
+    await expect(service.get(INTEGRATION_ID, WS, UID, '/api/things')).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+
+  it('caches GETs per user/integration/path+query', async () => {
+    outboundFetchMock.mockResolvedValue(fakeResponse(200, { n: 1 }));
+    await service.get(INTEGRATION_ID, WS, UID, '/api/things', { q: 'a' });
+    await service.get(INTEGRATION_ID, WS, UID, '/api/things', { q: 'a' });
+    expect(outboundFetchMock).toHaveBeenCalledTimes(1);
+
+    await service.get(INTEGRATION_ID, WS, UID, '/api/things', { q: 'b' });
+    expect(outboundFetchMock).toHaveBeenCalledTimes(2);
+
+    await service.get(INTEGRATION_ID, WS, 'user-2', '/api/things', { q: 'a' });
+    expect(outboundFetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not cache failed responses', async () => {
+    outboundFetchMock
+      .mockResolvedValueOnce(fakeResponse(500, {}))
+      .mockResolvedValueOnce(fakeResponse(200, { ok: true }));
+    await expect(service.get(INTEGRATION_ID, WS, UID, '/api/things')).rejects.toMatchObject({
+      status: 500,
+    });
+    await expect(service.get(INTEGRATION_ID, WS, UID, '/api/things')).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it('deduplicates concurrent refreshes behind one lock', async () => {
+    let resolveRefresh: (t: DecryptedTokens) => void;
+    oauthService.refreshTokens.mockReturnValue(
+      new Promise<DecryptedTokens>((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+    oauthService.getTokens.mockResolvedValue(
+      tokens({ expiresAt: new Date(Date.now() - 1000) }),
+    );
+    outboundFetchMock.mockResolvedValue(fakeResponse(200, {}));
+
+    const first = service.get(INTEGRATION_ID, WS, UID, '/api/a');
+    const second = service.get(INTEGRATION_ID, WS, UID, '/api/b');
+    await new Promise((r) => setImmediate(r));
+    resolveRefresh!(tokens({ accessToken: 'access-2' }));
+    await Promise.all([first, second]);
+    expect(oauthService.refreshTokens).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/server/src/integrations/integration-oauth/integration-oauth-client.service.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth-client.service.ts
@@ -1,0 +1,338 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  outboundFetch,
+  OutboundResponse,
+  readOutboundBody,
+} from './outbound-url-guard';
+import { IntegrationManifest } from './manifest.types';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import {
+  DecryptedTokens,
+  IntegrationOAuthService,
+} from './integration-oauth.service';
+import {
+  IntegrationOAuthConnectionService,
+  ResolvedIntegrationOAuthConnection,
+} from './integration-oauth-connection.service';
+
+export class IntegrationReconnectRequiredError extends Error {
+  constructor(integrationId: string) {
+    super(`Reconnect required for integration: ${integrationId}`);
+    this.name = 'IntegrationReconnectRequiredError';
+  }
+}
+
+export class IntegrationNotConnectedError extends Error {
+  constructor(integrationId: string) {
+    super(`Integration not connected: ${integrationId}`);
+    this.name = 'IntegrationNotConnectedError';
+  }
+}
+
+export class IntegrationNotConfiguredError extends Error {
+  constructor(integrationId: string) {
+    super(`Integration not configured: ${integrationId}`);
+    this.name = 'IntegrationNotConfiguredError';
+  }
+}
+
+interface RequestOptions {
+  method?: string;
+  query?: Record<string, string | number | undefined>;
+  headers?: Record<string, string>;
+  body?: unknown;
+  /** Skip the 30s LRU cache for this call. Defaults to true for non-GET. */
+  skipCache?: boolean;
+}
+
+interface CacheEntry {
+  expiresAt: number;
+  body: unknown;
+  status: number;
+}
+
+/**
+ * Per-user authenticated outbound HTTP. Refreshes the access token on a
+ * 401 (once); per-(workspace, user, integration) mutex prevents concurrent
+ * refreshes racing each other. 30s in-memory LRU on GETs absorbs the herd when
+ * a page has many embeds. Returns the parsed JSON body.
+ */
+@Injectable()
+export class IntegrationOAuthClientService {
+  private readonly logger = new Logger(IntegrationOAuthClientService.name);
+
+  private readonly refreshLocks = new Map<string, Promise<DecryptedTokens>>();
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly cacheTtlMs = 30_000;
+  private readonly cacheMaxSize = 1024;
+
+  constructor(
+    private readonly registry: IntegrationOAuthRegistry,
+    private readonly oauthService: IntegrationOAuthService,
+    private readonly connectionService: IntegrationOAuthConnectionService,
+  ) {}
+
+  async request<T = unknown>(
+    integrationId: string,
+    workspaceId: string,
+    userId: string,
+    path: string,
+    options: RequestOptions = {},
+  ): Promise<T> {
+    const manifest = this.registry.requireForIntegrationId(integrationId);
+    const method = (options.method ?? 'GET').toUpperCase();
+    const cacheable = method === 'GET' && !options.skipCache;
+
+    const cacheKey = cacheable
+      ? this.buildCacheKey(
+          workspaceId,
+          userId,
+          integrationId,
+          method,
+          path,
+          options.query,
+        )
+      : null;
+    if (cacheKey) {
+      const hit = this.cacheGet(cacheKey);
+      if (hit) return hit as T;
+    }
+
+    let tokens = await this.requireTokens(integrationId, workspaceId, userId);
+
+    let resp = await this.send(
+      integrationId,
+      manifest,
+      workspaceId,
+      path,
+      method,
+      tokens.accessToken,
+      options,
+    );
+    if (resp.status === 401) {
+      tokens = await this.refreshOnce(integrationId, workspaceId, userId);
+      resp = await this.send(
+        integrationId,
+        manifest,
+        workspaceId,
+        path,
+        method,
+        tokens.accessToken,
+        options,
+      );
+      if (resp.status === 401) {
+        await this.oauthService.markNeedsReconnect(
+          userId,
+          workspaceId,
+          integrationId,
+        );
+        throw new IntegrationReconnectRequiredError(integrationId);
+      }
+    }
+
+    const body = await this.parseBody(resp);
+    if (!resp.ok) {
+      const err = new Error(
+        `Integration ${integrationId} request failed (${resp.status})`,
+      );
+      (err as Error & { status?: number; body?: unknown }).status = resp.status;
+      (err as Error & { status?: number; body?: unknown }).body = body;
+      throw err;
+    }
+
+    if (cacheKey) {
+      this.cacheSet(cacheKey, {
+        expiresAt: Date.now() + this.cacheTtlMs,
+        body,
+        status: resp.status,
+      });
+    }
+    return body as T;
+  }
+
+  /** Convenience wrapper for callers that want a typed JSON response. */
+  async get<T = unknown>(
+    integrationId: string,
+    workspaceId: string,
+    userId: string,
+    path: string,
+    query?: Record<string, string | number | undefined>,
+  ): Promise<T> {
+    return this.request<T>(integrationId, workspaceId, userId, path, {
+      method: 'GET',
+      query,
+    });
+  }
+
+  async baseUrl(integrationId: string, workspaceId: string): Promise<string> {
+    return (await this.requireConnection(integrationId, workspaceId)).baseUrl;
+  }
+
+  /** Admin-configured connection settings declared by the manifest. */
+  async settings(
+    integrationId: string,
+    workspaceId: string,
+  ): Promise<Record<string, string>> {
+    return (await this.requireConnection(integrationId, workspaceId)).settings;
+  }
+
+  // ---- internals ----
+
+  private async requireTokens(
+    integrationId: string,
+    workspaceId: string,
+    userId: string,
+  ): Promise<DecryptedTokens> {
+    await this.requireConnection(integrationId, workspaceId);
+    const tokens = await this.oauthService.getTokens(
+      userId,
+      workspaceId,
+      integrationId,
+    );
+    if (!tokens) {
+      throw new IntegrationNotConnectedError(integrationId);
+    }
+    if (tokens.needsReconnect) {
+      throw new IntegrationReconnectRequiredError(integrationId);
+    }
+    // Proactive refresh saves a guaranteed 401 round-trip.
+    if (
+      tokens.expiresAt &&
+      tokens.expiresAt.getTime() <= Date.now() &&
+      tokens.refreshToken
+    ) {
+      return this.refreshOnce(integrationId, workspaceId, userId);
+    }
+    return tokens;
+  }
+
+  private async refreshOnce(
+    integrationId: string,
+    workspaceId: string,
+    userId: string,
+  ): Promise<DecryptedTokens> {
+    const lockKey = `${workspaceId}::${userId}::${integrationId}`;
+    const existing = this.refreshLocks.get(lockKey);
+    if (existing) return existing;
+
+    const promise = (async () => {
+      try {
+        return await this.oauthService.refreshTokens(
+          userId,
+          workspaceId,
+          integrationId,
+        );
+      } catch (err) {
+        await this.oauthService.markNeedsReconnect(
+          userId,
+          workspaceId,
+          integrationId,
+        );
+        this.logger.warn(
+          `Refresh failed for integration=${integrationId} workspace=${workspaceId} user=${userId}: ${(err as Error).message}`,
+        );
+        throw new IntegrationReconnectRequiredError(integrationId);
+      } finally {
+        this.refreshLocks.delete(lockKey);
+      }
+    })();
+    this.refreshLocks.set(lockKey, promise);
+    return promise;
+  }
+
+  private async send(
+    integrationId: string,
+    manifest: IntegrationManifest,
+    workspaceId: string,
+    path: string,
+    method: string,
+    accessToken: string,
+    options: RequestOptions,
+  ): Promise<OutboundResponse> {
+    const connection = await this.requireConnection(integrationId, workspaceId);
+    const url = new URL(`${connection.baseUrl}${path}`);
+    if (options.query) {
+      for (const [k, v] of Object.entries(options.query)) {
+        if (v !== undefined) url.searchParams.set(k, String(v));
+      }
+    }
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+      ...(options.headers ?? {}),
+    };
+    let body: string | undefined;
+    if (options.body !== undefined && method !== 'GET' && method !== 'HEAD') {
+      headers['Content-Type'] = 'application/json';
+      body = JSON.stringify(options.body);
+    }
+    return outboundFetch(url.toString(), { method, headers, body });
+  }
+
+  private async requireConnection(
+    integrationId: string,
+    workspaceId: string,
+  ): Promise<ResolvedIntegrationOAuthConnection> {
+    try {
+      return await this.connectionService.requireEnabled(
+        workspaceId,
+        integrationId,
+      );
+    } catch {
+      throw new IntegrationNotConfiguredError(integrationId);
+    }
+  }
+
+  private async parseBody(resp: OutboundResponse): Promise<unknown> {
+    const text = await readOutboundBody(resp);
+    const ct = resp.headers.get('content-type') ?? '';
+    if (ct.includes('application/json')) {
+      try {
+        return JSON.parse(text);
+      } catch {
+        return null;
+      }
+    }
+    return text;
+  }
+
+  private buildCacheKey(
+    workspaceId: string,
+    userId: string,
+    integrationId: string,
+    method: string,
+    path: string,
+    query?: Record<string, string | number | undefined>,
+  ): string {
+    const q = query
+      ? Object.entries(query)
+          .filter(([, v]) => v !== undefined)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([k, v]) => `${k}=${String(v)}`)
+          .join('&')
+      : '';
+    return `${workspaceId}::${userId}::${integrationId}::${method}::${path}?${q}`;
+  }
+
+  private cacheGet(key: string): unknown | null {
+    const entry = this.cache.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt <= Date.now()) {
+      this.cache.delete(key);
+      return null;
+    }
+    // Move-to-end for LRU.
+    this.cache.delete(key);
+    this.cache.set(key, entry);
+    return entry.body;
+  }
+
+  private cacheSet(key: string, entry: CacheEntry): void {
+    if (this.cache.size >= this.cacheMaxSize) {
+      // Drop the oldest (first inserted) entry.
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey !== undefined) this.cache.delete(firstKey);
+    }
+    this.cache.set(key, entry);
+  }
+}

--- a/apps/server/src/integrations/integration-oauth/integration-oauth-connection.repo.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth-connection.repo.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import { InjectKysely } from 'nestjs-kysely';
+import { sql } from 'kysely';
+import { KyselyDB } from '@docmost/db/types/kysely.types';
+import { IntegrationOauthConnection } from '@docmost/db/types/entity.types';
+
+export interface UpsertIntegrationOAuthConnectionInput {
+  workspaceId: string;
+  integrationId: string;
+  enabled: boolean;
+  baseUrl: string;
+  oauthClientId: string;
+  oauthClientSecretEncrypted?: string | null;
+  settings?: Record<string, string>;
+  actorUserId: string;
+}
+
+/** Workspace-scoped admin configuration for an integration OAuth provider. */
+@Injectable()
+export class IntegrationOAuthConnectionRepo {
+  constructor(@InjectKysely() private readonly db: KyselyDB) {}
+
+  async find(
+    workspaceId: string,
+    integrationId: string,
+  ): Promise<IntegrationOauthConnection | undefined> {
+    return this.db
+      .selectFrom('integrationOauthConnections')
+      .selectAll()
+      .where('workspaceId', '=', workspaceId)
+      .where('integrationId', '=', integrationId)
+      .executeTakeFirst();
+  }
+
+  async listByWorkspace(
+    workspaceId: string,
+  ): Promise<IntegrationOauthConnection[]> {
+    return this.db
+      .selectFrom('integrationOauthConnections')
+      .selectAll()
+      .where('workspaceId', '=', workspaceId)
+      .orderBy('integrationId', 'asc')
+      .execute();
+  }
+
+  async upsert(
+    input: UpsertIntegrationOAuthConnectionInput,
+  ): Promise<IntegrationOauthConnection> {
+    // Pass the object itself: postgres.js serializes JS objects to json,
+    // while a pre-stringified payload would land as a jsonb string scalar.
+    const settings = input.settings ?? {};
+    const row = {
+      workspaceId: input.workspaceId,
+      integrationId: input.integrationId,
+      enabled: input.enabled,
+      baseUrl: input.baseUrl,
+      oauthClientId: input.oauthClientId,
+      oauthClientSecretEncrypted: input.oauthClientSecretEncrypted ?? null,
+      settings,
+      createdById: input.actorUserId,
+      updatedById: input.actorUserId,
+    };
+
+    return this.db
+      .insertInto('integrationOauthConnections')
+      .values(row)
+      .onConflict((oc) =>
+        oc.columns(['workspaceId', 'integrationId']).doUpdateSet({
+          enabled: input.enabled,
+          baseUrl: input.baseUrl,
+          oauthClientId: input.oauthClientId,
+          oauthClientSecretEncrypted: input.oauthClientSecretEncrypted ?? null,
+          settings,
+          updatedById: input.actorUserId,
+          updatedAt: sql`now()`,
+        }),
+      )
+      .returningAll()
+      .executeTakeFirstOrThrow();
+  }
+}

--- a/apps/server/src/integrations/integration-oauth/integration-oauth-connection.service.spec.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth-connection.service.spec.ts
@@ -1,0 +1,197 @@
+import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { IntegrationOauthConnection } from '@docmost/db/types/entity.types';
+import { EnvironmentService } from '../environment/environment.service';
+import { IntegrationOAuthConnectionRepo } from './integration-oauth-connection.repo';
+import { IntegrationOAuthConnectionService } from './integration-oauth-connection.service';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import { IntegrationManifest } from './manifest.types';
+import { outboundFetch } from './outbound-url-guard';
+
+jest.mock('./outbound-url-guard', () => {
+  const actual = jest.requireActual('./outbound-url-guard');
+  return {
+    ...actual,
+    assertAllowedOutboundUrl: jest.fn().mockResolvedValue(undefined),
+    outboundFetch: jest.fn(),
+    readOutboundBody: jest.fn((resp: { __body?: string }) =>
+      Promise.resolve(resp.__body ?? ''),
+    ),
+  };
+});
+
+const outboundFetchMock = outboundFetch as jest.MockedFunction<
+  typeof outboundFetch
+>;
+
+function fakeResponse(status: number, body: unknown) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    __body: JSON.stringify(body),
+  } as never;
+}
+
+function row(
+  overrides: Partial<IntegrationOauthConnection> = {},
+): IntegrationOauthConnection {
+  return {
+    id: 'connection-1',
+    integrationId: 'windshift:connection-1',
+    workspaceId: 'workspace-1',
+    enabled: true,
+    baseUrl: 'https://windshift.example',
+    oauthClientId: 'wsoc_existing',
+    oauthClientSecretEncrypted: null,
+    settings: {},
+    createdById: 'user-1',
+    updatedById: 'user-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as IntegrationOauthConnection;
+}
+
+describe('IntegrationOAuthConnectionService', () => {
+  let registry: IntegrationOAuthRegistry;
+  let repo: {
+    find: jest.Mock;
+    listByWorkspace: jest.Mock;
+    upsert: jest.Mock;
+  };
+  let service: IntegrationOAuthConnectionService;
+
+  function buildService(manifestOverrides: Partial<IntegrationManifest> = {}) {
+    registry = new IntegrationOAuthRegistry();
+    registry.register({
+      id: 'windshift',
+      name: 'Windshift',
+      baseUrl: () => '',
+      authorizePath: '/oauth/authorize',
+      tokenPath: '/api/oauth/token',
+      scopes: ['items:read', 'workspaces:read', 'collections:read'],
+      scopeSeparator: ' ',
+      pkce: true,
+      dynamicClientRegistration: {
+        path: '/api/oauth/register',
+        clientName: 'Docmost Windshift',
+      },
+      clientIdEnv: 'WINDSHIFT_OAUTH_CLIENT_ID',
+      ...manifestOverrides,
+    });
+    repo = {
+      find: jest.fn().mockResolvedValue(undefined),
+      listByWorkspace: jest.fn().mockResolvedValue([]),
+      upsert: jest.fn(async (input) => row(input)),
+    };
+    service = new IntegrationOAuthConnectionService(
+      registry,
+      repo as unknown as IntegrationOAuthConnectionRepo,
+      {
+        getAppUrl: () => 'https://docmost.example',
+        getAppSecret: () => 'test-app-secret-with-enough-entropy',
+      } as unknown as EnvironmentService,
+      { get: () => undefined } as unknown as ConfigService,
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    buildService();
+  });
+
+  it('registers and persists a public client when saving a dynamic provider', async () => {
+    outboundFetchMock.mockResolvedValue(
+      fakeResponse(201, { client_id: 'wsoc_registered' }),
+    );
+
+    const result = await service.save(
+      'workspace-1',
+      'windshift:connection-1',
+      'user-1',
+      {
+        baseUrl: 'https://windshift.example/',
+        enabled: true,
+        settings: {},
+      },
+    );
+
+    expect(outboundFetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = outboundFetchMock.mock.calls[0];
+    expect(url).toBe('https://windshift.example/api/oauth/register');
+    expect(init).toMatchObject({
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+      },
+    });
+    expect(JSON.parse(init!.body as string)).toEqual({
+      client_name: 'Docmost Windshift',
+      redirect_uris: [
+        'https://docmost.example/api/integrations/oauth/windshift%3Aconnection-1/callback',
+      ],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      scope: 'items:read workspaces:read collections:read',
+    });
+    expect(repo.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oauthClientId: 'wsoc_registered',
+        oauthClientSecretEncrypted: null,
+      }),
+    );
+    expect(result).toMatchObject({
+      oauthClientId: 'wsoc_registered',
+      hasClientSecret: false,
+      automaticClientRegistration: true,
+    });
+  });
+
+  it('reuses the existing public client while the provider base URL is unchanged', async () => {
+    repo.find.mockResolvedValue(row());
+
+    await service.save('workspace-1', 'windshift:connection-1', 'user-1', {
+      baseUrl: 'https://windshift.example',
+      enabled: true,
+    });
+
+    expect(outboundFetchMock).not.toHaveBeenCalled();
+    expect(repo.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oauthClientId: 'wsoc_existing',
+        oauthClientSecretEncrypted: null,
+      }),
+    );
+  });
+
+  it('does not persist a connection when dynamic registration fails', async () => {
+    outboundFetchMock.mockResolvedValue(
+      fakeResponse(400, { error: 'invalid_client_metadata' }),
+    );
+
+    await expect(
+      service.save('workspace-1', 'windshift:connection-1', 'user-1', {
+        baseUrl: 'https://windshift.example',
+        enabled: true,
+      }),
+    ).rejects.toThrow(
+      new BadRequestException(
+        'Could not register an OAuth client with Windshift: registration endpoint returned 400',
+      ),
+    );
+    expect(repo.upsert).not.toHaveBeenCalled();
+  });
+
+  it('still requires an explicit client ID for manually configured providers', async () => {
+    buildService({ dynamicClientRegistration: undefined });
+
+    await expect(
+      service.save('workspace-1', 'windshift:connection-1', 'user-1', {
+        baseUrl: 'https://windshift.example',
+      }),
+    ).rejects.toThrow('OAuth client ID is required');
+    expect(repo.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/integrations/integration-oauth/integration-oauth-connection.service.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth-connection.service.ts
@@ -1,0 +1,393 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { IntegrationOauthConnection } from '@docmost/db/types/entity.types';
+import {
+  decryptString,
+  encryptString,
+} from '../../common/helpers/encryption.helper';
+import { EnvironmentService } from '../environment/environment.service';
+import {
+  IntegrationConnectionSettingField,
+  IntegrationManifest,
+  resolveBaseUrl,
+} from './manifest.types';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import { IntegrationOAuthConnectionRepo } from './integration-oauth-connection.repo';
+import { assertAllowedOutboundUrl } from './outbound-url-guard';
+
+const CLIENT_SECRET_ENCRYPTION_INFO = 'integration-oauth-client-secret-v1';
+
+export interface ResolvedIntegrationOAuthConnection {
+  integrationId: string;
+  providerId: string;
+  workspaceId: string;
+  enabled: boolean;
+  source: 'workspace' | 'env';
+  baseUrl: string;
+  oauthClientId: string;
+  oauthClientSecret?: string;
+  /** Manifest-declared connection settings, validated at save time. */
+  settings: Record<string, string>;
+}
+
+/** Setting field copy exposed to the admin UI (no validation internals). */
+export interface PublicIntegrationConnectionSettingField {
+  key: string;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  required: boolean;
+}
+
+export interface PublicIntegrationOAuthConnection {
+  integrationId: string;
+  providerId: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  enabled: boolean;
+  configured: boolean;
+  source?: 'workspace' | 'env';
+  baseUrl?: string;
+  baseUrlPlaceholder?: string;
+  oauthClientId?: string;
+  hasClientSecret: boolean;
+  settings?: Record<string, string>;
+  settingsFields: PublicIntegrationConnectionSettingField[];
+  redirectUri: string;
+  scopes: string[];
+}
+
+export interface SaveIntegrationOAuthConnectionInput {
+  enabled?: boolean;
+  baseUrl: string;
+  oauthClientId: string;
+  oauthClientSecret?: string | null;
+  settings?: Record<string, unknown>;
+}
+
+@Injectable()
+export class IntegrationOAuthConnectionService {
+  constructor(
+    private readonly registry: IntegrationOAuthRegistry,
+    private readonly repo: IntegrationOAuthConnectionRepo,
+    private readonly environmentService: EnvironmentService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async listAdmin(
+    workspaceId: string,
+  ): Promise<PublicIntegrationOAuthConnection[]> {
+    const rows = await this.repo.listByWorkspace(workspaceId);
+    const configured = rows.map((row) => {
+      const manifest = this.registry.requireForIntegrationId(row.integrationId);
+      return this.toPublicWorkspaceConnection(row, manifest);
+    });
+
+    const rowProviderIds = new Set(
+      rows.map((row) => this.registry.providerIdFor(row.integrationId)),
+    );
+    const providerPlaceholders = this.registry
+      .list()
+      .filter((manifest) => !rowProviderIds.has(manifest.id))
+      .map((manifest) => {
+        const env = this.resolveEnv(manifest, workspaceId);
+        return {
+          integrationId: manifest.id,
+          providerId: manifest.id,
+          name: manifest.name,
+          description: manifest.description,
+          icon: manifest.icon,
+          enabled: env?.enabled ?? false,
+          configured: !!env,
+          source: env?.source,
+          baseUrl: env?.baseUrl,
+          baseUrlPlaceholder: manifest.baseUrlPlaceholder,
+          oauthClientId: env?.oauthClientId,
+          hasClientSecret: !!env?.oauthClientSecret,
+          settings: env?.settings,
+          settingsFields: this.publicSettingsFields(manifest),
+          redirectUri: this.callbackUrl(manifest.id),
+          scopes: manifest.scopes,
+        };
+      });
+
+    return [...configured, ...providerPlaceholders];
+  }
+
+  async listConfigured(
+    workspaceId: string,
+  ): Promise<Map<string, ResolvedIntegrationOAuthConnection>> {
+    const out = new Map<string, ResolvedIntegrationOAuthConnection>();
+    const rows = await this.repo.listByWorkspace(workspaceId);
+    const rowProviderIds = new Set<string>();
+
+    for (const row of rows) {
+      rowProviderIds.add(this.registry.providerIdFor(row.integrationId));
+      const resolved = await this.resolve(workspaceId, row.integrationId);
+      if (resolved?.enabled) out.set(row.integrationId, resolved);
+    }
+
+    for (const manifest of this.registry.list()) {
+      if (rowProviderIds.has(manifest.id)) continue;
+      const resolved = await this.resolve(workspaceId, manifest.id);
+      if (resolved?.enabled) out.set(manifest.id, resolved);
+    }
+    return out;
+  }
+
+  async resolve(
+    workspaceId: string,
+    integrationId: string,
+  ): Promise<ResolvedIntegrationOAuthConnection | null> {
+    const manifest = this.registry.requireForIntegrationId(integrationId);
+    const row = await this.repo.find(workspaceId, integrationId);
+    if (row) {
+      return {
+        integrationId,
+        providerId: manifest.id,
+        workspaceId,
+        enabled: row.enabled,
+        source: 'workspace',
+        baseUrl: row.baseUrl,
+        oauthClientId: row.oauthClientId,
+        oauthClientSecret: row.oauthClientSecretEncrypted
+          ? decryptString(
+              row.oauthClientSecretEncrypted,
+              this.environmentService.getAppSecret(),
+              CLIENT_SECRET_ENCRYPTION_INFO,
+            )
+          : undefined,
+        settings: this.rowSettings(row),
+      };
+    }
+    if (integrationId === manifest.id) {
+      return this.resolveEnv(manifest, workspaceId);
+    }
+    return null;
+  }
+
+  async requireEnabled(
+    workspaceId: string,
+    integrationId: string,
+  ): Promise<ResolvedIntegrationOAuthConnection> {
+    const resolved = await this.resolve(workspaceId, integrationId);
+    if (!resolved?.enabled) {
+      throw new BadRequestException(
+        `Integration is not configured: ${integrationId}`,
+      );
+    }
+    return resolved;
+  }
+
+  async save(
+    workspaceId: string,
+    integrationId: string,
+    actorUserId: string,
+    input: SaveIntegrationOAuthConnectionInput,
+  ): Promise<PublicIntegrationOAuthConnection> {
+    const manifest = this.registry.requireForIntegrationId(integrationId);
+    const current = await this.repo.find(workspaceId, integrationId);
+    const baseUrl = this.normalizeBaseUrl(input.baseUrl);
+    // Fail fast with a friendly 400 when the deployment restricts integration
+    // egress; the dial-time guard in outbound-url-guard.ts stays authoritative.
+    try {
+      await assertAllowedOutboundUrl(baseUrl);
+    } catch (err) {
+      throw new BadRequestException((err as Error).message);
+    }
+    const oauthClientId = input.oauthClientId.trim();
+    if (!oauthClientId) {
+      throw new BadRequestException('OAuth client ID is required');
+    }
+
+    const envSecret = this.resolveEnv(manifest, workspaceId)?.oauthClientSecret;
+    let oauthClientSecretEncrypted =
+      current?.oauthClientSecretEncrypted ?? null;
+    if (
+      !current &&
+      typeof input.oauthClientSecret === 'undefined' &&
+      envSecret
+    ) {
+      oauthClientSecretEncrypted = encryptString(
+        envSecret,
+        this.environmentService.getAppSecret(),
+        CLIENT_SECRET_ENCRYPTION_INFO,
+      );
+    }
+    if (typeof input.oauthClientSecret !== 'undefined') {
+      const raw = input.oauthClientSecret?.trim() ?? '';
+      oauthClientSecretEncrypted = raw
+        ? encryptString(
+            raw,
+            this.environmentService.getAppSecret(),
+            CLIENT_SECRET_ENCRYPTION_INFO,
+          )
+        : null;
+    }
+
+    const settings = this.normalizeSettings(manifest, input.settings);
+
+    const row = await this.repo.upsert({
+      workspaceId,
+      integrationId,
+      enabled: input.enabled ?? true,
+      baseUrl,
+      oauthClientId,
+      oauthClientSecretEncrypted,
+      settings,
+      actorUserId,
+    });
+
+    return this.toPublicWorkspaceConnection(row, manifest);
+  }
+
+  callbackUrl(integrationId: string): string {
+    return `${this.environmentService.getAppUrl()}/api/integrations/oauth/${encodeURIComponent(integrationId)}/callback`;
+  }
+
+  private toPublicWorkspaceConnection(
+    row: IntegrationOauthConnection,
+    manifest: IntegrationManifest,
+  ): PublicIntegrationOAuthConnection {
+    return {
+      integrationId: row.integrationId,
+      providerId: manifest.id,
+      name: manifest.name,
+      description: manifest.description,
+      icon: manifest.icon,
+      enabled: row.enabled,
+      configured: true,
+      source: 'workspace',
+      baseUrl: row.baseUrl,
+      baseUrlPlaceholder: manifest.baseUrlPlaceholder,
+      oauthClientId: row.oauthClientId,
+      hasClientSecret: !!row.oauthClientSecretEncrypted,
+      settings: this.rowSettings(row),
+      settingsFields: this.publicSettingsFields(manifest),
+      redirectUri: this.callbackUrl(row.integrationId),
+      scopes: manifest.scopes,
+    };
+  }
+
+  /**
+   * Validates and normalizes admin-supplied settings against the manifest's
+   * declared fields. Unknown keys are dropped; values are trimmed and
+   * transformed before the pattern check.
+   */
+  private normalizeSettings(
+    manifest: IntegrationManifest,
+    raw: Record<string, unknown> | undefined,
+  ): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const field of manifest.connectionSettings ?? []) {
+      const value = this.normalizeSettingValue(field, raw?.[field.key]);
+      if (value !== null) out[field.key] = value;
+    }
+    return out;
+  }
+
+  private normalizeSettingValue(
+    field: IntegrationConnectionSettingField,
+    raw: unknown,
+  ): string | null {
+    const trimmed = typeof raw === 'string' ? raw.trim() : '';
+    if (!trimmed) {
+      if (field.required) {
+        throw new BadRequestException(`${field.label} is required`);
+      }
+      return null;
+    }
+    const value =
+      field.transform === 'uppercase'
+        ? trimmed.toUpperCase()
+        : field.transform === 'lowercase'
+          ? trimmed.toLowerCase()
+          : trimmed;
+    if (field.pattern && !new RegExp(field.pattern).test(value)) {
+      throw new BadRequestException(`${field.label} is invalid`);
+    }
+    return value;
+  }
+
+  private publicSettingsFields(
+    manifest: IntegrationManifest,
+  ): PublicIntegrationConnectionSettingField[] {
+    return (manifest.connectionSettings ?? []).map((field) => ({
+      key: field.key,
+      label: field.label,
+      description: field.description,
+      placeholder: field.placeholder,
+      required: field.required ?? false,
+    }));
+  }
+
+  private rowSettings(row: IntegrationOauthConnection): Record<string, string> {
+    let raw: unknown = row.settings;
+    // Tolerate rows persisted as a jsonb string scalar (double-encoded by an
+    // earlier driver/serializer combination) by unwrapping one level.
+    if (typeof raw === 'string') {
+      try {
+        raw = JSON.parse(raw);
+      } catch {
+        return {};
+      }
+    }
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(raw)) {
+      if (typeof value === 'string') out[key] = value;
+    }
+    return out;
+  }
+
+  private resolveEnv(
+    manifest: IntegrationManifest,
+    workspaceId: string,
+  ): ResolvedIntegrationOAuthConnection | null {
+    const baseUrl = this.normalizeOptionalBaseUrl(resolveBaseUrl(manifest));
+    const oauthClientId =
+      this.configService.get<string>(manifest.clientIdEnv) || '';
+    if (!baseUrl || !oauthClientId) return null;
+    return {
+      integrationId: manifest.id,
+      providerId: manifest.id,
+      workspaceId,
+      enabled: true,
+      source: 'env',
+      baseUrl,
+      oauthClientId,
+      oauthClientSecret: manifest.clientSecretEnv
+        ? this.configService.get<string>(manifest.clientSecretEnv) || undefined
+        : undefined,
+      settings: {},
+    };
+  }
+
+  private normalizeOptionalBaseUrl(raw: string): string | null {
+    if (!raw) return null;
+    try {
+      return this.normalizeBaseUrl(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  private normalizeBaseUrl(raw: string): string {
+    const trimmed = raw.trim();
+    if (!trimmed) throw new BadRequestException('Base URL is required');
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      throw new BadRequestException('Base URL must be a valid URL');
+    }
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      throw new BadRequestException('Base URL must use http or https');
+    }
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString().replace(/\/+$/, '');
+  }
+}

--- a/apps/server/src/integrations/integration-oauth/integration-oauth-connection.service.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth-connection.service.ts
@@ -13,7 +13,11 @@ import {
 } from './manifest.types';
 import { IntegrationOAuthRegistry } from './manifest.registry';
 import { IntegrationOAuthConnectionRepo } from './integration-oauth-connection.repo';
-import { assertAllowedOutboundUrl } from './outbound-url-guard';
+import {
+  assertAllowedOutboundUrl,
+  outboundFetch,
+  readOutboundBody,
+} from './outbound-url-guard';
 
 const CLIENT_SECRET_ENCRYPTION_INFO = 'integration-oauth-client-secret-v1';
 
@@ -52,6 +56,7 @@ export interface PublicIntegrationOAuthConnection {
   baseUrlPlaceholder?: string;
   oauthClientId?: string;
   hasClientSecret: boolean;
+  automaticClientRegistration: boolean;
   settings?: Record<string, string>;
   settingsFields: PublicIntegrationConnectionSettingField[];
   redirectUri: string;
@@ -61,7 +66,7 @@ export interface PublicIntegrationOAuthConnection {
 export interface SaveIntegrationOAuthConnectionInput {
   enabled?: boolean;
   baseUrl: string;
-  oauthClientId: string;
+  oauthClientId?: string;
   oauthClientSecret?: string | null;
   settings?: Record<string, unknown>;
 }
@@ -105,6 +110,7 @@ export class IntegrationOAuthConnectionService {
           baseUrlPlaceholder: manifest.baseUrlPlaceholder,
           oauthClientId: env?.oauthClientId,
           hasClientSecret: !!env?.oauthClientSecret,
+          automaticClientRegistration: !!manifest.dynamicClientRegistration,
           settings: env?.settings,
           settingsFields: this.publicSettingsFields(manifest),
           redirectUri: this.callbackUrl(manifest.id),
@@ -196,34 +202,50 @@ export class IntegrationOAuthConnectionService {
     } catch (err) {
       throw new BadRequestException((err as Error).message);
     }
-    const oauthClientId = input.oauthClientId.trim();
+    const registeredClient = manifest.dynamicClientRegistration
+      ? await this.resolveDynamicClient(
+          manifest,
+          integrationId,
+          baseUrl,
+          current,
+        )
+      : null;
+    const oauthClientId =
+      registeredClient?.clientId ?? input.oauthClientId?.trim() ?? '';
     if (!oauthClientId) {
       throw new BadRequestException('OAuth client ID is required');
     }
 
-    const envSecret = this.resolveEnv(manifest, workspaceId)?.oauthClientSecret;
-    let oauthClientSecretEncrypted =
-      current?.oauthClientSecretEncrypted ?? null;
-    if (
-      !current &&
-      typeof input.oauthClientSecret === 'undefined' &&
-      envSecret
-    ) {
-      oauthClientSecretEncrypted = encryptString(
-        envSecret,
-        this.environmentService.getAppSecret(),
-        CLIENT_SECRET_ENCRYPTION_INFO,
-      );
-    }
-    if (typeof input.oauthClientSecret !== 'undefined') {
-      const raw = input.oauthClientSecret?.trim() ?? '';
-      oauthClientSecretEncrypted = raw
-        ? encryptString(
-            raw,
-            this.environmentService.getAppSecret(),
-            CLIENT_SECRET_ENCRYPTION_INFO,
-          )
-        : null;
+    let oauthClientSecretEncrypted: string | null;
+    if (registeredClient) {
+      oauthClientSecretEncrypted = null;
+    } else {
+      const envSecret = this.resolveEnv(
+        manifest,
+        workspaceId,
+      )?.oauthClientSecret;
+      oauthClientSecretEncrypted = current?.oauthClientSecretEncrypted ?? null;
+      if (
+        !current &&
+        typeof input.oauthClientSecret === 'undefined' &&
+        envSecret
+      ) {
+        oauthClientSecretEncrypted = encryptString(
+          envSecret,
+          this.environmentService.getAppSecret(),
+          CLIENT_SECRET_ENCRYPTION_INFO,
+        );
+      }
+      if (typeof input.oauthClientSecret !== 'undefined') {
+        const raw = input.oauthClientSecret?.trim() ?? '';
+        oauthClientSecretEncrypted = raw
+          ? encryptString(
+              raw,
+              this.environmentService.getAppSecret(),
+              CLIENT_SECRET_ENCRYPTION_INFO,
+            )
+          : null;
+      }
     }
 
     const settings = this.normalizeSettings(manifest, input.settings);
@@ -263,6 +285,7 @@ export class IntegrationOAuthConnectionService {
       baseUrlPlaceholder: manifest.baseUrlPlaceholder,
       oauthClientId: row.oauthClientId,
       hasClientSecret: !!row.oauthClientSecretEncrypted,
+      automaticClientRegistration: !!manifest.dynamicClientRegistration,
       settings: this.rowSettings(row),
       settingsFields: this.publicSettingsFields(manifest),
       redirectUri: this.callbackUrl(row.integrationId),
@@ -362,6 +385,59 @@ export class IntegrationOAuthConnectionService {
         : undefined,
       settings: {},
     };
+  }
+
+  private async resolveDynamicClient(
+    manifest: IntegrationManifest,
+    integrationId: string,
+    baseUrl: string,
+    current: IntegrationOauthConnection | undefined,
+  ): Promise<{ clientId: string }> {
+    if (
+      current?.baseUrl === baseUrl &&
+      current.oauthClientId &&
+      !current.oauthClientSecretEncrypted
+    ) {
+      return { clientId: current.oauthClientId };
+    }
+
+    const registration = manifest.dynamicClientRegistration!;
+    const registrationUrl = new URL(
+      registration.path,
+      `${baseUrl}/`,
+    ).toString();
+    const payload = {
+      client_name: registration.clientName ?? `Docmost ${manifest.name}`,
+      redirect_uris: [this.callbackUrl(integrationId)],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      scope: manifest.scopes.join(manifest.scopeSeparator ?? ' '),
+    };
+
+    try {
+      const response = await outboundFetch(registrationUrl, {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+      const body = await readOutboundBody(response);
+      if (!response.ok) {
+        throw new Error(`registration endpoint returned ${response.status}`);
+      }
+      const result = JSON.parse(body) as { client_id?: unknown };
+      if (typeof result.client_id !== 'string' || !result.client_id.trim()) {
+        throw new Error('registration response did not include client_id');
+      }
+      return { clientId: result.client_id.trim() };
+    } catch (err) {
+      throw new BadRequestException(
+        `Could not register an OAuth client with ${manifest.name}: ${(err as Error).message}`,
+      );
+    }
   }
 
   private normalizeOptionalBaseUrl(raw: string): string | null {

--- a/apps/server/src/integrations/integration-oauth/integration-oauth-token.repo.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth-token.repo.ts
@@ -1,0 +1,93 @@
+import { Injectable } from '@nestjs/common';
+import { InjectKysely } from 'nestjs-kysely';
+import { sql } from 'kysely';
+import { KyselyDB } from '@docmost/db/types/kysely.types';
+import {
+  IntegrationOauthToken,
+  InsertableIntegrationOauthToken,
+} from '@docmost/db/types/entity.types';
+
+/**
+ * Token vault keyed `(user_id, workspace_id, integration_id)` — one row per
+ * user per workspace-scoped integration. Deals only in already-encrypted blobs;
+ * never sees plaintext.
+ */
+@Injectable()
+export class IntegrationOAuthTokenRepo {
+  constructor(@InjectKysely() private readonly db: KyselyDB) {}
+
+  async findByUserWorkspaceAndIntegration(
+    userId: string,
+    workspaceId: string,
+    integrationId: string,
+  ): Promise<IntegrationOauthToken | undefined> {
+    return this.db
+      .selectFrom('integrationOauthTokens')
+      .selectAll()
+      .where('userId', '=', userId)
+      .where('workspaceId', '=', workspaceId)
+      .where('integrationId', '=', integrationId)
+      .executeTakeFirst();
+  }
+
+  async listByUserWorkspace(
+    userId: string,
+    workspaceId: string,
+  ): Promise<IntegrationOauthToken[]> {
+    return this.db
+      .selectFrom('integrationOauthTokens')
+      .selectAll()
+      .where('userId', '=', userId)
+      .where('workspaceId', '=', workspaceId)
+      .orderBy('integrationId', 'asc')
+      .execute();
+  }
+
+  /** Used both on initial connect and after refresh-token rotation. */
+  async upsert(
+    row: InsertableIntegrationOauthToken,
+  ): Promise<IntegrationOauthToken> {
+    return this.db
+      .insertInto('integrationOauthTokens')
+      .values(row)
+      .onConflict((oc) =>
+        oc.columns(['userId', 'workspaceId', 'integrationId']).doUpdateSet({
+          accessTokenEncrypted: row.accessTokenEncrypted,
+          refreshTokenEncrypted: row.refreshTokenEncrypted ?? null,
+          expiresAt: row.expiresAt ?? null,
+          scopes: row.scopes ?? '',
+          needsReconnect: false,
+          updatedAt: sql`now()`,
+        }),
+      )
+      .returningAll()
+      .executeTakeFirstOrThrow();
+  }
+
+  async markNeedsReconnect(
+    userId: string,
+    workspaceId: string,
+    integrationId: string,
+  ): Promise<void> {
+    await this.db
+      .updateTable('integrationOauthTokens')
+      .set({ needsReconnect: true, updatedAt: sql`now()` })
+      .where('userId', '=', userId)
+      .where('workspaceId', '=', workspaceId)
+      .where('integrationId', '=', integrationId)
+      .execute();
+  }
+
+  async delete(
+    userId: string,
+    workspaceId: string,
+    integrationId: string,
+  ): Promise<void> {
+    await this.db
+      .deleteFrom('integrationOauthTokens')
+      .where('userId', '=', userId)
+      .where('workspaceId', '=', workspaceId)
+      .where('integrationId', '=', integrationId)
+      .execute();
+  }
+}

--- a/apps/server/src/integrations/integration-oauth/integration-oauth.controller.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth.controller.ts
@@ -1,0 +1,194 @@
+import {
+  BadRequestException,
+  Controller,
+  Delete,
+  Get,
+  Logger,
+  NotFoundException,
+  Param,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { FastifyReply } from 'fastify';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { AuthUser } from '../../common/decorators/auth-user.decorator';
+import { AuthWorkspace } from '../../common/decorators/auth-workspace.decorator';
+import { User, Workspace } from '@docmost/db/types/entity.types';
+import { EnvironmentService } from '../environment/environment.service';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import { IntegrationOAuthService } from './integration-oauth.service';
+import { IntegrationOAuthTokenRepo } from './integration-oauth-token.repo';
+import { IntegrationOAuthConnectionService } from './integration-oauth-connection.service';
+import {
+  PublicIntegrationResourceManifest,
+  toPublicResourceManifest,
+} from './resource.types';
+
+/**
+ * Explicit 302 + Location + send. NestJS+Fastify's `reply.redirect(url)`
+ * alone gets ignored in some configurations (the response goes out as a 200
+ * with empty body instead) — being explicit avoids the framework guessing.
+ */
+function sendRedirect(reply: FastifyReply, url: string): void {
+  reply.code(302).header('location', url).send();
+}
+
+interface IntegrationListItem {
+  id: string;
+  providerId: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  /** Connection base URL — lets the editor match pasted provider links. */
+  baseUrl: string;
+  scopes: string[];
+  connected: boolean;
+  needsReconnect: boolean;
+  connectedAt?: string;
+  expiresAt?: string;
+  resources: PublicIntegrationResourceManifest[];
+}
+
+// Mounts under the app's global `/api` prefix → `/api/integrations/oauth/*`.
+@Controller('integrations/oauth')
+@UseGuards(JwtAuthGuard)
+export class IntegrationOAuthController {
+  private readonly logger = new Logger(IntegrationOAuthController.name);
+
+  constructor(
+    private readonly registry: IntegrationOAuthRegistry,
+    private readonly oauthService: IntegrationOAuthService,
+    private readonly tokenRepo: IntegrationOAuthTokenRepo,
+    private readonly connectionService: IntegrationOAuthConnectionService,
+    private readonly environmentService: EnvironmentService,
+  ) {}
+
+  /** Manifests + per-user connection state for the settings UI. */
+  @Get()
+  async list(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ): Promise<IntegrationListItem[]> {
+    const tokens = await this.tokenRepo.listByUserWorkspace(
+      user.id,
+      workspace.id,
+    );
+    const configured = await this.connectionService.listConfigured(
+      workspace.id,
+    );
+    const tokensByIntegration = new Map(
+      tokens.map((t) => [t.integrationId, t]),
+    );
+    return [...configured.values()].map((connection) => {
+      const manifest = this.registry.require(connection.providerId);
+      const token = tokensByIntegration.get(connection.integrationId);
+      return {
+        id: connection.integrationId,
+        providerId: connection.providerId,
+        name: manifest.name,
+        description: manifest.description,
+        icon: manifest.icon,
+        baseUrl: connection.baseUrl,
+        scopes: manifest.scopes,
+        connected: !!token,
+        needsReconnect: token?.needsReconnect ?? false,
+        connectedAt:
+          token?.createdAt instanceof Date
+            ? token.createdAt.toISOString()
+            : undefined,
+        expiresAt:
+          token?.expiresAt instanceof Date
+            ? token.expiresAt.toISOString()
+            : undefined,
+        resources: (manifest.resources ?? []).map(toPublicResourceManifest),
+      };
+    });
+  }
+
+  /** Starts the OAuth flow. */
+  @Get(':integrationId/authorize')
+  async authorize(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+    @Param('integrationId') integrationId: string,
+    @Query('returnTo') returnTo: string | undefined,
+    @Res() reply: FastifyReply,
+  ): Promise<void> {
+    if (!this.registry.getForIntegrationId(integrationId)) {
+      throw new NotFoundException(`Unknown integration: ${integrationId}`);
+    }
+    // Relative paths only — guards against open-redirect via returnTo.
+    const safeReturnTo =
+      returnTo && returnTo.startsWith('/') && !returnTo.startsWith('//')
+        ? returnTo
+        : undefined;
+    const { url } = await this.oauthService.startAuthorize({
+      integrationId,
+      workspaceId: workspace.id,
+      userId: user.id,
+      returnTo: safeReturnTo,
+    });
+    sendRedirect(reply, url);
+  }
+
+  /** Provider redirects here after the user approves or denies. */
+  @Get(':integrationId/callback')
+  async callback(
+    @Param('integrationId') integrationId: string,
+    @Query('code') code: string,
+    @Query('state') stateToken: string,
+    @Query('error') error: string | undefined,
+    @Query('error_description') errorDescription: string | undefined,
+    @Res() reply: FastifyReply,
+  ): Promise<void> {
+    if (!this.registry.getForIntegrationId(integrationId)) {
+      throw new NotFoundException(`Unknown integration: ${integrationId}`);
+    }
+    const settingsUrl = `${this.environmentService.getAppUrl()}/settings/account/integrations`;
+    if (error) {
+      const reason = encodeURIComponent(errorDescription ?? error);
+      sendRedirect(
+        reply,
+        `${settingsUrl}?error=${reason}&integration=${integrationId}`,
+      );
+      return;
+    }
+    if (!code || !stateToken) {
+      throw new BadRequestException('Missing code or state');
+    }
+    try {
+      const { returnTo } = await this.oauthService.completeCallback({
+        integrationId,
+        code,
+        stateToken,
+      });
+      const dest = returnTo
+        ? `${this.environmentService.getAppUrl()}${returnTo}`
+        : `${settingsUrl}?connected=true&integration=${integrationId}`;
+      sendRedirect(reply, dest);
+    } catch (err) {
+      this.logger.warn(
+        `OAuth callback failed for integration=${integrationId}: ${(err as Error).message}`,
+      );
+      sendRedirect(
+        reply,
+        `${settingsUrl}?error=callback_failed&integration=${integrationId}`,
+      );
+    }
+  }
+
+  /** Revoke the user's workspace-scoped connection — deletes the token row. */
+  @Delete(':integrationId/connection')
+  async disconnect(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+    @Param('integrationId') integrationId: string,
+  ): Promise<{ disconnected: boolean }> {
+    if (!this.registry.getForIntegrationId(integrationId)) {
+      throw new NotFoundException(`Unknown integration: ${integrationId}`);
+    }
+    await this.oauthService.disconnect(user.id, workspace.id, integrationId);
+    return { disconnected: true };
+  }
+}

--- a/apps/server/src/integrations/integration-oauth/integration-oauth.module.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth.module.ts
@@ -1,0 +1,42 @@
+import { Global, Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { EnvironmentModule } from '../environment/environment.module';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import { IntegrationOAuthTokenRepo } from './integration-oauth-token.repo';
+import { IntegrationOAuthConnectionRepo } from './integration-oauth-connection.repo';
+import { IntegrationOAuthConnectionService } from './integration-oauth-connection.service';
+import { IntegrationOAuthService } from './integration-oauth.service';
+import { IntegrationOAuthClientService } from './integration-oauth-client.service';
+import { IntegrationOAuthController } from './integration-oauth.controller';
+import { IntegrationOAuthAdminController } from './integration-oauth-admin.controller';
+import { IntegrationResourceController } from './integration-resource.controller';
+
+/**
+ * Generic third-party-OAuth framework. Consumer modules declare an
+ * IntegrationManifest and call IntegrationOAuthRegistry.register() at boot.
+ * @Global so consumers don't have to re-import this everywhere.
+ */
+@Global()
+@Module({
+  imports: [ConfigModule, EnvironmentModule],
+  controllers: [
+    IntegrationOAuthAdminController,
+    IntegrationOAuthController,
+    IntegrationResourceController,
+  ],
+  providers: [
+    IntegrationOAuthRegistry,
+    IntegrationOAuthTokenRepo,
+    IntegrationOAuthConnectionRepo,
+    IntegrationOAuthConnectionService,
+    IntegrationOAuthService,
+    IntegrationOAuthClientService,
+  ],
+  exports: [
+    IntegrationOAuthRegistry,
+    IntegrationOAuthConnectionService,
+    IntegrationOAuthService,
+    IntegrationOAuthClientService,
+  ],
+})
+export class IntegrationOAuthModule {}

--- a/apps/server/src/integrations/integration-oauth/integration-oauth.service.spec.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth.service.spec.ts
@@ -1,0 +1,305 @@
+import { createHash } from 'node:crypto';
+import { Cache } from 'cache-manager';
+import { IntegrationOAuthService } from './integration-oauth.service';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import { IntegrationManifest } from './manifest.types';
+import { IntegrationOAuthTokenRepo } from './integration-oauth-token.repo';
+import { IntegrationOAuthConnectionService } from './integration-oauth-connection.service';
+import { EnvironmentService } from '../environment/environment.service';
+import { decryptString } from '../../common/helpers/encryption.helper';
+import { outboundFetch } from './outbound-url-guard';
+
+jest.mock('./outbound-url-guard', () => {
+  const actual = jest.requireActual('./outbound-url-guard');
+  return {
+    ...actual,
+    outboundFetch: jest.fn(),
+    readOutboundBody: jest.fn((resp: { __body?: string }) =>
+      Promise.resolve(resp.__body ?? ''),
+    ),
+  };
+});
+
+const APP_SECRET = 'test-app-secret-with-enough-entropy-0123456789';
+const INTEGRATION_ID = 'alpha:1111';
+const TOKEN_INFO = 'integration-oauth-token-v1';
+
+const outboundFetchMock = outboundFetch as jest.MockedFunction<typeof outboundFetch>;
+
+function fakeResponse(status: number, body: unknown) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: () => 'application/json' },
+    __body: JSON.stringify(body),
+  } as never;
+}
+
+function memoryCache(): Cache {
+  const store = new Map<string, unknown>();
+  return {
+    get: jest.fn(async (key: string) => store.get(key)),
+    set: jest.fn(async (key: string, value: unknown) => {
+      store.set(key, value);
+    }),
+    del: jest.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  } as unknown as Cache;
+}
+
+describe('IntegrationOAuthService', () => {
+  let registry: IntegrationOAuthRegistry;
+  let tokenRepo: { upsert: jest.Mock; findByUserWorkspaceAndIntegration: jest.Mock };
+  let connectionService: { requireEnabled: jest.Mock; callbackUrl: jest.Mock };
+  let cache: Cache;
+  let service: IntegrationOAuthService;
+
+  function buildService(manifestOverrides: Partial<IntegrationManifest> = {}) {
+    registry = new IntegrationOAuthRegistry();
+    registry.register({
+      id: 'alpha',
+      name: 'Alpha',
+      baseUrl: () => 'https://provider.example.com',
+      authorizePath: '/oauth/authorize',
+      tokenPath: '/oauth/token',
+      scopes: ['items:read', 'workspaces:read'],
+      scopeSeparator: ' ',
+      pkce: true,
+      clientIdEnv: 'TEST_CLIENT_ID',
+      clientSecretEnv: 'TEST_CLIENT_SECRET',
+      ...manifestOverrides,
+    } as IntegrationManifest);
+
+    tokenRepo = {
+      upsert: jest.fn().mockResolvedValue({}),
+      findByUserWorkspaceAndIntegration: jest.fn().mockResolvedValue(null),
+    };
+    connectionService = {
+      requireEnabled: jest.fn().mockResolvedValue({
+        integrationId: INTEGRATION_ID,
+        baseUrl: 'https://provider.example.com',
+        oauthClientId: 'client-1',
+        oauthClientSecret: 'secret-1',
+        settings: {},
+      }),
+      callbackUrl: jest.fn(
+        (id: string) => `https://docmost.example.com/api/integrations/oauth/${id}/callback`,
+      ),
+    };
+    cache = memoryCache();
+    service = new IntegrationOAuthService(
+      registry,
+      tokenRepo as unknown as IntegrationOAuthTokenRepo,
+      connectionService as unknown as IntegrationOAuthConnectionService,
+      { getAppSecret: () => APP_SECRET } as unknown as EnvironmentService,
+      cache,
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    buildService();
+  });
+
+  async function startAuthorize() {
+    return service.startAuthorize({
+      integrationId: INTEGRATION_ID,
+      workspaceId: 'ws-1',
+      userId: 'user-1',
+      returnTo: '/settings/account/integrations',
+    });
+  }
+
+  describe('startAuthorize', () => {
+    it('builds the authorize URL with client, scopes, state, and PKCE challenge', async () => {
+      const { url } = await startAuthorize();
+      const parsed = new URL(url);
+      expect(parsed.origin + parsed.pathname).toBe(
+        'https://provider.example.com/oauth/authorize',
+      );
+      expect(parsed.searchParams.get('client_id')).toBe('client-1');
+      expect(parsed.searchParams.get('response_type')).toBe('code');
+      expect(parsed.searchParams.get('scope')).toBe('items:read workspaces:read');
+      expect(parsed.searchParams.get('redirect_uri')).toBe(
+        `https://docmost.example.com/api/integrations/oauth/${INTEGRATION_ID}/callback`,
+      );
+      expect(parsed.searchParams.get('state')).toMatch(/^[0-9a-f]{64}$/);
+      expect(parsed.searchParams.get('code_challenge')).toBeTruthy();
+      expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+    });
+
+    it('derives the S256 challenge from the stored verifier', async () => {
+      const { url } = await startAuthorize();
+      const state = new URL(url).searchParams.get('state')!;
+      const stored = await cache.get<{ codeVerifier?: string }>(
+        `integration-oauth:state:${state}`,
+      );
+      const expected = createHash('sha256')
+        .update(stored!.codeVerifier!)
+        .digest('base64url');
+      expect(new URL(url).searchParams.get('code_challenge')).toBe(expected);
+    });
+
+    it('omits PKCE params for non-PKCE providers', async () => {
+      buildService({ pkce: false });
+      const { url } = await startAuthorize();
+      expect(new URL(url).searchParams.get('code_challenge')).toBeNull();
+    });
+
+    it('issues a fresh state per authorize call', async () => {
+      const first = new URL((await startAuthorize()).url).searchParams.get('state');
+      const second = new URL((await startAuthorize()).url).searchParams.get('state');
+      expect(first).not.toBe(second);
+    });
+  });
+
+  describe('completeCallback', () => {
+    async function authorizeAndGetState(): Promise<string> {
+      const { url } = await startAuthorize();
+      return new URL(url).searchParams.get('state')!;
+    }
+
+    it('exchanges the code with the verifier and persists encrypted tokens', async () => {
+      const state = await authorizeAndGetState();
+      outboundFetchMock.mockResolvedValue(
+        fakeResponse(200, {
+          access_token: 'provider-access',
+          refresh_token: 'provider-refresh',
+          expires_in: 3600,
+          scope: 'items:read',
+        }),
+      );
+
+      const result = await service.completeCallback({
+        integrationId: INTEGRATION_ID,
+        code: 'auth-code',
+        stateToken: state,
+      });
+      expect(result).toMatchObject({
+        userId: 'user-1',
+        workspaceId: 'ws-1',
+        returnTo: '/settings/account/integrations',
+      });
+
+      const [tokenUrl, init] = outboundFetchMock.mock.calls[0];
+      expect(tokenUrl).toBe('https://provider.example.com/oauth/token');
+      const sent = new URLSearchParams(init!.body as string);
+      expect(sent.get('grant_type')).toBe('authorization_code');
+      expect(sent.get('code')).toBe('auth-code');
+      expect(sent.get('code_verifier')).toBeTruthy();
+
+      const row = tokenRepo.upsert.mock.calls[0][0];
+      expect(row.accessTokenEncrypted).not.toContain('provider-access');
+      expect(decryptString(row.accessTokenEncrypted, APP_SECRET, TOKEN_INFO)).toBe(
+        'provider-access',
+      );
+      expect(decryptString(row.refreshTokenEncrypted, APP_SECRET, TOKEN_INFO)).toBe(
+        'provider-refresh',
+      );
+    });
+
+    it('rejects replayed state: the second callback with the same token fails', async () => {
+      const state = await authorizeAndGetState();
+      outboundFetchMock.mockResolvedValue(
+        fakeResponse(200, { access_token: 'a', expires_in: 60 }),
+      );
+      await service.completeCallback({
+        integrationId: INTEGRATION_ID,
+        code: 'code-1',
+        stateToken: state,
+      });
+      await expect(
+        service.completeCallback({
+          integrationId: INTEGRATION_ID,
+          code: 'code-2',
+          stateToken: state,
+        }),
+      ).rejects.toThrow(/Invalid or expired OAuth state/);
+    });
+
+    it('rejects unknown state tokens', async () => {
+      await expect(
+        service.completeCallback({
+          integrationId: INTEGRATION_ID,
+          code: 'code',
+          stateToken: 'f'.repeat(64),
+        }),
+      ).rejects.toThrow(/Invalid or expired OAuth state/);
+    });
+
+    it('rejects a state minted for a different integration', async () => {
+      const state = await authorizeAndGetState();
+      await expect(
+        service.completeCallback({
+          integrationId: 'alpha:2222',
+          code: 'code',
+          stateToken: state,
+        }),
+      ).rejects.toThrow(/does not match callback integration/);
+    });
+
+    it('surfaces provider token-endpoint failures', async () => {
+      const state = await authorizeAndGetState();
+      outboundFetchMock.mockResolvedValue(
+        fakeResponse(400, { error: 'invalid_grant' }),
+      );
+      await expect(
+        service.completeCallback({
+          integrationId: INTEGRATION_ID,
+          code: 'bad-code',
+          stateToken: state,
+        }),
+      ).rejects.toThrow(/token exchange failed \(400\)/);
+    });
+  });
+
+  describe('refreshTokens', () => {
+    function storedRow(secret: string) {
+      const { encryptString } = jest.requireActual(
+        '../../common/helpers/encryption.helper',
+      );
+      return {
+        accessTokenEncrypted: encryptString('old-access', secret, TOKEN_INFO),
+        refreshTokenEncrypted: encryptString('old-refresh', secret, TOKEN_INFO),
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+        scopes: 'items:read',
+        needsReconnect: false,
+      };
+    }
+
+    it('keeps the previous refresh token when the provider does not rotate it', async () => {
+      tokenRepo.findByUserWorkspaceAndIntegration.mockResolvedValue(
+        storedRow(APP_SECRET),
+      );
+      outboundFetchMock.mockResolvedValue(
+        fakeResponse(200, { access_token: 'new-access', expires_in: 3600 }),
+      );
+      tokenRepo.upsert.mockImplementation(async (row) => {
+        // Subsequent getTokens reads back what was just stored.
+        tokenRepo.findByUserWorkspaceAndIntegration.mockResolvedValue({
+          ...row,
+          needsReconnect: false,
+        });
+        return row;
+      });
+
+      const refreshed = await service.refreshTokens('user-1', 'ws-1', INTEGRATION_ID);
+      expect(refreshed.accessToken).toBe('new-access');
+      expect(refreshed.refreshToken).toBe('old-refresh');
+
+      const sent = new URLSearchParams(
+        outboundFetchMock.mock.calls[0][1]!.body as string,
+      );
+      expect(sent.get('grant_type')).toBe('refresh_token');
+      expect(sent.get('refresh_token')).toBe('old-refresh');
+    });
+
+    it('throws when no refresh token is stored', async () => {
+      tokenRepo.findByUserWorkspaceAndIntegration.mockResolvedValue(null);
+      await expect(
+        service.refreshTokens('user-1', 'ws-1', INTEGRATION_ID),
+      ).rejects.toThrow(/No refresh token/);
+    });
+  });
+});

--- a/apps/server/src/integrations/integration-oauth/integration-oauth.service.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-oauth.service.ts
@@ -1,0 +1,317 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { createHash, randomBytes } from 'node:crypto';
+import {
+  encryptString,
+  decryptString,
+} from '../../common/helpers/encryption.helper';
+import { EnvironmentService } from '../environment/environment.service';
+import { outboundFetch, readOutboundBody } from './outbound-url-guard';
+import { IntegrationManifest } from './manifest.types';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import { IntegrationOAuthTokenRepo } from './integration-oauth-token.repo';
+import {
+  IntegrationOAuthConnectionService,
+  ResolvedIntegrationOAuthConnection,
+} from './integration-oauth-connection.service';
+
+const STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const STATE_PREFIX = 'integration-oauth:state:';
+const TOKEN_ENCRYPTION_INFO = 'integration-oauth-token-v1';
+
+interface OAuthState {
+  userId: string;
+  workspaceId: string;
+  integrationId: string;
+  codeVerifier?: string;
+  returnTo?: string;
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+}
+
+export interface DecryptedTokens {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: Date;
+  scopes: string;
+  needsReconnect: boolean;
+}
+
+@Injectable()
+export class IntegrationOAuthService {
+  private readonly logger = new Logger(IntegrationOAuthService.name);
+
+  constructor(
+    private readonly registry: IntegrationOAuthRegistry,
+    private readonly tokenRepo: IntegrationOAuthTokenRepo,
+    private readonly connectionService: IntegrationOAuthConnectionService,
+    private readonly environmentService: EnvironmentService,
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
+  ) {}
+
+  /** Builds the authorize redirect URL and stashes one-shot state in Redis. */
+  async startAuthorize(args: {
+    integrationId: string;
+    workspaceId: string;
+    userId: string;
+    returnTo?: string;
+  }): Promise<{ url: string }> {
+    const manifest = this.registry.requireForIntegrationId(args.integrationId);
+    const connection = await this.connectionService.requireEnabled(
+      args.workspaceId,
+      args.integrationId,
+    );
+
+    const stateToken = randomBytes(32).toString('hex');
+    const params: Record<string, string> = {
+      client_id: connection.oauthClientId,
+      redirect_uri: this.callbackUrl(connection.integrationId),
+      response_type: 'code',
+      scope: manifest.scopes.join(manifest.scopeSeparator ?? ' '),
+      state: stateToken,
+      ...(manifest.extraAuthParams ?? {}),
+    };
+
+    let codeVerifier: string | undefined;
+    if (manifest.pkce) {
+      codeVerifier = randomBytes(32).toString('base64url');
+      const challenge = createHash('sha256')
+        .update(codeVerifier)
+        .digest('base64url');
+      params.code_challenge = challenge;
+      params.code_challenge_method = 'S256';
+    }
+
+    const stateValue: OAuthState = {
+      userId: args.userId,
+      workspaceId: args.workspaceId,
+      integrationId: connection.integrationId,
+      codeVerifier,
+      returnTo: args.returnTo,
+    };
+    await this.cache.set(STATE_PREFIX + stateToken, stateValue, STATE_TTL_MS);
+
+    const url = `${connection.baseUrl}${manifest.authorizePath}?${new URLSearchParams(params).toString()}`;
+    return { url };
+  }
+
+  /** Validates+consumes the state token, exchanges the code, persists tokens. */
+  async completeCallback(args: {
+    integrationId: string;
+    code: string;
+    stateToken: string;
+  }): Promise<{ userId: string; workspaceId: string; returnTo?: string }> {
+    const stateKey = STATE_PREFIX + args.stateToken;
+    const state = (await this.cache.get<OAuthState>(stateKey)) ?? null;
+    if (!state) {
+      throw new Error('Invalid or expired OAuth state');
+    }
+    // One-shot — drop the state immediately to prevent replay.
+    await this.cache.del(stateKey);
+
+    if (state.integrationId !== args.integrationId) {
+      throw new Error('OAuth state does not match callback integration');
+    }
+
+    const manifest = this.registry.requireForIntegrationId(args.integrationId);
+    const connection = await this.connectionService.requireEnabled(
+      state.workspaceId,
+      args.integrationId,
+    );
+    const tokens = await this.exchangeCodeForTokens(
+      manifest,
+      connection,
+      args.code,
+      state.codeVerifier,
+    );
+    await this.persistTokens(
+      state.userId,
+      state.workspaceId,
+      args.integrationId,
+      tokens,
+    );
+    return {
+      userId: state.userId,
+      workspaceId: state.workspaceId,
+      returnTo: state.returnTo,
+    };
+  }
+
+  /** Decrypted tokens for the user/workspace/integration tuple, or null if not connected. */
+  async getTokens(
+    userId: string,
+    workspaceId: string,
+    integrationId: string,
+  ): Promise<DecryptedTokens | null> {
+    const row = await this.tokenRepo.findByUserWorkspaceAndIntegration(
+      userId,
+      workspaceId,
+      integrationId,
+    );
+    if (!row) return null;
+    const secret = this.environmentService.getAppSecret();
+    return {
+      accessToken: decryptString(
+        row.accessTokenEncrypted,
+        secret,
+        TOKEN_ENCRYPTION_INFO,
+      ),
+      refreshToken: row.refreshTokenEncrypted
+        ? decryptString(
+            row.refreshTokenEncrypted,
+            secret,
+            TOKEN_ENCRYPTION_INFO,
+          )
+        : undefined,
+      expiresAt: row.expiresAt ? new Date(row.expiresAt) : undefined,
+      scopes: row.scopes,
+      needsReconnect: row.needsReconnect,
+    };
+  }
+
+  /** RFC 6749 refresh-token grant. Throws on rejection — caller marks needs-reconnect. */
+  async refreshTokens(
+    userId: string,
+    workspaceId: string,
+    integrationId: string,
+  ): Promise<DecryptedTokens> {
+    const current = await this.getTokens(userId, workspaceId, integrationId);
+    if (!current?.refreshToken) {
+      throw new Error('No refresh token stored for this connection');
+    }
+
+    const manifest = this.registry.requireForIntegrationId(integrationId);
+    const connection = await this.connectionService.requireEnabled(
+      workspaceId,
+      integrationId,
+    );
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: current.refreshToken,
+      client_id: connection.oauthClientId,
+    });
+    if (connection.oauthClientSecret)
+      body.set('client_secret', connection.oauthClientSecret);
+
+    const resp = await outboundFetch(
+      `${connection.baseUrl}${manifest.tokenPath}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      },
+    );
+    if (!resp.ok) {
+      const text = await readOutboundBody(resp).catch(() => '');
+      throw new Error(
+        `Refresh token exchange failed (${resp.status}): ${text}`,
+      );
+    }
+    const tokens = JSON.parse(await readOutboundBody(resp)) as TokenResponse;
+    await this.persistTokens(
+      userId,
+      workspaceId,
+      integrationId,
+      tokens,
+      current.refreshToken,
+    );
+    return (await this.getTokens(userId, workspaceId, integrationId))!;
+  }
+
+  async markNeedsReconnect(
+    userId: string,
+    workspaceId: string,
+    integrationId: string,
+  ): Promise<void> {
+    await this.tokenRepo.markNeedsReconnect(userId, workspaceId, integrationId);
+  }
+
+  async disconnect(
+    userId: string,
+    workspaceId: string,
+    integrationId: string,
+  ): Promise<void> {
+    await this.tokenRepo.delete(userId, workspaceId, integrationId);
+  }
+
+  callbackUrl(integrationId: string): string {
+    return this.connectionService.callbackUrl(integrationId);
+  }
+
+  // ---- internals ----
+
+  private async exchangeCodeForTokens(
+    manifest: IntegrationManifest,
+    connection: ResolvedIntegrationOAuthConnection,
+    code: string,
+    codeVerifier?: string,
+  ): Promise<TokenResponse> {
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: this.callbackUrl(connection.integrationId),
+      client_id: connection.oauthClientId,
+    });
+    if (connection.oauthClientSecret)
+      body.set('client_secret', connection.oauthClientSecret);
+    if (codeVerifier) body.set('code_verifier', codeVerifier);
+
+    const resp = await outboundFetch(
+      `${connection.baseUrl}${manifest.tokenPath}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      },
+    );
+    if (!resp.ok) {
+      const text = await readOutboundBody(resp).catch(() => '');
+      throw new Error(`OAuth token exchange failed (${resp.status}): ${text}`);
+    }
+    return JSON.parse(await readOutboundBody(resp)) as TokenResponse;
+  }
+
+  private async persistTokens(
+    userId: string,
+    workspaceId: string,
+    integrationId: string,
+    tokens: TokenResponse,
+    fallbackRefreshToken?: string,
+  ): Promise<void> {
+    if (!tokens.access_token) {
+      throw new Error('Token response missing access_token');
+    }
+    const secret = this.environmentService.getAppSecret();
+    // Providers that don't rotate (e.g. Google) only return a refresh token
+    // on the first exchange. Fall back to the existing one to avoid
+    // locking the user out on the next refresh.
+    const refreshToken = tokens.refresh_token ?? fallbackRefreshToken;
+    const expiresAt = tokens.expires_in
+      ? new Date(Date.now() + tokens.expires_in * 1000)
+      : null;
+
+    await this.tokenRepo.upsert({
+      userId,
+      workspaceId,
+      integrationId,
+      accessTokenEncrypted: encryptString(
+        tokens.access_token,
+        secret,
+        TOKEN_ENCRYPTION_INFO,
+      ),
+      refreshTokenEncrypted: refreshToken
+        ? encryptString(refreshToken, secret, TOKEN_ENCRYPTION_INFO)
+        : null,
+      expiresAt,
+      scopes: tokens.scope ?? '',
+      needsReconnect: false,
+    });
+  }
+}

--- a/apps/server/src/integrations/integration-oauth/integration-resource-client.spec.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-resource-client.spec.ts
@@ -1,0 +1,98 @@
+import { createScopedResourceClient } from './integration-resource-client';
+import { IntegrationOAuthClientService } from './integration-oauth-client.service';
+import { IntegrationResourceManifest } from './resource.types';
+
+const SCOPE = {
+  integrationId: 'alpha:1111',
+  workspaceId: 'ws-1',
+  userId: 'user-1',
+};
+
+function resource(outboundPaths?: string[]): IntegrationResourceManifest {
+  return {
+    id: 'thing',
+    title: 'Thing',
+    renderKind: 'item-card',
+    security: outboundPaths ? { outboundPaths } : undefined,
+    resolve: async () => ({ kind: 'item-card', key: 'k', title: 't' }),
+  };
+}
+
+describe('createScopedResourceClient', () => {
+  let clientService: jest.Mocked<
+    Pick<IntegrationOAuthClientService, 'get' | 'baseUrl' | 'settings'>
+  >;
+
+  beforeEach(() => {
+    clientService = {
+      get: jest.fn().mockResolvedValue({ ok: true }),
+      baseUrl: jest.fn().mockResolvedValue('https://provider.example.com'),
+      settings: jest.fn().mockResolvedValue({ defaultWorkspaceKey: 'WI' }),
+    };
+  });
+
+  function client(outboundPaths?: string[]) {
+    return createScopedResourceClient(
+      clientService as unknown as IntegrationOAuthClientService,
+      resource(outboundPaths),
+      SCOPE,
+    );
+  }
+
+  it('allows declared literal paths and binds the scope', async () => {
+    const c = client(['/api/items']);
+    await c.get('/api/items', { q: 'x' });
+    expect(clientService.get).toHaveBeenCalledWith(
+      SCOPE.integrationId,
+      SCOPE.workspaceId,
+      SCOPE.userId,
+      '/api/items',
+      { q: 'x' },
+    );
+  });
+
+  it('matches :param segments against exactly one segment', async () => {
+    const c = client(['/api/items/:id']);
+    await expect(c.get('/api/items/42')).resolves.toEqual({ ok: true });
+    await expect(c.get('/api/items')).rejects.toThrow(/not declared/);
+    await expect(c.get('/api/items/42/comments')).rejects.toThrow(
+      /not declared/,
+    );
+  });
+
+  it('rejects undeclared paths', async () => {
+    const c = client(['/api/items']);
+    await expect(c.get('/api/admin/users')).rejects.toThrow(/not declared/);
+    expect(clientService.get).not.toHaveBeenCalled();
+  });
+
+  it('rejects path traversal away from declared prefixes', async () => {
+    const c = client(['/api/items/:id']);
+    await expect(c.get('/api/items/../admin')).rejects.toThrow(/not declared/);
+  });
+
+  it('blocks every path when the resource declares none', async () => {
+    const c = client(undefined);
+    await expect(c.get('/api/items')).rejects.toThrow(/not declared/);
+  });
+
+  it('does not treat regex metacharacters in declarations as patterns', async () => {
+    const c = client(['/api/items.json']);
+    await expect(c.get('/api/itemsXjson')).rejects.toThrow(/not declared/);
+    await expect(c.get('/api/items.json')).resolves.toEqual({ ok: true });
+  });
+
+  it('passes baseUrl and settings through with the bound scope', async () => {
+    const c = client(['/api/items']);
+    await expect(c.baseUrl()).resolves.toBe('https://provider.example.com');
+    await expect(c.settings()).resolves.toEqual({ defaultWorkspaceKey: 'WI' });
+    expect(clientService.baseUrl).toHaveBeenCalledWith(
+      SCOPE.integrationId,
+      SCOPE.workspaceId,
+    );
+    expect(clientService.settings).toHaveBeenCalledWith(
+      SCOPE.integrationId,
+      SCOPE.workspaceId,
+    );
+  });
+});

--- a/apps/server/src/integrations/integration-oauth/integration-resource-client.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-resource-client.ts
@@ -1,0 +1,65 @@
+import { IntegrationOAuthClientService } from './integration-oauth-client.service';
+import {
+  IntegrationResourceClient,
+  IntegrationResourceManifest,
+} from './resource.types';
+
+/**
+ * Compiles a declared outbound path ('/api/items/:id') into a matcher.
+ * `:param` segments match exactly one path segment; everything else is
+ * matched literally.
+ */
+function compileOutboundPath(pattern: string): RegExp {
+  const segments = pattern
+    .split('/')
+    .map((segment) =>
+      segment.startsWith(':') && segment.length > 1
+        ? '[^/]+'
+        : segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+    );
+  return new RegExp(`^${segments.join('/')}$`);
+}
+
+/**
+ * Binds the outbound client to one (integration, workspace, user, resource)
+ * and enforces the resource's declared `security.outboundPaths` allowlist.
+ * Resource handlers never see the unscoped client, so a provider bug cannot
+ * reach paths it did not declare.
+ */
+export function createScopedResourceClient(
+  clientService: IntegrationOAuthClientService,
+  resource: IntegrationResourceManifest,
+  scope: { integrationId: string; workspaceId: string; userId: string },
+): IntegrationResourceClient {
+  const allowedPaths = (resource.security?.outboundPaths ?? []).map(
+    compileOutboundPath,
+  );
+
+  return {
+    get<T = unknown>(
+      path: string,
+      query?: Record<string, string | number | undefined>,
+    ): Promise<T> {
+      if (!allowedPaths.some((re) => re.test(path))) {
+        return Promise.reject(
+          new Error(
+            `Outbound path not declared in resource '${resource.id}' security.outboundPaths: ${path}`,
+          ),
+        );
+      }
+      return clientService.get<T>(
+        scope.integrationId,
+        scope.workspaceId,
+        scope.userId,
+        path,
+        query,
+      );
+    },
+    baseUrl(): Promise<string> {
+      return clientService.baseUrl(scope.integrationId, scope.workspaceId);
+    },
+    settings(): Promise<Record<string, string>> {
+      return clientService.settings(scope.integrationId, scope.workspaceId);
+    },
+  };
+}

--- a/apps/server/src/integrations/integration-oauth/integration-resource.controller.spec.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-resource.controller.spec.ts
@@ -1,0 +1,205 @@
+import { HttpException, NotFoundException } from '@nestjs/common';
+import { User, Workspace } from '@docmost/db/types/entity.types';
+import { IntegrationResourceController } from './integration-resource.controller';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import {
+  IntegrationNotConfiguredError,
+  IntegrationNotConnectedError,
+  IntegrationOAuthClientService,
+  IntegrationReconnectRequiredError,
+} from './integration-oauth-client.service';
+import { IntegrationManifest } from './manifest.types';
+import { IntegrationResourceManifest } from './resource.types';
+
+const USER = { id: 'user-1' } as User;
+const WORKSPACE = { id: 'ws-1' } as Workspace;
+const INTEGRATION_ID = 'alpha:1111';
+
+function buildController(resources: IntegrationResourceManifest[]) {
+  const registry = new IntegrationOAuthRegistry();
+  registry.register({
+    id: 'alpha',
+    name: 'Alpha',
+    baseUrl: () => 'https://provider.example.com',
+    authorizePath: '/oauth/authorize',
+    tokenPath: '/oauth/token',
+    scopes: ['read'],
+    clientIdEnv: 'TEST_CLIENT_ID',
+    clientSecretEnv: 'TEST_CLIENT_SECRET',
+    resources,
+  } as IntegrationManifest);
+  const clientService = {
+    get: jest.fn(),
+    baseUrl: jest.fn(),
+    settings: jest.fn(),
+  } as unknown as IntegrationOAuthClientService;
+  return new IntegrationResourceController(registry, clientService);
+}
+
+function itemResource(
+  overrides: Partial<IntegrationResourceManifest> = {},
+): IntegrationResourceManifest {
+  return {
+    id: 'item',
+    title: 'Item',
+    renderKind: 'item-card',
+    resolve: async (_ctx, args) => ({
+      kind: 'item-card',
+      key: args.resourceKey,
+      title: 'Resolved',
+    }),
+    ...overrides,
+  };
+}
+
+async function httpError(promise: Promise<unknown>): Promise<HttpException> {
+  try {
+    await promise;
+  } catch (err) {
+    return err as HttpException;
+  }
+  throw new Error('expected the call to reject');
+}
+
+describe('IntegrationResourceController', () => {
+  describe('lookup', () => {
+    it('404s on unknown integrations', async () => {
+      const controller = buildController([itemResource()]);
+      await expect(
+        controller.resolve(USER, WORKSPACE, 'nope:1', 'item', 'WI-1', undefined),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('404s on unknown resources', async () => {
+      const controller = buildController([itemResource()]);
+      await expect(
+        controller.resolve(USER, WORKSPACE, INTEGRATION_ID, 'nope', 'WI-1', undefined),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('search', () => {
+    it('returns empty items when the resource declares no search', async () => {
+      const controller = buildController([itemResource()]);
+      await expect(
+        controller.search(USER, WORKSPACE, INTEGRATION_ID, 'item', 'q', undefined),
+      ).resolves.toEqual({ items: [] });
+    });
+
+    it('passes only the typed q/limit args to the provider search', async () => {
+      const search = jest.fn().mockResolvedValue([{ key: 'k', title: 't' }]);
+      const controller = buildController([itemResource({ search })]);
+      const result = await controller.search(
+        USER,
+        WORKSPACE,
+        INTEGRATION_ID,
+        'item',
+        'hello',
+        '5',
+      );
+      expect(result).toEqual({ items: [{ key: 'k', title: 't' }] });
+      expect(search).toHaveBeenCalledTimes(1);
+      const [ctx, args] = search.mock.calls[0];
+      expect(args).toEqual({ q: 'hello', limit: 5 });
+      expect(ctx).toMatchObject({
+        integrationId: INTEGRATION_ID,
+        workspaceId: WORKSPACE.id,
+        userId: USER.id,
+      });
+      expect(typeof ctx.client.get).toBe('function');
+    });
+
+    it('drops a non-numeric limit instead of forwarding it', async () => {
+      const search = jest.fn().mockResolvedValue([]);
+      const controller = buildController([itemResource({ search })]);
+      await controller.search(USER, WORKSPACE, INTEGRATION_ID, 'item', 'q', 'abc');
+      expect(search.mock.calls[0][1]).toEqual({ q: 'q', limit: undefined });
+    });
+  });
+
+  describe('resolve', () => {
+    it('requires a resource key', async () => {
+      const controller = buildController([itemResource()]);
+      const err = await httpError(
+        controller.resolve(USER, WORKSPACE, INTEGRATION_ID, 'item', undefined, undefined),
+      );
+      expect(err.getStatus()).toBe(400);
+      expect(err.getResponse()).toMatchObject({
+        code: 'INTEGRATION_RESOURCE_BAD_REQUEST',
+      });
+    });
+
+    it('resolves with parsed params', async () => {
+      const resolve = jest.fn().mockResolvedValue({
+        kind: 'table-report',
+        title: 'Report',
+        rows: [],
+      });
+      const controller = buildController([itemResource({ resolve })]);
+      await controller.resolve(
+        USER,
+        WORKSPACE,
+        INTEGRATION_ID,
+        'item',
+        'report-1',
+        JSON.stringify({ page: 2 }),
+      );
+      expect(resolve.mock.calls[0][1]).toEqual({
+        resourceKey: 'report-1',
+        params: { page: 2 },
+      });
+    });
+
+    it('rejects malformed and non-object params JSON', async () => {
+      const controller = buildController([itemResource()]);
+      for (const bad of ['{not json', '[1,2]', '"str"']) {
+        const err = await httpError(
+          controller.resolve(USER, WORKSPACE, INTEGRATION_ID, 'item', 'k', bad),
+        );
+        expect(err.getStatus()).toBe(400);
+      }
+    });
+  });
+
+  describe('error mapping', () => {
+    async function resolveWith(thrown: Error) {
+      const controller = buildController([
+        itemResource({ resolve: async () => Promise.reject(thrown) }),
+      ]);
+      return httpError(
+        controller.resolve(USER, WORKSPACE, INTEGRATION_ID, 'item', 'WI-1', undefined),
+      );
+    }
+
+    it.each([
+      [new IntegrationNotConfiguredError('alpha'), 'INTEGRATION_NOT_CONFIGURED'],
+      [new IntegrationNotConnectedError('alpha'), 'INTEGRATION_NOT_CONNECTED'],
+      [
+        new IntegrationReconnectRequiredError('alpha'),
+        'INTEGRATION_RECONNECT_REQUIRED',
+      ],
+    ])('maps %p to a 409 with a stable code', async (thrown, code) => {
+      const err = await resolveWith(thrown);
+      expect(err.getStatus()).toBe(409);
+      expect(err.getResponse()).toMatchObject({ code });
+    });
+
+    it('maps provider HTTP errors to their status', async () => {
+      const providerErr = new Error('not found') as Error & { status?: number };
+      providerErr.status = 404;
+      const err = await resolveWith(providerErr);
+      expect(err.getStatus()).toBe(404);
+      expect(err.getResponse()).toMatchObject({
+        code: 'INTEGRATION_PROVIDER_HTTP_ERROR',
+      });
+    });
+
+    it('maps unexpected provider failures to an opaque 502', async () => {
+      const err = await resolveWith(new Error('secret token abc123 leaked'));
+      expect(err.getStatus()).toBe(502);
+      const body = err.getResponse() as { code: string; message: string };
+      expect(body.code).toBe('INTEGRATION_RESOURCE_ERROR');
+      expect(body.message).not.toContain('abc123');
+    });
+  });
+});

--- a/apps/server/src/integrations/integration-oauth/integration-resource.controller.ts
+++ b/apps/server/src/integrations/integration-oauth/integration-resource.controller.ts
@@ -1,0 +1,209 @@
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Logger,
+  NotFoundException,
+  Param,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { AuthUser } from '../../common/decorators/auth-user.decorator';
+import { AuthWorkspace } from '../../common/decorators/auth-workspace.decorator';
+import { User, Workspace } from '@docmost/db/types/entity.types';
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import {
+  IntegrationOAuthClientService,
+  IntegrationNotConfiguredError,
+  IntegrationNotConnectedError,
+  IntegrationReconnectRequiredError,
+} from './integration-oauth-client.service';
+import { createScopedResourceClient } from './integration-resource-client';
+import { IntegrationResourceManifest } from './resource.types';
+
+/**
+ * Generic editor resource controller. Handlers call the resource manifest's
+ * search/resolve functions with a scoped client that enforces the resource's
+ * declared outbound-path allowlist; raw browser paths, methods, headers, or
+ * query strings are never forwarded to the provider.
+ */
+@Controller('integrations/:integrationId/resources/:resourceId')
+@UseGuards(JwtAuthGuard)
+export class IntegrationResourceController {
+  private readonly logger = new Logger(IntegrationResourceController.name);
+
+  constructor(
+    private readonly registry: IntegrationOAuthRegistry,
+    private readonly clientService: IntegrationOAuthClientService,
+  ) {}
+
+  @Get('search')
+  async search(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+    @Param('integrationId') integrationId: string,
+    @Param('resourceId') resourceId: string,
+    @Query('q') q: string | undefined,
+    @Query('limit') limit: string | undefined,
+  ): Promise<{ items: unknown[] }> {
+    const resource = this.requireResource(integrationId, resourceId);
+    if (!resource.search) return { items: [] };
+
+    const parsedLimit = limit ? Number.parseInt(limit, 10) : undefined;
+    const items = await this.wrap(integrationId, resourceId, () =>
+      resource.search!(
+        this.buildContext(resource, integrationId, workspace.id, user.id),
+        {
+          q,
+          limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+        },
+      ),
+    );
+    return { items };
+  }
+
+  @Get('resolve')
+  async resolve(
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+    @Param('integrationId') integrationId: string,
+    @Param('resourceId') resourceId: string,
+    @Query('key') key: string | undefined,
+    @Query('params') paramsJson: string | undefined,
+  ): Promise<unknown> {
+    const resource = this.requireResource(integrationId, resourceId);
+    if (!key) {
+      throw new HttpException(
+        {
+          code: 'INTEGRATION_RESOURCE_BAD_REQUEST',
+          message: 'Missing resource key',
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const params = this.parseParams(paramsJson);
+    return this.wrap(integrationId, resourceId, () =>
+      resource.resolve(
+        this.buildContext(resource, integrationId, workspace.id, user.id),
+        { resourceKey: key, params },
+      ),
+    );
+  }
+
+  private buildContext(
+    resource: IntegrationResourceManifest,
+    integrationId: string,
+    workspaceId: string,
+    userId: string,
+  ) {
+    return {
+      integrationId,
+      workspaceId,
+      userId,
+      client: createScopedResourceClient(this.clientService, resource, {
+        integrationId,
+        workspaceId,
+        userId,
+      }),
+    };
+  }
+
+  private requireResource(integrationId: string, resourceId: string) {
+    const manifest = this.registry.getForIntegrationId(integrationId);
+    if (!manifest) {
+      throw new NotFoundException(`Unknown integration: ${integrationId}`);
+    }
+    const resource = manifest.resources?.find((r) => r.id === resourceId);
+    if (!resource) {
+      throw new NotFoundException(
+        `Unknown integration resource: ${integrationId}/${resourceId}`,
+      );
+    }
+    return resource;
+  }
+
+  private parseParams(
+    paramsJson: string | undefined,
+  ): Record<string, unknown> | undefined {
+    if (!paramsJson) return undefined;
+    try {
+      const parsed = JSON.parse(paramsJson) as unknown;
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // handled below
+    }
+    throw new HttpException(
+      {
+        code: 'INTEGRATION_RESOURCE_BAD_REQUEST',
+        message: 'Invalid params JSON',
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+
+  private async wrap<T>(
+    integrationId: string,
+    resourceId: string,
+    call: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await call();
+    } catch (err) {
+      if (err instanceof IntegrationNotConfiguredError) {
+        throw new HttpException(
+          {
+            code: 'INTEGRATION_NOT_CONFIGURED',
+            message: `Ask a workspace admin to configure ${integrationId}`,
+          },
+          HttpStatus.CONFLICT,
+        );
+      }
+      if (err instanceof IntegrationNotConnectedError) {
+        throw new HttpException(
+          {
+            code: 'INTEGRATION_NOT_CONNECTED',
+            message: `Connect ${integrationId} to use this embed`,
+          },
+          HttpStatus.CONFLICT,
+        );
+      }
+      if (err instanceof IntegrationReconnectRequiredError) {
+        throw new HttpException(
+          {
+            code: 'INTEGRATION_RECONNECT_REQUIRED',
+            message: `Reconnect ${integrationId} to refresh access`,
+          },
+          HttpStatus.CONFLICT,
+        );
+      }
+
+      const status = (err as { status?: number }).status;
+      if (typeof status === 'number' && status >= 400 && status < 600) {
+        throw new HttpException(
+          {
+            code: 'INTEGRATION_PROVIDER_HTTP_ERROR',
+            status,
+            message: (err as Error).message,
+          },
+          status,
+        );
+      }
+
+      this.logger.warn(
+        `Integration resource failed integration=${integrationId} resource=${resourceId}: ${(err as Error).message}`,
+      );
+      throw new HttpException(
+        {
+          code: 'INTEGRATION_RESOURCE_ERROR',
+          message: 'Integration resource failed',
+        },
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+  }
+}

--- a/apps/server/src/integrations/integration-oauth/manifest.registry.spec.ts
+++ b/apps/server/src/integrations/integration-oauth/manifest.registry.spec.ts
@@ -1,0 +1,61 @@
+import { IntegrationOAuthRegistry } from './manifest.registry';
+import { IntegrationManifest } from './manifest.types';
+
+function manifest(id: string): IntegrationManifest {
+  return {
+    id,
+    name: id,
+    baseUrl: () => 'https://provider.example.com',
+    authorizePath: '/oauth/authorize',
+    tokenPath: '/oauth/token',
+    scopes: ['read'],
+    clientIdEnv: 'TEST_CLIENT_ID',
+    clientSecretEnv: 'TEST_CLIENT_SECRET',
+  } as IntegrationManifest;
+}
+
+describe('IntegrationOAuthRegistry', () => {
+  let registry: IntegrationOAuthRegistry;
+
+  beforeEach(() => {
+    registry = new IntegrationOAuthRegistry();
+  });
+
+  it('registers and lists manifests', () => {
+    registry.register(manifest('alpha'));
+    registry.register(manifest('beta'));
+    expect(registry.list().map((m) => m.id)).toEqual(['alpha', 'beta']);
+  });
+
+  it('rejects duplicate ids', () => {
+    registry.register(manifest('alpha'));
+    expect(() => registry.register(manifest('alpha'))).toThrow(
+      /already registered/,
+    );
+  });
+
+  it('returns undefined for unknown ids', () => {
+    expect(registry.get('nope')).toBeUndefined();
+    expect(registry.getForIntegrationId('nope:0000')).toBeUndefined();
+  });
+
+  it('require throws for unknown ids', () => {
+    expect(() => registry.require('nope')).toThrow(/Unknown integration/);
+    expect(() => registry.requireForIntegrationId('nope:0000')).toThrow(
+      /Unknown integration/,
+    );
+  });
+
+  it('resolves provider manifests from providerId:uuid integration ids', () => {
+    registry.register(manifest('alpha'));
+    const id = 'alpha:7c5e6cb2-0000-4000-8000-000000000000';
+    expect(registry.providerIdFor(id)).toBe('alpha');
+    expect(registry.getForIntegrationId(id)?.id).toBe('alpha');
+    expect(registry.requireForIntegrationId(id).id).toBe('alpha');
+  });
+
+  it('treats a bare provider id as its own integration id', () => {
+    registry.register(manifest('alpha'));
+    expect(registry.getForIntegrationId('alpha')?.id).toBe('alpha');
+  });
+});

--- a/apps/server/src/integrations/integration-oauth/manifest.registry.spec.ts
+++ b/apps/server/src/integrations/integration-oauth/manifest.registry.spec.ts
@@ -34,6 +34,16 @@ describe('IntegrationOAuthRegistry', () => {
     );
   });
 
+  it('requires PKCE for dynamically registered public clients', () => {
+    expect(() =>
+      registry.register({
+        ...manifest('alpha'),
+        pkce: false,
+        dynamicClientRegistration: { path: '/oauth/register' },
+      }),
+    ).toThrow(/must enable PKCE/);
+  });
+
   it('returns undefined for unknown ids', () => {
     expect(registry.get('nope')).toBeUndefined();
     expect(registry.getForIntegrationId('nope:0000')).toBeUndefined();

--- a/apps/server/src/integrations/integration-oauth/manifest.registry.ts
+++ b/apps/server/src/integrations/integration-oauth/manifest.registry.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { IntegrationManifest } from './manifest.types';
+
+/**
+ * In-memory registry of integration manifests. Consumer modules call
+ * `register()` at boot. Manifests are code-defined and shipped with the
+ * deployment — DB persistence would let an admin redirect tokens to a
+ * different provider at runtime.
+ */
+@Injectable()
+export class IntegrationOAuthRegistry {
+  private readonly logger = new Logger(IntegrationOAuthRegistry.name);
+  private readonly manifests = new Map<string, IntegrationManifest>();
+
+  register(manifest: IntegrationManifest): void {
+    if (this.manifests.has(manifest.id)) {
+      throw new Error(
+        `Integration manifest with id="${manifest.id}" is already registered`,
+      );
+    }
+    this.manifests.set(manifest.id, manifest);
+    this.logger.log(`Registered integration manifest: ${manifest.id}`);
+  }
+
+  get(id: string): IntegrationManifest | undefined {
+    return this.manifests.get(id);
+  }
+
+  providerIdFor(integrationId: string): string {
+    return integrationId.split(':', 1)[0];
+  }
+
+  getForIntegrationId(integrationId: string): IntegrationManifest | undefined {
+    return this.get(this.providerIdFor(integrationId));
+  }
+
+  /** Throws when the integration is unknown — for routes that need to fail loudly. */
+  require(id: string): IntegrationManifest {
+    const m = this.manifests.get(id);
+    if (!m) {
+      throw new Error(`Unknown integration: ${id}`);
+    }
+    return m;
+  }
+
+  requireForIntegrationId(integrationId: string): IntegrationManifest {
+    return this.require(this.providerIdFor(integrationId));
+  }
+
+  list(): IntegrationManifest[] {
+    return [...this.manifests.values()];
+  }
+}

--- a/apps/server/src/integrations/integration-oauth/manifest.registry.ts
+++ b/apps/server/src/integrations/integration-oauth/manifest.registry.ts
@@ -18,6 +18,11 @@ export class IntegrationOAuthRegistry {
         `Integration manifest with id="${manifest.id}" is already registered`,
       );
     }
+    if (manifest.dynamicClientRegistration && !manifest.pkce) {
+      throw new Error(
+        `Integration manifest with id="${manifest.id}" must enable PKCE for dynamic public client registration`,
+      );
+    }
     this.manifests.set(manifest.id, manifest);
     this.logger.log(`Registered integration manifest: ${manifest.id}`);
   }

--- a/apps/server/src/integrations/integration-oauth/manifest.types.ts
+++ b/apps/server/src/integrations/integration-oauth/manifest.types.ts
@@ -1,0 +1,61 @@
+/**
+ * OAuth + identity contract for a third-party integration. Each consumer
+ * module declares one of these and registers it with IntegrationOAuthRegistry
+ * at boot.
+ */
+import { IntegrationResourceManifest } from './resource.types';
+
+/**
+ * Provider-defined connection setting rendered generically in the admin
+ * connection form and persisted in the connection's `settings` JSON blob.
+ */
+export interface IntegrationConnectionSettingField {
+  /** Key in the connection settings object. */
+  key: string;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  required?: boolean;
+  /** Regex source the trimmed value must match (anchor it yourself). */
+  pattern?: string;
+  /** Normalization applied before validation and storage. */
+  transform?: 'uppercase' | 'lowercase';
+}
+
+export interface IntegrationManifest {
+  /** Stable identifier — used in URLs, env vars, and the token table. */
+  id: string;
+  /** Display name for the settings UI. */
+  name: string;
+  description?: string;
+  /** Provider base URL. A thunk lets env-driven values resolve at request time. */
+  baseUrl: string | (() => string);
+  /** Placeholder for the admin connection form's base URL input. */
+  baseUrlPlaceholder?: string;
+  /** e.g. /oauth/authorize */
+  authorizePath: string;
+  /** e.g. /api/oauth/token */
+  tokenPath: string;
+  scopes: string[];
+  /** Defaults to ' '. Some providers use ','. */
+  scopeSeparator?: string;
+  /** Extra authorize-URL params (e.g. prompt=consent). */
+  extraAuthParams?: Record<string, string>;
+  /** PKCE S256. Required for public clients; recommended for confidential. */
+  pkce?: boolean;
+  /** Env var holding the OAuth client_id. */
+  clientIdEnv: string;
+  /** Env var holding the OAuth client_secret (omit for public clients). */
+  clientSecretEnv?: string;
+  icon?: string;
+  /** Extra admin-configured connection settings, rendered generically. */
+  connectionSettings?: IntegrationConnectionSettingField[];
+  /** Safe editor resources exposed through the generic integration surface. */
+  resources?: IntegrationResourceManifest[];
+}
+
+/** Resolves IntegrationManifest.baseUrl whether it's a literal or a thunk. */
+export function resolveBaseUrl(manifest: IntegrationManifest): string {
+  const raw = typeof manifest.baseUrl === 'function' ? manifest.baseUrl() : manifest.baseUrl;
+  return raw.replace(/\/+$/, '');
+}

--- a/apps/server/src/integrations/integration-oauth/manifest.types.ts
+++ b/apps/server/src/integrations/integration-oauth/manifest.types.ts
@@ -22,6 +22,17 @@ export interface IntegrationConnectionSettingField {
   transform?: 'uppercase' | 'lowercase';
 }
 
+/**
+ * RFC 7591 registration metadata for providers that issue a public OAuth
+ * client to each Docmost integration connection.
+ */
+export interface IntegrationDynamicClientRegistration {
+  /** Registration endpoint relative to the configured provider base URL. */
+  path: string;
+  /** Optional display name sent to the provider. Defaults to `Docmost <name>`. */
+  clientName?: string;
+}
+
 export interface IntegrationManifest {
   /** Stable identifier — used in URLs, env vars, and the token table. */
   id: string;
@@ -43,6 +54,11 @@ export interface IntegrationManifest {
   extraAuthParams?: Record<string, string>;
   /** PKCE S256. Required for public clients; recommended for confidential. */
   pkce?: boolean;
+  /**
+   * Register a public client automatically when an admin saves the connection.
+   * The resulting client has no secret and users authorize their own accounts.
+   */
+  dynamicClientRegistration?: IntegrationDynamicClientRegistration;
   /** Env var holding the OAuth client_id. */
   clientIdEnv: string;
   /** Env var holding the OAuth client_secret (omit for public clients). */
@@ -56,6 +72,9 @@ export interface IntegrationManifest {
 
 /** Resolves IntegrationManifest.baseUrl whether it's a literal or a thunk. */
 export function resolveBaseUrl(manifest: IntegrationManifest): string {
-  const raw = typeof manifest.baseUrl === 'function' ? manifest.baseUrl() : manifest.baseUrl;
+  const raw =
+    typeof manifest.baseUrl === 'function'
+      ? manifest.baseUrl()
+      : manifest.baseUrl;
   return raw.replace(/\/+$/, '');
 }

--- a/apps/server/src/integrations/integration-oauth/outbound-url-guard.spec.ts
+++ b/apps/server/src/integrations/integration-oauth/outbound-url-guard.spec.ts
@@ -1,0 +1,159 @@
+import {
+  allowLocalConnections,
+  integrationMaxResponseBytes,
+  integrationRequestTimeoutMs,
+  isBlockedOutboundAddress,
+  OutboundResponse,
+  OutboundResponseTooLargeError,
+  readOutboundBody,
+} from './outbound-url-guard';
+
+function streamResponse(
+  chunks: string[],
+  headers: Record<string, string> = {},
+): OutboundResponse {
+  const encoder = new TextEncoder();
+  const queue = [...chunks];
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const next = queue.shift();
+      if (next === undefined) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(encoder.encode(next));
+    },
+  });
+  return {
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+    body,
+  } as unknown as OutboundResponse;
+}
+
+describe('outbound-url-guard', () => {
+  describe('allowLocalConnections', () => {
+    const original = process.env.INTEGRATION_ALLOW_LOCAL_CONNECTIONS;
+
+    afterEach(() => {
+      if (original === undefined) {
+        delete process.env.INTEGRATION_ALLOW_LOCAL_CONNECTIONS;
+      } else {
+        process.env.INTEGRATION_ALLOW_LOCAL_CONNECTIONS = original;
+      }
+    });
+
+    it('defaults to allowing local connections (guard off)', () => {
+      delete process.env.INTEGRATION_ALLOW_LOCAL_CONNECTIONS;
+      expect(allowLocalConnections()).toBe(true);
+    });
+
+    it('only the explicit string "false" enables the guard', () => {
+      process.env.INTEGRATION_ALLOW_LOCAL_CONNECTIONS = 'false';
+      expect(allowLocalConnections()).toBe(false);
+      process.env.INTEGRATION_ALLOW_LOCAL_CONNECTIONS = 'true';
+      expect(allowLocalConnections()).toBe(true);
+    });
+  });
+
+  describe('isBlockedOutboundAddress', () => {
+    const blocked = [
+      '127.0.0.1', // loopback
+      '127.8.8.8', // loopback /8
+      '0.0.0.0', // unspecified
+      '169.254.169.254', // link-local / cloud metadata
+      '10.1.2.3', // RFC1918
+      '172.16.0.1', // RFC1918
+      '172.31.255.255', // RFC1918 upper edge
+      '192.168.1.1', // RFC1918
+      '100.64.0.1', // CGNAT
+      '224.0.0.1', // multicast
+      '255.255.255.255', // broadcast
+      '::1', // v6 loopback
+      '::', // v6 unspecified
+      'fe80::1', // v6 link-local
+      'fc00::1', // v6 unique-local
+      'fd12:3456::1', // v6 unique-local /7
+      'ff02::1', // v6 multicast
+      '::ffff:127.0.0.1', // v4-mapped loopback
+      '::ffff:10.0.0.1', // v4-mapped RFC1918
+      '2002:7f00:0001::', // 6to4-embedded 127.0.0.1
+      '64:ff9b::a00:1', // NAT64-embedded 10.0.0.1
+      'not-an-ip', // unparseable → fail closed
+    ];
+
+    const allowed = [
+      '8.8.8.8',
+      '1.1.1.1',
+      '93.184.216.34',
+      '172.32.0.1', // just past RFC1918 172.16/12
+      '100.128.0.1', // just past CGNAT /10
+      '2606:4700::1111',
+      '2002:0808:0808::', // 6to4-embedded 8.8.8.8
+      '64:ff9b::808:808', // NAT64-embedded 8.8.8.8
+    ];
+
+    it.each(blocked)('blocks %s', (address) => {
+      expect(isBlockedOutboundAddress(address)).toBe(true);
+    });
+
+    it.each(allowed)('allows %s', (address) => {
+      expect(isBlockedOutboundAddress(address)).toBe(false);
+    });
+  });
+
+  describe('egress limits configuration', () => {
+    afterEach(() => {
+      delete process.env.INTEGRATION_REQUEST_TIMEOUT_MS;
+      delete process.env.INTEGRATION_MAX_RESPONSE_BYTES;
+    });
+
+    it('uses safe defaults', () => {
+      expect(integrationRequestTimeoutMs()).toBe(15_000);
+      expect(integrationMaxResponseBytes()).toBe(5 * 1024 * 1024);
+    });
+
+    it('honors env overrides and rejects nonsense values', () => {
+      process.env.INTEGRATION_REQUEST_TIMEOUT_MS = '3000';
+      process.env.INTEGRATION_MAX_RESPONSE_BYTES = '1024';
+      expect(integrationRequestTimeoutMs()).toBe(3000);
+      expect(integrationMaxResponseBytes()).toBe(1024);
+
+      process.env.INTEGRATION_REQUEST_TIMEOUT_MS = '-1';
+      process.env.INTEGRATION_MAX_RESPONSE_BYTES = 'lots';
+      expect(integrationRequestTimeoutMs()).toBe(15_000);
+      expect(integrationMaxResponseBytes()).toBe(5 * 1024 * 1024);
+    });
+  });
+
+  describe('readOutboundBody', () => {
+    it('reads multi-chunk bodies under the limit', async () => {
+      const resp = streamResponse(['{"a":', '1}']);
+      await expect(readOutboundBody(resp, 1024)).resolves.toBe('{"a":1}');
+    });
+
+    it('fails fast on a Content-Length above the limit', async () => {
+      const resp = streamResponse(['x'], { 'content-length': '2048' });
+      await expect(readOutboundBody(resp, 1024)).rejects.toBeInstanceOf(
+        OutboundResponseTooLargeError,
+      );
+    });
+
+    it('aborts a stream that exceeds the limit despite its headers', async () => {
+      const resp = streamResponse(
+        ['a'.repeat(600), 'b'.repeat(600), 'c'.repeat(600)],
+        { 'content-length': '10' },
+      );
+      await expect(readOutboundBody(resp, 1024)).rejects.toBeInstanceOf(
+        OutboundResponseTooLargeError,
+      );
+    });
+
+    it('returns an empty string for bodyless responses', async () => {
+      const resp = {
+        headers: { get: () => null },
+        body: null,
+      } as unknown as OutboundResponse;
+      await expect(readOutboundBody(resp, 1024)).resolves.toBe('');
+    });
+  });
+});

--- a/apps/server/src/integrations/integration-oauth/outbound-url-guard.ts
+++ b/apps/server/src/integrations/integration-oauth/outbound-url-guard.ts
@@ -1,0 +1,278 @@
+import { lookup } from 'node:dns';
+import { isIP } from 'node:net';
+import { Agent, fetch as undiciFetch, RequestInit, Response } from 'undici';
+
+/**
+ * SSRF guard for integration outbound HTTP (token endpoints and resource
+ * calls, whose base URLs are workspace-admin-configured).
+ *
+ * DISABLED by default: self-hosted deployments routinely run providers on the
+ * same private network or docker bridge, and Docmost historically applied no
+ * egress restrictions. Operators of multi-tenant or otherwise exposed
+ * deployments opt in with INTEGRATION_ALLOW_LOCAL_CONNECTIONS=false, after
+ * which integration egress to loopback, link-local (incl. cloud metadata),
+ * RFC1918/CGNAT, and IPv6 unique-local destinations is refused.
+ *
+ * Enforcement is two-layered:
+ * - IP-literal hosts are checked synchronously before the request.
+ * - DNS names are checked inside the dialer's lookup hook — after resolution,
+ *   before the TCP connect — so a record that changes between validation and
+ *   connect (DNS rebinding) is still caught.
+ */
+
+/** Response type produced by outboundFetch (undici's, not the DOM lib's). */
+export type OutboundResponse = Response;
+
+export function allowLocalConnections(): boolean {
+  return process.env.INTEGRATION_ALLOW_LOCAL_CONNECTIONS !== 'false';
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+function positiveIntEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/** Per-request deadline for integration egress (token + resource calls). */
+export function integrationRequestTimeoutMs(): number {
+  return positiveIntEnv(
+    'INTEGRATION_REQUEST_TIMEOUT_MS',
+    DEFAULT_REQUEST_TIMEOUT_MS,
+  );
+}
+
+/** Hard cap on provider response bodies read into memory. */
+export function integrationMaxResponseBytes(): number {
+  return positiveIntEnv(
+    'INTEGRATION_MAX_RESPONSE_BYTES',
+    DEFAULT_MAX_RESPONSE_BYTES,
+  );
+}
+
+export class OutboundResponseTooLargeError extends Error {
+  constructor(limit: number) {
+    super(`Integration response exceeded the ${limit}-byte limit`);
+    this.name = 'OutboundResponseTooLargeError';
+  }
+}
+
+/**
+ * Reads a response body as text, aborting once it exceeds the configured
+ * byte limit — a declared Content-Length above the limit fails fast, and the
+ * stream is counted as it arrives so a lying or absent header cannot bypass
+ * the cap.
+ */
+export async function readOutboundBody(
+  resp: OutboundResponse,
+  maxBytes = integrationMaxResponseBytes(),
+): Promise<string> {
+  const declared = Number.parseInt(resp.headers.get('content-length') ?? '', 10);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new OutboundResponseTooLargeError(maxBytes);
+  }
+  if (!resp.body) return '';
+
+  const reader = resp.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > maxBytes) {
+        throw new OutboundResponseTooLargeError(maxBytes);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+    if (received > maxBytes) {
+      await resp.body.cancel().catch(() => undefined);
+    }
+  }
+
+  const merged = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+const IPV4_BLOCKED_RANGES: Array<[number, number]> = [
+  // [network, prefix] — loopback, unspecified, link-local, RFC1918, CGNAT,
+  // multicast, broadcast.
+  [ipv4ToInt('127.0.0.0'), 8],
+  [ipv4ToInt('0.0.0.0'), 8],
+  [ipv4ToInt('169.254.0.0'), 16],
+  [ipv4ToInt('10.0.0.0'), 8],
+  [ipv4ToInt('172.16.0.0'), 12],
+  [ipv4ToInt('192.168.0.0'), 16],
+  [ipv4ToInt('100.64.0.0'), 10],
+  [ipv4ToInt('224.0.0.0'), 4],
+  [ipv4ToInt('255.255.255.255'), 32],
+];
+
+function ipv4ToInt(ip: string): number {
+  return ip
+    .split('.')
+    .reduce((acc, octet) => (acc << 8) + Number.parseInt(octet, 10), 0);
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  const value = ipv4ToInt(ip);
+  return IPV4_BLOCKED_RANGES.some(([network, prefix]) => {
+    const mask = prefix === 0 ? 0 : (~0 << (32 - prefix)) >>> 0;
+    return (value & mask) >>> 0 === (network & mask) >>> 0;
+  });
+}
+
+/** Returns the first two hextets of a normalized IPv6 address. */
+function ipv6Hextets(ip: string): number[] {
+  const [head, tail = ''] = ip.split('::');
+  const headParts = head ? head.split(':') : [];
+  const tailParts = tail ? tail.split(':') : [];
+  const missing = 8 - headParts.length - tailParts.length;
+  const parts = [
+    ...headParts,
+    ...Array.from({ length: Math.max(missing, 0) }, () => '0'),
+    ...tailParts,
+  ];
+  return parts.map((p) => (p.includes('.') ? -1 : Number.parseInt(p, 16) || 0));
+}
+
+/** Extracts an embedded IPv4 from mapped (::ffff:), 6to4, and NAT64 forms. */
+function embeddedIpv4(ip: string): string | null {
+  const lower = ip.toLowerCase();
+  const v4Suffix = lower.match(/(\d{1,3}(?:\.\d{1,3}){3})$/)?.[1] ?? null;
+  if (lower.startsWith('::ffff:') && v4Suffix) return v4Suffix;
+  const hextets = ipv6Hextets(lower);
+  if (hextets[0] === 0x2002) {
+    // 6to4: 2002:AABB:CCDD::/48 embeds A.B.C.D.
+    return [
+      hextets[1] >> 8,
+      hextets[1] & 0xff,
+      hextets[2] >> 8,
+      hextets[2] & 0xff,
+    ].join('.');
+  }
+  if (hextets[0] === 0x64 && hextets[1] === 0xff9b) {
+    // NAT64 64:ff9b::/96 embeds the IPv4 in the last 32 bits.
+    if (v4Suffix) return v4Suffix;
+    return [
+      hextets[6] >> 8,
+      hextets[6] & 0xff,
+      hextets[7] >> 8,
+      hextets[7] & 0xff,
+    ].join('.');
+  }
+  return null;
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const lower = ip.split('%')[0].toLowerCase();
+  if (lower === '::' || lower === '::1') return true;
+  const first = ipv6Hextets(lower)[0] ?? 0;
+  if ((first & 0xffc0) === 0xfe80) return true; // link-local fe80::/10
+  if ((first & 0xfe00) === 0xfc00) return true; // unique-local fc00::/7
+  if ((first & 0xff00) === 0xff00) return true; // multicast ff00::/8
+  const v4 = embeddedIpv4(lower);
+  return v4 !== null && isBlockedIpv4(v4);
+}
+
+/** True when the address must not be dialed while the guard is enabled. */
+export function isBlockedOutboundAddress(address: string): boolean {
+  const version = isIP(address);
+  if (version === 4) return isBlockedIpv4(address);
+  if (version === 6) return isBlockedIpv6(address);
+  return true;
+}
+
+export class BlockedOutboundUrlError extends Error {
+  constructor(host: string) {
+    super(
+      `Outbound integration host resolves to a blocked address: ${host}. ` +
+        'This deployment sets INTEGRATION_ALLOW_LOCAL_CONNECTIONS=false; use a ' +
+        'publicly routable provider URL or lift that restriction.',
+    );
+    this.name = 'BlockedOutboundUrlError';
+  }
+}
+
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address: any,
+  family?: number,
+) => void;
+
+function guardedLookup(
+  hostname: string,
+  options: { all?: boolean },
+  callback: LookupCallback,
+): void {
+  lookup(hostname, { ...options, all: true }, (err, addresses) => {
+    if (err) return callback(err, undefined);
+    const list = Array.isArray(addresses)
+      ? addresses
+      : [{ address: addresses as unknown as string, family: 4 }];
+    if (list.some((entry) => isBlockedOutboundAddress(entry.address))) {
+      return callback(new BlockedOutboundUrlError(hostname), undefined);
+    }
+    if (options.all) return callback(null, list);
+    callback(null, list[0].address, list[0].family);
+  });
+}
+
+let guardedAgent: Agent | undefined;
+
+function getGuardedAgent(): Agent {
+  guardedAgent ??= new Agent({ connect: { lookup: guardedLookup as any } });
+  return guardedAgent;
+}
+
+/**
+ * Save-time validation: friendly error for the admin connection form. The
+ * dial-time hook stays authoritative; this only fails fast on configs that
+ * could never be dialed.
+ */
+export async function assertAllowedOutboundUrl(rawUrl: string): Promise<void> {
+  if (allowLocalConnections()) return;
+  const hostname = new URL(rawUrl).hostname.replace(/^\[|\]$/g, '');
+  if (isIP(hostname)) {
+    if (isBlockedOutboundAddress(hostname)) {
+      throw new BlockedOutboundUrlError(hostname);
+    }
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    // Only surface guard verdicts here — a transient DNS failure should not
+    // block saving a connection the dial-time hook will police anyway.
+    guardedLookup(hostname, { all: true }, (err) =>
+      err instanceof BlockedOutboundUrlError ? reject(err) : resolve(),
+    );
+  });
+}
+
+/**
+ * The only way integration code performs outbound HTTP. Applies the guard
+ * (when enabled) to both IP-literal and DNS-resolved destinations; with the
+ * guard disabled it behaves exactly like global fetch.
+ */
+export function outboundFetch(
+  url: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const signal = init.signal ?? AbortSignal.timeout(integrationRequestTimeoutMs());
+  if (allowLocalConnections()) {
+    return undiciFetch(url, { ...init, signal });
+  }
+  const hostname = new URL(url).hostname.replace(/^\[|\]$/g, '');
+  if (isIP(hostname) && isBlockedOutboundAddress(hostname)) {
+    return Promise.reject(new BlockedOutboundUrlError(hostname));
+  }
+  return undiciFetch(url, { ...init, signal, dispatcher: getGuardedAgent() });
+}

--- a/apps/server/src/integrations/integration-oauth/resource.types.ts
+++ b/apps/server/src/integrations/integration-oauth/resource.types.ts
@@ -1,0 +1,168 @@
+export type IntegrationResourceRenderKind = 'item-card' | 'table-report';
+
+export interface IntegrationResourcePickerManifest {
+  placeholder?: string;
+  emptyLabel?: string;
+  searchOnEmpty?: boolean;
+}
+
+export interface IntegrationResourceMenuManifest {
+  title: string;
+  description?: string;
+  searchTerms?: string[];
+  icon?: 'link' | 'table';
+}
+
+export interface IntegrationResourceSearchResult {
+  /** Stable provider-owned key persisted in the editor node. */
+  key: string;
+  title: string;
+  subtitle?: string;
+  badge?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntegrationItemCardPayload {
+  kind: 'item-card';
+  key: string;
+  title: string;
+  url?: string;
+  status?: string;
+  priority?: string;
+  assignee?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntegrationTableReportRow {
+  id: string;
+  key?: string;
+  title: string;
+  url?: string;
+  status?: string;
+  assignee?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IntegrationTableReportPayload {
+  kind: 'table-report';
+  title: string;
+  description?: string;
+  total?: number;
+  rows: IntegrationTableReportRow[];
+  /**
+   * 1-based page this payload covers. Resolve is re-invoked with
+   * `params: { page }` when the view loads more rows; providers that
+   * support paging read it and set `hasMore` accordingly.
+   */
+  page?: number;
+  /** True when rows exist beyond this page — enables the Load more control. */
+  hasMore?: boolean;
+}
+
+export type IntegrationResolvedResource =
+  | IntegrationItemCardPayload
+  | IntegrationTableReportPayload;
+
+/**
+ * Outbound provider access scoped to one (integration, workspace, user,
+ * resource). GET-only, and every path must match one of the resource's
+ * declared `security.outboundPaths` — the framework rejects anything else.
+ */
+export interface IntegrationResourceClient {
+  get<T = unknown>(
+    path: string,
+    query?: Record<string, string | number | undefined>,
+  ): Promise<T>;
+  /** Resolved connection base URL — for building display links. */
+  baseUrl(): Promise<string>;
+  /** Admin-configured connection settings declared by the manifest. */
+  settings(): Promise<Record<string, string>>;
+}
+
+export interface IntegrationResourceContext {
+  integrationId: string;
+  workspaceId: string;
+  userId: string;
+  client: IntegrationResourceClient;
+}
+
+export interface IntegrationResourceSearchArgs {
+  q?: string;
+  limit?: number;
+}
+
+export interface IntegrationResourceResolveArgs {
+  resourceKey: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * Paste-to-embed URL pattern, matched client-side against text typed or
+ * pasted into the editor. `pattern` is a regex source applied after the
+ * connection's base URL; capture provider keys with named groups and
+ * reference them in `resourceKey` as `{name}`.
+ */
+export interface IntegrationResourceUrlPattern {
+  pattern: string;
+  /** e.g. 'id:{id}' */
+  resourceKey: string;
+}
+
+/**
+ * Declarative, safe resource surface exposed to the editor. Providers own all
+ * outbound paths and normalization here; the generic controller never accepts
+ * arbitrary provider paths, methods, or unvetted query forwarding.
+ */
+export interface IntegrationResourceManifest {
+  id: string;
+  title: string;
+  description?: string;
+  renderKind: IntegrationResourceRenderKind;
+  searchTerms?: string[];
+  picker?: IntegrationResourcePickerManifest;
+  menu?: IntegrationResourceMenuManifest;
+  /** Provider URLs that auto-convert to embeds when pasted in the editor. */
+  urlPatterns?: IntegrationResourceUrlPattern[];
+  /**
+   * Enforced outbound allowlist: `search`/`resolve` may only GET paths
+   * matching these patterns (`:param` segments match one path segment).
+   * A resource that declares none cannot reach the provider at all.
+   */
+  security?: {
+    outboundPaths: string[];
+  };
+  search?: (
+    ctx: IntegrationResourceContext,
+    args: IntegrationResourceSearchArgs,
+  ) => Promise<IntegrationResourceSearchResult[]>;
+  resolve: (
+    ctx: IntegrationResourceContext,
+    args: IntegrationResourceResolveArgs,
+  ) => Promise<IntegrationResolvedResource>;
+}
+
+export interface PublicIntegrationResourceManifest {
+  id: string;
+  title: string;
+  description?: string;
+  renderKind: IntegrationResourceRenderKind;
+  searchTerms: string[];
+  picker?: IntegrationResourcePickerManifest;
+  menu?: IntegrationResourceMenuManifest;
+  urlPatterns?: IntegrationResourceUrlPattern[];
+}
+
+export function toPublicResourceManifest(
+  resource: IntegrationResourceManifest,
+): PublicIntegrationResourceManifest {
+  return {
+    id: resource.id,
+    title: resource.title,
+    description: resource.description,
+    renderKind: resource.renderKind,
+    searchTerms: resource.searchTerms ?? [],
+    picker: resource.picker,
+    menu: resource.menu,
+    urlPatterns: resource.urlPatterns,
+  };
+}

--- a/apps/server/src/integrations/windshift/windshift.manifest.ts
+++ b/apps/server/src/integrations/windshift/windshift.manifest.ts
@@ -1,0 +1,40 @@
+import { IntegrationManifest } from '../integration-oauth/manifest.types';
+import { WINDSHIFT_RESOURCES } from './windshift.resources';
+
+/**
+ * Windshift provider definition. A workspace admin supplies the base connection
+ * through Settings → Workspace integrations, or the deployment can provide
+ * WINDSHIFT_* env defaults. Either way, users authorize their own Windshift
+ * accounts; the admin setup is not a shared bearer token.
+ *
+ * Register the per-connection redirect URI shown in the admin form
+ * (`${APP_URL}/api/integrations/oauth/<integrationId>/callback`) in the
+ * matching windshift oauth_clients row.
+ */
+export const WINDSHIFT_MANIFEST: IntegrationManifest = {
+  id: 'windshift',
+  name: 'Windshift',
+  description:
+    'Embed live windshift items and collection reports in docmost pages.',
+  baseUrl: () => process.env.WINDSHIFT_BASE_URL ?? '',
+  baseUrlPlaceholder: 'https://windshift.example.com',
+  authorizePath: '/oauth/authorize',
+  tokenPath: '/api/oauth/token',
+  scopes: ['items:read', 'workspaces:read', 'collections:read'],
+  scopeSeparator: ' ',
+  pkce: true,
+  clientIdEnv: 'WINDSHIFT_OAUTH_CLIENT_ID',
+  clientSecretEnv: 'WINDSHIFT_OAUTH_CLIENT_SECRET',
+  connectionSettings: [
+    {
+      key: 'defaultWorkspaceKey',
+      label: 'Default workspace key',
+      description:
+        'Item-picker shorthand: a bare number like 123 resolves against this workspace.',
+      placeholder: 'WI',
+      pattern: '^[A-Za-z][A-Za-z0-9]*$',
+      transform: 'uppercase',
+    },
+  ],
+  resources: WINDSHIFT_RESOURCES,
+};

--- a/apps/server/src/integrations/windshift/windshift.manifest.ts
+++ b/apps/server/src/integrations/windshift/windshift.manifest.ts
@@ -4,12 +4,9 @@ import { WINDSHIFT_RESOURCES } from './windshift.resources';
 /**
  * Windshift provider definition. A workspace admin supplies the base connection
  * through Settings → Workspace integrations, or the deployment can provide
- * WINDSHIFT_* env defaults. Either way, users authorize their own Windshift
- * accounts; the admin setup is not a shared bearer token.
- *
- * Register the per-connection redirect URI shown in the admin form
- * (`${APP_URL}/api/integrations/oauth/<integrationId>/callback`) in the
- * matching windshift oauth_clients row.
+ * WINDSHIFT_* env defaults. For workspace configuration, Docmost registers a
+ * public client automatically. Either way, users authorize their own
+ * Windshift accounts; the admin setup is not a shared bearer token.
  */
 export const WINDSHIFT_MANIFEST: IntegrationManifest = {
   id: 'windshift',
@@ -23,6 +20,10 @@ export const WINDSHIFT_MANIFEST: IntegrationManifest = {
   scopes: ['items:read', 'workspaces:read', 'collections:read'],
   scopeSeparator: ' ',
   pkce: true,
+  dynamicClientRegistration: {
+    path: '/api/oauth/register',
+    clientName: 'Docmost Windshift',
+  },
   clientIdEnv: 'WINDSHIFT_OAUTH_CLIENT_ID',
   clientSecretEnv: 'WINDSHIFT_OAUTH_CLIENT_SECRET',
   connectionSettings: [

--- a/apps/server/src/integrations/windshift/windshift.module.ts
+++ b/apps/server/src/integrations/windshift/windshift.module.ts
@@ -1,0 +1,25 @@
+import { Injectable, Logger, Module, OnModuleInit } from '@nestjs/common';
+import { IntegrationOAuthRegistry } from '../integration-oauth/manifest.registry';
+import { WINDSHIFT_MANIFEST } from './windshift.manifest';
+
+/**
+ * Registers the Windshift provider manifest at boot. User-facing resource and
+ * OAuth lists still hide it until a workspace admin configures a base
+ * connection (or legacy WINDSHIFT_* env vars provide one).
+ */
+@Injectable()
+class WindshiftRegistration implements OnModuleInit {
+  private readonly logger = new Logger(WindshiftRegistration.name);
+
+  constructor(private readonly registry: IntegrationOAuthRegistry) {}
+
+  onModuleInit(): void {
+    this.registry.register(WINDSHIFT_MANIFEST);
+    this.logger.log('Registered windshift integration provider');
+  }
+}
+
+@Module({
+  providers: [WindshiftRegistration],
+})
+export class WindshiftModule {}

--- a/apps/server/src/integrations/windshift/windshift.resources.spec.ts
+++ b/apps/server/src/integrations/windshift/windshift.resources.spec.ts
@@ -1,0 +1,277 @@
+import {
+  IntegrationResourceContext,
+  IntegrationTableReportPayload,
+} from '../integration-oauth/resource.types';
+import { WINDSHIFT_RESOURCES } from './windshift.resources';
+
+const itemResource = WINDSHIFT_RESOURCES.find((r) => r.id === 'item')!;
+const reportResource = WINDSHIFT_RESOURCES.find(
+  (r) => r.id === 'collectionReport',
+)!;
+
+const WINDSHIFT_ITEM = {
+  id: 7,
+  workspace_id: 2,
+  workspace_key: 'WI',
+  workspace_item_number: 123,
+  title: 'Fix the flux capacitor',
+  status: { name: 'In Progress' },
+  priority: { name: 'High' },
+  assignee: { full_name: 'Doc Brown', email: 'doc@example.com' },
+};
+
+function fakeCtx(overrides: {
+  get?: jest.Mock;
+  settings?: Record<string, string>;
+  baseUrl?: string;
+}): IntegrationResourceContext & { get: jest.Mock } {
+  const get = overrides.get ?? jest.fn();
+  return {
+    integrationId: 'windshift:1111',
+    workspaceId: 'ws-1',
+    userId: 'user-1',
+    get,
+    client: {
+      get,
+      baseUrl: jest.fn().mockResolvedValue(overrides.baseUrl ?? 'https://ws.example.com'),
+      settings: jest.fn().mockResolvedValue(overrides.settings ?? {}),
+    },
+  };
+}
+
+describe('windshift item resource', () => {
+  describe('search', () => {
+    it('returns nothing for an empty query without calling the provider', async () => {
+      const ctx = fakeCtx({});
+      await expect(itemResource.search!(ctx, { q: '  ' })).resolves.toEqual([]);
+      expect(ctx.get).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits direct item keys like WI-123', async () => {
+      const ctx = fakeCtx({});
+      const results = await itemResource.search!(ctx, { q: 'wi-123' });
+      expect(results).toEqual([{ key: 'WI-123', title: 'WI-123', badge: 'WI-123' }]);
+      expect(ctx.get).not.toHaveBeenCalled();
+    });
+
+    it('resolves bare numbers against the connection default workspace key', async () => {
+      const ctx = fakeCtx({ settings: { defaultWorkspaceKey: 'WI' } });
+      const results = await itemResource.search!(ctx, { q: '123' });
+      expect(results).toEqual([{ key: 'WI-123', title: 'WI-123', badge: 'WI-123' }]);
+    });
+
+    it('treats bare numbers as text search when no default workspace key is set', async () => {
+      const ctx = fakeCtx({ get: jest.fn().mockResolvedValue({ data: [] }) });
+      await itemResource.search!(ctx, { q: '123' });
+      expect(ctx.get).toHaveBeenCalledWith('/rest/api/v1/search/items', {
+        q: '123',
+        limit: 10,
+        exclude_personal: 'true',
+      });
+    });
+
+    it('normalizes provider search results', async () => {
+      const ctx = fakeCtx({
+        get: jest.fn().mockResolvedValue({ data: [WINDSHIFT_ITEM] }),
+      });
+      const results = await itemResource.search!(ctx, { q: 'flux', limit: 5 });
+      expect(ctx.get).toHaveBeenCalledWith('/rest/api/v1/search/items', {
+        q: 'flux',
+        limit: 5,
+        exclude_personal: 'true',
+      });
+      expect(results).toEqual([
+        {
+          key: 'WI-123',
+          title: 'Fix the flux capacitor',
+          subtitle: 'In Progress',
+          badge: 'WI-123',
+          metadata: { workspaceKey: 'WI', itemNumber: 123 },
+        },
+      ]);
+    });
+  });
+
+  describe('resolve', () => {
+    it('resolves workspace keys through the workspace item endpoint', async () => {
+      const ctx = fakeCtx({
+        get: jest.fn().mockResolvedValue(WINDSHIFT_ITEM),
+      });
+      const payload = await itemResource.resolve(ctx, { resourceKey: 'WI-123' });
+      expect(ctx.get).toHaveBeenCalledWith('/rest/api/v1/workspaces/WI/items/123', {
+        exclude_personal: 'true',
+      });
+      expect(payload).toMatchObject({
+        kind: 'item-card',
+        key: 'WI-123',
+        title: 'Fix the flux capacitor',
+        url: 'https://ws.example.com/workspaces/2/items/7',
+        status: 'In Progress',
+        priority: 'High',
+        assignee: 'Doc Brown',
+      });
+    });
+
+    it('canonicalizes paste-url id: keys via the items endpoint', async () => {
+      const ctx = fakeCtx({
+        get: jest.fn().mockResolvedValue(WINDSHIFT_ITEM),
+      });
+      const payload = await itemResource.resolve(ctx, { resourceKey: 'id:7' });
+      expect(ctx.get).toHaveBeenCalledWith('/rest/api/v1/items/7', {
+        exclude_personal: 'true',
+      });
+      expect(payload).toMatchObject({ kind: 'item-card', key: 'WI-123' });
+    });
+
+    it('rejects malformed keys with a 400-shaped error', async () => {
+      const ctx = fakeCtx({});
+      await expect(
+        itemResource.resolve(ctx, { resourceKey: '!!nope!!' }),
+      ).rejects.toMatchObject({ status: 400 });
+      expect(ctx.get).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('windshift collectionReport resource', () => {
+  const COLLECTION = {
+    id: 4,
+    slug: 'sprint-board',
+    name: 'Sprint board',
+    description: 'Current sprint',
+  };
+
+  describe('search', () => {
+    it('lists collections and maps slug keys', async () => {
+      const ctx = fakeCtx({
+        get: jest.fn().mockResolvedValue({ data: [COLLECTION] }),
+      });
+      const results = await reportResource.search!(ctx, { q: 'sprint' });
+      expect(ctx.get).toHaveBeenCalledWith('/rest/api/v1/collections', {
+        q: 'sprint',
+        limit: 10,
+      });
+      expect(results).toEqual([
+        {
+          key: 'sprint-board',
+          title: 'Sprint board',
+          subtitle: 'Current sprint',
+          badge: 'sprint-board',
+        },
+      ]);
+    });
+
+    it('falls back to numeric ids for slugless collections', async () => {
+      const ctx = fakeCtx({
+        get: jest
+          .fn()
+          .mockResolvedValue({ data: [{ ...COLLECTION, slug: undefined }] }),
+      });
+      const results = await reportResource.search!(ctx, {});
+      expect(results[0].key).toBe('4');
+    });
+  });
+
+  describe('resolve', () => {
+    function reportCtx(pagination: Record<string, unknown>) {
+      return fakeCtx({
+        get: jest.fn().mockImplementation((path: string) => {
+          if (path.endsWith('/items')) {
+            return Promise.resolve({ data: [WINDSHIFT_ITEM], pagination });
+          }
+          return Promise.resolve(COLLECTION);
+        }),
+      });
+    }
+
+    it('serves page 1 by default and normalizes rows', async () => {
+      const ctx = reportCtx({ total: 120, has_more: true });
+      const payload = (await reportResource.resolve(ctx, {
+        resourceKey: 'sprint-board',
+      })) as IntegrationTableReportPayload;
+      expect(ctx.get).toHaveBeenCalledWith(
+        '/rest/api/v1/collections/sprint-board/items',
+        { page: 1, limit: 50, exclude_personal: 'true' },
+      );
+      expect(payload).toMatchObject({
+        kind: 'table-report',
+        title: 'Sprint board',
+        total: 120,
+        page: 1,
+        hasMore: true,
+      });
+      expect(payload.rows).toEqual([
+        {
+          id: '7',
+          key: 'WI-123',
+          title: 'Fix the flux capacitor',
+          url: 'https://ws.example.com/workspaces/2/items/7',
+          status: 'In Progress',
+          assignee: 'Doc Brown',
+        },
+      ]);
+    });
+
+    it('passes the requested page through to the provider', async () => {
+      const ctx = reportCtx({ total: 120, has_more: false });
+      const payload = (await reportResource.resolve(ctx, {
+        resourceKey: 'sprint-board',
+        params: { page: 3 },
+      })) as IntegrationTableReportPayload;
+      expect(ctx.get).toHaveBeenCalledWith(
+        '/rest/api/v1/collections/sprint-board/items',
+        { page: 3, limit: 50, exclude_personal: 'true' },
+      );
+      expect(payload.page).toBe(3);
+      expect(payload.hasMore).toBe(false);
+    });
+
+    it.each([
+      [undefined, 1],
+      [{ page: 0 }, 1],
+      [{ page: -5 }, 1],
+      [{ page: 2.5 }, 1],
+      [{ page: 'evil' }, 1],
+      [{ page: 99999999 }, 1000],
+    ])('clamps params %p to page %i', async (params, expected) => {
+      const ctx = reportCtx({});
+      await reportResource.resolve(ctx, {
+        resourceKey: 'sprint-board',
+        params: params as Record<string, unknown> | undefined,
+      });
+      expect(ctx.get).toHaveBeenCalledWith(
+        '/rest/api/v1/collections/sprint-board/items',
+        { page: expected, limit: 50, exclude_personal: 'true' },
+      );
+    });
+
+    it('reports hasMore=false when the provider omits pagination', async () => {
+      const ctx = fakeCtx({
+        get: jest.fn().mockImplementation((path: string) =>
+          Promise.resolve(
+            path.endsWith('/items') ? { data: [WINDSHIFT_ITEM] } : COLLECTION,
+          ),
+        ),
+      });
+      const payload = (await reportResource.resolve(ctx, {
+        resourceKey: 'sprint-board',
+      })) as IntegrationTableReportPayload;
+      expect(payload.hasMore).toBe(false);
+      expect(payload.total).toBe(1);
+    });
+  });
+});
+
+describe('personal workspace exclusion', () => {
+  it('passes exclude_personal so the API hides personal items (404 passthrough)', async () => {
+    const notFound = new Error('Item not found') as Error & { status?: number };
+    notFound.status = 404;
+    const ctx = fakeCtx({ get: jest.fn().mockRejectedValue(notFound) });
+    await expect(
+      itemResource.resolve(ctx, { resourceKey: 'PERS-4' }),
+    ).rejects.toMatchObject({ status: 404 });
+    expect(ctx.get).toHaveBeenCalledWith('/rest/api/v1/workspaces/PERS/items/4', {
+      exclude_personal: 'true',
+    });
+  });
+});

--- a/apps/server/src/integrations/windshift/windshift.resources.ts
+++ b/apps/server/src/integrations/windshift/windshift.resources.ts
@@ -1,0 +1,277 @@
+import {
+  IntegrationItemCardPayload,
+  IntegrationResourceContext,
+  IntegrationResourceManifest,
+  IntegrationResourceSearchResult,
+  IntegrationTableReportPayload,
+} from '../integration-oauth/resource.types';
+
+interface WindshiftItem {
+  id: number;
+  workspace_id: number;
+  workspace_key: string;
+  workspace_item_number: number;
+  key?: string;
+  title: string;
+  status?: { name?: string };
+  priority?: { name?: string };
+  assignee?: { full_name?: string; email?: string };
+}
+
+interface WindshiftCollection {
+  id: number;
+  slug?: string;
+  name: string;
+  description?: string;
+}
+
+function windshiftUrl(baseUrl: string, path: string): string | undefined {
+  const base = baseUrl.replace(/\/+$/, '');
+  if (!base) return undefined;
+  return `${base}${path}`;
+}
+
+function itemKey(item: WindshiftItem): string {
+  return item.key || `${item.workspace_key}-${item.workspace_item_number}`;
+}
+
+function itemUrl(baseUrl: string, item: WindshiftItem): string | undefined {
+  return windshiftUrl(
+    baseUrl,
+    `/workspaces/${item.workspace_id}/items/${item.id}`,
+  );
+}
+
+function normalizeItemCard(
+  baseUrl: string,
+  item: WindshiftItem,
+): IntegrationItemCardPayload {
+  return {
+    kind: 'item-card',
+    key: itemKey(item),
+    title: item.title,
+    url: itemUrl(baseUrl, item),
+    status: item.status?.name,
+    priority: item.priority?.name,
+    assignee: item.assignee?.full_name ?? item.assignee?.email,
+    metadata: {
+      id: item.id,
+      workspaceId: item.workspace_id,
+      workspaceKey: item.workspace_key,
+      itemNumber: item.workspace_item_number,
+    },
+  };
+}
+
+function normalizeItemSearch(
+  item: WindshiftItem,
+): IntegrationResourceSearchResult {
+  return {
+    key: itemKey(item),
+    title: item.title,
+    subtitle: item.status?.name,
+    badge: itemKey(item),
+    metadata: {
+      workspaceKey: item.workspace_key,
+      itemNumber: item.workspace_item_number,
+    },
+  };
+}
+
+function parseItemKey(
+  raw: string,
+): { workspaceKey: string; itemNumber: number } | null {
+  const match = raw.trim().match(/^([A-Za-z][A-Za-z0-9]*)[-_\s]?(\d+)$/);
+  if (!match) return null;
+  return {
+    workspaceKey: match[1].toUpperCase(),
+    itemNumber: Number.parseInt(match[2], 10),
+  };
+}
+
+/**
+ * Like parseItemKey, but also accepts a bare item number ("123") when the
+ * admin configured a default workspace key on the connection.
+ */
+async function parseQueryItemKey(
+  ctx: IntegrationResourceContext,
+  raw: string,
+): Promise<{ workspaceKey: string; itemNumber: number } | null> {
+  const direct = parseItemKey(raw);
+  if (direct) return direct;
+  if (!/^\d+$/.test(raw)) return null;
+  const { defaultWorkspaceKey } = await ctx.client.settings();
+  if (!defaultWorkspaceKey) return null;
+  return {
+    workspaceKey: defaultWorkspaceKey,
+    itemNumber: Number.parseInt(raw, 10),
+  };
+}
+
+function collectionKey(collection: WindshiftCollection): string {
+  return collection.slug && collection.slug.length > 0
+    ? collection.slug
+    : String(collection.id);
+}
+
+const REPORT_PAGE_SIZE = 50;
+const REPORT_MAX_PAGE = 1000;
+
+/** Clamps the view-supplied `params.page` to a sane 1-based page number. */
+function reportPage(params: Record<string, unknown> | undefined): number {
+  const raw = params?.page;
+  const page = typeof raw === 'number' ? raw : Number.parseInt(String(raw ?? ''), 10);
+  if (!Number.isInteger(page) || page < 1) return 1;
+  return Math.min(page, REPORT_MAX_PAGE);
+}
+
+export const WINDSHIFT_RESOURCES: IntegrationResourceManifest[] = [
+  {
+    id: 'item',
+    title: 'Windshift item',
+    description: 'Embed a live Windshift item card.',
+    renderKind: 'item-card',
+    searchTerms: ['windshift', 'item', 'ticket', 'task'],
+    picker: {
+      placeholder: 'Search by title or paste WI-123',
+      emptyLabel: 'No matching items',
+    },
+    menu: {
+      title: 'Windshift item',
+      description: 'Embed a live Windshift item card',
+      searchTerms: ['windshift', 'item', 'ticket', 'task'],
+      icon: 'link',
+    },
+    urlPatterns: [
+      {
+        pattern: '/workspaces/\\d+/items/(?<id>\\d+)',
+        resourceKey: 'id:{id}',
+      },
+    ],
+    security: {
+      outboundPaths: [
+        '/rest/api/v1/search/items',
+        '/rest/api/v1/workspaces/:workspaceKey/items/:itemNumber',
+        '/rest/api/v1/items/:id',
+      ],
+    },
+    async search(ctx, args) {
+      const q = args.q?.trim() ?? '';
+      if (!q) return [];
+
+      const parsed = await parseQueryItemKey(ctx, q);
+      if (parsed) {
+        const key = `${parsed.workspaceKey}-${parsed.itemNumber}`;
+        return [{ key, title: key, badge: key }];
+      }
+
+      // Personal-workspace items must never surface on a shared page; the
+      // API enforces this server-side via exclude_personal.
+      const body = await ctx.client.get<{ data?: WindshiftItem[] }>(
+        '/rest/api/v1/search/items',
+        { q, limit: args.limit ?? 10, exclude_personal: 'true' },
+      );
+      return (body.data ?? []).map(normalizeItemSearch);
+    },
+    async resolve(ctx, args) {
+      let item: WindshiftItem;
+      const idHint = args.resourceKey.startsWith('id:')
+        ? Number.parseInt(args.resourceKey.slice(3), 10)
+        : undefined;
+      if (idHint && Number.isFinite(idHint)) {
+        item = await ctx.client.get<WindshiftItem>(
+          `/rest/api/v1/items/${encodeURIComponent(String(idHint))}`,
+          { exclude_personal: 'true' },
+        );
+      } else {
+        const parsed = parseItemKey(args.resourceKey);
+        if (!parsed) {
+          const err = new Error('Invalid Windshift item key');
+          (err as Error & { status?: number }).status = 400;
+          throw err;
+        }
+        item = await ctx.client.get<WindshiftItem>(
+          `/rest/api/v1/workspaces/${encodeURIComponent(parsed.workspaceKey)}/items/${encodeURIComponent(String(parsed.itemNumber))}`,
+          { exclude_personal: 'true' },
+        );
+      }
+      const baseUrl = await ctx.client.baseUrl();
+      return normalizeItemCard(baseUrl, item);
+    },
+  },
+  {
+    id: 'collectionReport',
+    title: 'Windshift report',
+    description: 'Embed a live Windshift collection report.',
+    renderKind: 'table-report',
+    searchTerms: ['windshift', 'report', 'collection', 'table'],
+    picker: {
+      placeholder: 'Search collections by name…',
+      emptyLabel: 'No matching collections',
+      searchOnEmpty: true,
+    },
+    menu: {
+      title: 'Windshift report',
+      description: 'Embed a live Windshift collection report',
+      searchTerms: ['windshift', 'report', 'collection', 'table'],
+      icon: 'table',
+    },
+    security: {
+      outboundPaths: [
+        '/rest/api/v1/collections',
+        '/rest/api/v1/collections/:key',
+        '/rest/api/v1/collections/:key/items',
+      ],
+    },
+    async search(ctx, args) {
+      const query: Record<string, string | number | undefined> = {
+        limit: args.limit ?? 10,
+      };
+      if (args.q) query.q = args.q;
+      const body = await ctx.client.get<{
+        items?: WindshiftCollection[];
+        data?: WindshiftCollection[];
+      }>('/rest/api/v1/collections', query);
+      return (body.items ?? body.data ?? []).map((collection) => ({
+        key: collectionKey(collection),
+        title: collection.name,
+        subtitle: collection.description,
+        badge: collection.slug,
+      }));
+    },
+    async resolve(ctx, args) {
+      const key = args.resourceKey;
+      const page = reportPage(args.params);
+      const collection = await ctx.client.get<WindshiftCollection>(
+        `/rest/api/v1/collections/${encodeURIComponent(key)}`,
+      );
+      const body = await ctx.client.get<{
+        data?: WindshiftItem[];
+        pagination?: { total?: number; has_more?: boolean };
+      }>(`/rest/api/v1/collections/${encodeURIComponent(key)}/items`, {
+        page,
+        limit: REPORT_PAGE_SIZE,
+        exclude_personal: 'true',
+      });
+      const rows = body.data ?? [];
+      const baseUrl = await ctx.client.baseUrl();
+      const payload: IntegrationTableReportPayload = {
+        kind: 'table-report',
+        title: collection.name,
+        description: collection.description,
+        total: body.pagination?.total ?? rows.length,
+        page,
+        hasMore: body.pagination?.has_more ?? false,
+        rows: rows.map((item) => ({
+          id: String(item.id),
+          key: itemKey(item),
+          title: item.title,
+          url: itemUrl(baseUrl, item),
+          status: item.status?.name,
+          assignee: item.assignee?.full_name ?? item.assignee?.email,
+        })),
+      };
+      return payload;
+    },
+  },
+];

--- a/packages/editor-ext/src/index.ts
+++ b/packages/editor-ext/src/index.ts
@@ -20,6 +20,7 @@ export * from "./lib/mention";
 export * from "./lib/markdown";
 export * from "./lib/search-and-replace";
 export * from "./lib/embed-provider";
+export * from "./lib/integration-embed";
 export * from "./lib/subpages";
 export * from "./lib/transclusion";
 export * from "./lib/highlight";

--- a/packages/editor-ext/src/lib/integration-embed.ts
+++ b/packages/editor-ext/src/lib/integration-embed.ts
@@ -1,0 +1,152 @@
+import { Node, mergeAttributes, nodeInputRule } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+export interface IntegrationEmbedAttributes {
+  integrationId?: string;
+  resourceId?: string;
+  resourceKey?: string;
+  labelAtInsert?: string;
+  renderKind?: "item-card" | "table-report" | string;
+  params?: Record<string, unknown> | null;
+}
+
+/** Structural twin of tiptap's InputRuleMatch — lets callers supply dynamic finders. */
+export interface IntegrationEmbedInputRuleMatch {
+  index: number;
+  text: string;
+  replaceWith?: string;
+  match?: RegExpMatchArray;
+  data?: Record<string, any>;
+}
+
+export interface IntegrationEmbedInputRule {
+  find: RegExp | ((text: string) => IntegrationEmbedInputRuleMatch | null);
+  getAttributes: (
+    match: RegExpMatchArray & { data?: Record<string, any> },
+  ) => IntegrationEmbedAttributes;
+}
+
+export interface IntegrationEmbedOptions {
+  HTMLAttributes: Record<string, any>;
+  view: any;
+  inputRules: IntegrationEmbedInputRule[];
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    integrationEmbed: {
+      setIntegrationEmbed: (attributes: IntegrationEmbedAttributes) => ReturnType;
+    };
+  }
+}
+
+function parseParams(element: HTMLElement): Record<string, unknown> | null {
+  const raw = element.getAttribute("data-params");
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Ignore malformed persisted attrs and fall back to null.
+  }
+  return null;
+}
+
+export const IntegrationEmbed = Node.create<IntegrationEmbedOptions>({
+  name: "integrationEmbed",
+  inline: false,
+  group: "block",
+  isolating: true,
+  atom: true,
+  defining: true,
+  draggable: true,
+
+  addOptions() {
+    return { HTMLAttributes: {}, view: null, inputRules: [] };
+  },
+
+  addAttributes() {
+    return {
+      integrationId: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-integration-id") ?? "",
+        renderHTML: (attributes: IntegrationEmbedAttributes) => ({
+          "data-integration-id": attributes.integrationId ?? "",
+        }),
+      },
+      resourceId: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-resource-id") ?? "",
+        renderHTML: (attributes: IntegrationEmbedAttributes) => ({
+          "data-resource-id": attributes.resourceId ?? "",
+        }),
+      },
+      resourceKey: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-resource-key") ?? "",
+        renderHTML: (attributes: IntegrationEmbedAttributes) => ({
+          "data-resource-key": attributes.resourceKey ?? "",
+        }),
+      },
+      labelAtInsert: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-label") ?? "",
+        renderHTML: (attributes: IntegrationEmbedAttributes) => ({
+          "data-label": attributes.labelAtInsert ?? "",
+        }),
+      },
+      renderKind: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-render-kind") ?? "",
+        renderHTML: (attributes: IntegrationEmbedAttributes) => ({
+          "data-render-kind": attributes.renderKind ?? "",
+        }),
+      },
+      params: {
+        default: null,
+        parseHTML: parseParams,
+        renderHTML: (attributes: IntegrationEmbedAttributes) => {
+          if (!attributes.params) return {};
+          return { "data-params": JSON.stringify(attributes.params) };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: `div[data-type="${this.name}"]` }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes({ "data-type": this.name }, this.options.HTMLAttributes, HTMLAttributes),
+    ];
+  },
+
+  addCommands() {
+    return {
+      setIntegrationEmbed:
+        (attrs: IntegrationEmbedAttributes) =>
+        ({ commands }) =>
+          commands.insertContent({ type: this.name, attrs }),
+    };
+  },
+
+  addInputRules() {
+    return (this.options.inputRules ?? []).map((rule) =>
+      nodeInputRule({
+        find: rule.find,
+        type: this.type,
+        getAttributes: rule.getAttributes,
+      }),
+    );
+  },
+
+  addNodeView() {
+    this.editor.isInitialized = true;
+    return ReactNodeViewRenderer(this.options.view);
+  },
+});


### PR DESCRIPTION
# feat: Windshift integration provider

## What this is

Adds Windshift on top of the generic integration framework in #2151.

**Depends on:** #2151. Because GitHub cannot use the framework PR's fork branch as this PR's base, the branch is stacked while both PRs remain open.

## OAuth model

This uses a user OAuth flow, not an admin bearer credential:

1. A Docmost workspace admin enters only the Windshift base URL (plus the optional default workspace key).
2. Docmost calls Windshift's RFC 7591 endpoint and registers a public client for that integration connection.
3. Each Docmost member connects their own Windshift account and receives their own encrypted token set.

The public client has no secret, uses authorization code + PKCE, and requests the fixed scope set below in one authorization request. There are no progressive OAuth claims/scopes.

```text
items:read workspaces:read collections:read
```

For legacy environment-based configuration, `WINDSHIFT_OAUTH_CLIENT_ID` and `WINDSHIFT_OAUTH_CLIENT_SECRET` remain supported alongside `WINDSHIFT_BASE_URL`; normal workspace UI setup requires only the base URL.

Windshift's dynamic registration endpoint must be resource-neutral so this REST integration is not assigned the MCP audience. That compatibility change is tracked in [Windshiftapp/core#146](https://github.com/Windshiftapp/core/pull/146). Omni needs no code change because it already supplies `/mcp` explicitly during authorization, token exchange, and refresh.

## Resources

- `item` → normalized `item-card`, including direct keys, text search, stable URLs, and paste auto-unfurl.
- `collectionReport` → normalized, paginated `table-report`.
- Every provider call supplies `exclude_personal=true`, so personal-workspace items are not exposed on shared Docmost pages (requires Windshift 0.8+).

Provider functions own the allowed Windshift endpoints and normalize the API responses; the browser cannot proxy arbitrary requests.

## Validation

- [x] Windshift provider Jest suite: 20 tests.
- [x] Generic integration OAuth Jest suite: 7 suites, 92 tests.
- [x] Client Vitest suite: 3 files, 64 tests.
- [x] Server and client production builds.
- [x] Clean local stack with fresh PostgreSQL, Redis, Docmost storage, and Windshift SQLite database.
- [x] Omni compatibility: Windshift connector 3 tests; connector OAuth integration 5 tests.

## Notes

The previous Windshift-specific proxy/controller/editor-node approach has been removed. Windshift contributes only its manifest, safe resource definitions, provider registration, and optional paste matcher.
