### PR TITLE
fix: sanitize page titles in export filenames to prevent path traversal

### DIFF
--- a/apps/server/src/integrations/export/export.service.ts
+++ b/apps/server/src/integrations/export/export.service.ts
@@ -8,6 +8,7 @@ import { jsonToHtml, jsonToNode } from '../../collaboration/collaboration.util';
 import { ExportFormat } from './dto/export-dto';
 import { Page } from '@docmost/db/types/entity.types';
 import { InjectKysely } from 'nestjs-kysely';
+import { sanitizeFileName } from '../../common/helpers';
 import { KyselyDB } from '@docmost/db/types/kysely.types';
 import * as JSZip from 'jszip';
 import { StorageService } from '../storage/storage.service';
@@ -315,13 +316,14 @@ export class ExportService {
         }
 
         const pageTitle = getPageTitle(page.title);
+        const safePageTitle = sanitizeFileName(pageTitle);
         const pageExportContent = await this.exportPage(format, {
           ...page,
           content: updatedJsonContent,
         });
 
         folder.file(
-          `${pageTitle}${getExportExtension(format)}`,
+          `${safePageTitle}${getExportExtension(format)}`,
           pageExportContent,
         );
 
@@ -339,7 +341,7 @@ export class ExportService {
         };
 
         if (childPages.length > 0) {
-          const pageFolder = folder.folder(pageTitle);
+          const pageFolder = folder.folder(safePageTitle);
           stack.push({ folder: pageFolder, parentPageId: page.id });
         }
       }

--- a/apps/server/src/integrations/export/utils.ts
+++ b/apps/server/src/integrations/export/utils.ts
@@ -6,6 +6,7 @@ import { validate as isValidUUID } from 'uuid';
 import * as path from 'path';
 import { Page } from '@docmost/db/types/entity.types';
 import { isAttachmentNode } from '../../common/helpers/prosemirror/utils';
+import { sanitizeFileName } from '../../common/helpers';
 
 export type PageExportTree = Record<string, Page[]>;
 
@@ -167,7 +168,7 @@ export function computeLocalPath(
   const children = tree[parentPageId] || [];
 
   for (const page of children) {
-    const title = encodeURIComponent(getPageTitle(page.title));
+    const title = encodeURIComponent(sanitizeFileName(getPageTitle(page.title)));
     const localPath = `${currentPath}${title}`;
     slugIdToPath[page.slugId] = `${localPath}${getExportExtension(format)}`;
 


### PR DESCRIPTION
## Problem

Page titles containing slashes (e.g. "Foo 12/2020") created unintended subdirectories in ZIP exports and broken file paths. When a note is titled "Foo 12/2020", the exported file becomes "Foo 12/2020.md" instead of a single file.

## Root cause

 returns the raw title, which is then used directly as ZIP entry paths () and folder names (). No filesystem sanitization is applied.

## Fix

Apply  (already in the codebase) to page titles before using them as ZIP entry paths and local path segments. This strips filesystem-unsafe characters like .

### Files changed

-  — sanitize titles in  for file and folder entries
-  — sanitize titles in  for path mapping

Fixes #1552