### PR TITLE
fix: subpage not loading issue

### DIFF
--- a/apps/client/src/features/editor/components/subpages/subpages-view.tsx
+++ b/apps/client/src/features/editor/components/subpages/subpages-view.tsx
@@ -21,13 +21,20 @@ export default function SubpagesView(props: NodeViewProps) {
 
   //@ts-ignore
   const currentPageId = editor.storage.pageId;
+  //@ts-ignore
+  const currentSpaceId = editor.storage.spaceId;
 
   // Get subpages from shared tree if we're in a shared context
   const sharedSubpages = useSharedPageSubpages(currentPageId);
 
-  const { data, isLoading, error } = useGetSidebarPagesQuery(
-    shareId ? null : { pageId: currentPageId },
-  );
+  const sidebarParams = useMemo(() => {
+    if (shareId || !currentPageId) return null;
+    return currentSpaceId
+      ? { pageId: currentPageId, spaceId: currentSpaceId }
+      : { pageId: currentPageId };
+  }, [currentPageId, currentSpaceId, shareId]);
+
+  const { data, isLoading, error } = useGetSidebarPagesQuery(sidebarParams);
 
   const subpages = useMemo(() => {
     // If we're in a shared context, use the shared subpages

--- a/apps/client/src/features/editor/full-editor.tsx
+++ b/apps/client/src/features/editor/full-editor.tsx
@@ -48,6 +48,7 @@ export interface FullEditorProps {
   title: string;
   content: string;
   spaceSlug: string;
+  spaceId: string;
   editable: boolean;
   creator?: PageUser;
   contributors?: IContributor[];
@@ -60,6 +61,7 @@ export function FullEditor({
   slugId,
   content,
   spaceSlug,
+  spaceId,
   editable,
   creator,
   contributors,
@@ -109,6 +111,7 @@ export function FullEditor({
       />
       <MemoizedPageEditor
         pageId={pageId}
+        spaceId={spaceId}
         editable={editable}
         content={content}
         canComment={canComment}

--- a/apps/client/src/features/editor/page-editor.tsx
+++ b/apps/client/src/features/editor/page-editor.tsx
@@ -78,6 +78,7 @@ import { useTranslation } from "react-i18next";
 
 interface PageEditorProps {
   pageId: string;
+  spaceId: string;
   editable: boolean;
   content: any;
   canComment?: boolean;
@@ -85,6 +86,7 @@ interface PageEditorProps {
 
 export default function PageEditor({
   pageId,
+  spaceId,
   editable,
   content,
   canComment,
@@ -310,6 +312,8 @@ export default function PageEditor({
           setEditor(editor);
           // @ts-ignore
           editor.storage.pageId = pageId;
+          // @ts-ignore
+          editor.storage.spaceId = spaceId;
           handleScrollTo(editor);
           editorRef.current = editor;
         }
@@ -321,7 +325,7 @@ export default function PageEditor({
         debouncedUpdateContent(editorJson);
       },
     },
-    [pageId, editable, extensions],
+    [pageId, spaceId, editable, extensions],
   );
 
   const editorIsEditable = useEditorState({
@@ -418,6 +422,14 @@ export default function PageEditor({
             attributes: {
               "aria-label": t("Page content"),
             },
+          }}
+          onCreate={({ editor }) => {
+            if (editor) {
+              // @ts-ignore
+              editor.storage.pageId = pageId;
+              // @ts-ignore
+              editor.storage.spaceId = spaceId;
+            }
           }}
         />
       ) : (

--- a/apps/client/src/features/page/queries/page-query.test.ts
+++ b/apps/client/src/features/page/queries/page-query.test.ts
@@ -1,0 +1,239 @@
+import { QueryClient } from "@tanstack/react-query";
+import type { InfiniteData } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IPagination } from "@/lib/types";
+import type { IPage } from "@/features/page/types/page.types";
+
+const mocks = vi.hoisted(() => ({
+  queryClient: undefined as any,
+}));
+
+vi.mock("@/main.tsx", () => ({
+  get queryClient() {
+    return mocks.queryClient;
+  },
+}));
+
+import {
+  addPageToSidebarCache,
+  invalidateOnCreatePage,
+  invalidateOnDeletePage,
+  invalidateOnUpdatePage,
+  updateCacheOnMovePage,
+} from "./page-query";
+
+function makePage(overrides: Partial<IPage> & { id: string }): IPage {
+  return {
+    id: overrides.id,
+    slugId: overrides.slugId ?? `${overrides.id}-slug`,
+    title: overrides.title ?? overrides.id,
+    content: "",
+    icon: overrides.icon ?? null,
+    coverPhoto: null,
+    parentPageId: overrides.parentPageId ?? null,
+    creatorId: "user-1",
+    spaceId: overrides.spaceId ?? "space-1",
+    workspaceId: "workspace-1",
+    isLocked: false,
+    lastUpdatedById: "user-1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    position: overrides.position ?? "a0",
+    hasChildren: overrides.hasChildren ?? false,
+    creator: null,
+    lastUpdatedBy: null,
+    deletedBy: null,
+    space: { id: overrides.spaceId ?? "space-1", slug: "space-1" },
+    ...overrides,
+  };
+}
+
+function makeInfiniteData<T>(
+  items: T[],
+): InfiniteData<IPagination<T>, unknown> {
+  return {
+    pageParams: [undefined],
+    pages: [
+      {
+        items,
+        meta: {
+          hasNextPage: false,
+          nextCursor: null,
+        } as any,
+      },
+    ],
+  };
+}
+
+function sidebarItems(queryKey: unknown[]) {
+  const queryClient = mocks.queryClient as QueryClient;
+  return queryClient
+    .getQueryData<InfiniteData<IPagination<Partial<IPage>>, unknown>>(queryKey)
+    ?.pages.flatMap((page) => page.items);
+}
+
+describe("page sidebar cache updates", () => {
+  beforeEach(() => {
+    mocks.queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  it("appends created child pages to sidebar caches with and without spaceId", () => {
+    const parent = makePage({ id: "parent", hasChildren: false });
+    const child = makePage({ id: "child", parentPageId: "parent" });
+
+    const pageIdOnlyKey = ["sidebar-pages", { pageId: "parent" }];
+    const pageWithSpaceKey = [
+      "sidebar-pages",
+      { pageId: "parent", spaceId: "space-1" },
+    ];
+
+    mocks.queryClient.setQueryData(pageIdOnlyKey, makeInfiniteData([]));
+    mocks.queryClient.setQueryData(pageWithSpaceKey, makeInfiniteData([]));
+    mocks.queryClient.setQueryData(
+      ["root-sidebar-pages", "space-1"],
+      makeInfiniteData([parent]),
+    );
+
+    invalidateOnCreatePage(child);
+
+    expect(sidebarItems(pageIdOnlyKey)?.map((page) => page.id)).toEqual([
+      "child",
+    ]);
+    expect(sidebarItems(pageWithSpaceKey)?.map((page) => page.id)).toEqual([
+      "child",
+    ]);
+    expect(
+      sidebarItems(["root-sidebar-pages", "space-1"])?.find(
+        (page) => page.id === "parent",
+      )?.hasChildren,
+    ).toBe(true);
+  });
+
+  it("dedupes local add operations such as duplicate or restore", () => {
+    const child = makePage({ id: "child", parentPageId: "parent" });
+    const pageWithSpaceKey = [
+      "sidebar-pages",
+      { pageId: "parent", spaceId: "space-1" },
+    ];
+
+    mocks.queryClient.setQueryData(pageWithSpaceKey, makeInfiniteData([]));
+
+    addPageToSidebarCache(child);
+    addPageToSidebarCache(child);
+
+    expect(sidebarItems(pageWithSpaceKey)?.map((page) => page.id)).toEqual([
+      "child",
+    ]);
+  });
+
+  it("updates renamed child pages in both sidebar cache key shapes", () => {
+    const child = makePage({ id: "child", parentPageId: "parent" });
+    const pageIdOnlyKey = ["sidebar-pages", { pageId: "parent" }];
+    const pageWithSpaceKey = [
+      "sidebar-pages",
+      { pageId: "parent", spaceId: "space-1" },
+    ];
+
+    mocks.queryClient.setQueryData(pageIdOnlyKey, makeInfiniteData([child]));
+    mocks.queryClient.setQueryData(pageWithSpaceKey, makeInfiniteData([child]));
+
+    invalidateOnUpdatePage("space-1", "parent", "child", "Renamed", "icon");
+
+    expect(sidebarItems(pageIdOnlyKey)?.[0].title).toBe("Renamed");
+    expect(sidebarItems(pageIdOnlyKey)?.[0].icon).toBe("icon");
+    expect(sidebarItems(pageWithSpaceKey)?.[0].title).toBe("Renamed");
+    expect(sidebarItems(pageWithSpaceKey)?.[0].icon).toBe("icon");
+  });
+
+  it("removes deleted pages from both sidebar cache key shapes", () => {
+    const child = makePage({ id: "child", parentPageId: "parent" });
+    const sibling = makePage({ id: "sibling", parentPageId: "parent" });
+    const pageIdOnlyKey = ["sidebar-pages", { pageId: "parent" }];
+    const pageWithSpaceKey = [
+      "sidebar-pages",
+      { pageId: "parent", spaceId: "space-1" },
+    ];
+
+    mocks.queryClient.setQueryData(
+      pageIdOnlyKey,
+      makeInfiniteData([child, sibling]),
+    );
+    mocks.queryClient.setQueryData(
+      pageWithSpaceKey,
+      makeInfiniteData([child, sibling]),
+    );
+
+    invalidateOnDeletePage("child");
+
+    expect(sidebarItems(pageIdOnlyKey)?.map((page) => page.id)).toEqual([
+      "sibling",
+    ]);
+    expect(sidebarItems(pageWithSpaceKey)?.map((page) => page.id)).toEqual([
+      "sibling",
+    ]);
+  });
+
+  it("moves pages between parent sidebar caches with and without spaceId", () => {
+    const oldParent = makePage({ id: "old-parent", hasChildren: true });
+    const newParent = makePage({ id: "new-parent", hasChildren: false });
+    const child = makePage({ id: "child", parentPageId: "old-parent" });
+    const movedChild = { ...child, parentPageId: "new-parent" };
+
+    const oldPageIdOnlyKey = ["sidebar-pages", { pageId: "old-parent" }];
+    const oldPageWithSpaceKey = [
+      "sidebar-pages",
+      { pageId: "old-parent", spaceId: "space-1" },
+    ];
+    const newPageIdOnlyKey = ["sidebar-pages", { pageId: "new-parent" }];
+    const newPageWithSpaceKey = [
+      "sidebar-pages",
+      { pageId: "new-parent", spaceId: "space-1" },
+    ];
+
+    mocks.queryClient.setQueryData(oldPageIdOnlyKey, makeInfiniteData([child]));
+    mocks.queryClient.setQueryData(
+      oldPageWithSpaceKey,
+      makeInfiniteData([child]),
+    );
+    mocks.queryClient.setQueryData(newPageIdOnlyKey, makeInfiniteData([]));
+    mocks.queryClient.setQueryData(newPageWithSpaceKey, makeInfiniteData([]));
+    mocks.queryClient.setQueryData(
+      ["root-sidebar-pages", "space-1"],
+      makeInfiniteData([oldParent, newParent]),
+    );
+
+    updateCacheOnMovePage(
+      "space-1",
+      "child",
+      "old-parent",
+      "new-parent",
+      movedChild,
+    );
+
+    expect(sidebarItems(oldPageIdOnlyKey)).toEqual([]);
+    expect(sidebarItems(oldPageWithSpaceKey)).toEqual([]);
+    expect(sidebarItems(newPageIdOnlyKey)?.map((page) => page.id)).toEqual([
+      "child",
+    ]);
+    expect(sidebarItems(newPageWithSpaceKey)?.map((page) => page.id)).toEqual([
+      "child",
+    ]);
+    expect(
+      sidebarItems(["root-sidebar-pages", "space-1"])?.find(
+        (page) => page.id === "old-parent",
+      )?.hasChildren,
+    ).toBe(false);
+    expect(
+      sidebarItems(["root-sidebar-pages", "space-1"])?.find(
+        (page) => page.id === "new-parent",
+      )?.hasChildren,
+    ).toBe(true);
+  });
+});

--- a/apps/client/src/features/page/queries/page-query.ts
+++ b/apps/client/src/features/page/queries/page-query.ts
@@ -227,7 +227,7 @@ export function useRestorePageMutation() {
         }, 50);
       }
 
-      //  await queryClient.invalidateQueries({ queryKey: ["sidebar-pages", restoredPage.spaceId] });
+      addPageToSidebarCache(restoredPage);
 
       // Also invalidate deleted pages query to refresh the trash list
       await queryClient.invalidateQueries({
@@ -332,7 +332,109 @@ export function useDeletedPagesQuery(
   });
 }
 
-export function invalidateOnCreatePage(data: Partial<IPage>) {
+function isSidebarChildrenQuery(queryKey: QueryKey, pageId: string): boolean {
+  const params = queryKey[1] as SidebarPagesParams | undefined;
+  return queryKey[0] === "sidebar-pages" && params?.pageId === pageId;
+}
+
+function isRootSidebarQuery(queryKey: QueryKey, spaceId: string): boolean {
+  return queryKey[0] === "root-sidebar-pages" && queryKey[1] === spaceId;
+}
+
+function getSidebarQueriesByParent(
+  parentPageId: string | null,
+  spaceId: string,
+) {
+  return queryClient.getQueriesData<InfiniteData<IPagination<Partial<IPage>>>>({
+    predicate: (query) =>
+      parentPageId === null
+        ? isRootSidebarQuery(query.queryKey, spaceId)
+        : isSidebarChildrenQuery(query.queryKey, parentPageId),
+  });
+}
+
+function appendPageToSidebarData(
+  old: InfiniteData<IPagination<Partial<IPage>>> | undefined,
+  pageData: Partial<IPage>,
+) {
+  if (!old) return old;
+
+  const exists = old.pages.some((page) =>
+    page.items.some((item) => item.id === pageData.id),
+  );
+  if (exists) return old;
+
+  return {
+    ...old,
+    pages: old.pages.map((page, index) =>
+      index === old.pages.length - 1
+        ? { ...page, items: [...page.items, pageData] }
+        : page,
+    ),
+  };
+}
+
+function updatePageInSidebarData(
+  old: InfiniteData<IPagination<IPage>> | undefined,
+  pageId: string,
+  data: Partial<IPage>,
+) {
+  if (!old) return old;
+
+  return {
+    ...old,
+    pages: old.pages.map((page) => ({
+      ...page,
+      items: page.items.map((sidebarPage: IPage) =>
+        sidebarPage.id === pageId ? { ...sidebarPage, ...data } : sidebarPage,
+      ),
+    })),
+  };
+}
+
+function removePageFromSidebarData(
+  old: InfiniteData<IPagination<IPage>> | undefined,
+  pageId: string,
+) {
+  if (!old) return old;
+
+  return {
+    ...old,
+    pages: old.pages.map((page) => ({
+      ...page,
+      items: page.items.filter(
+        (sidebarPage: IPage) => sidebarPage.id !== pageId,
+      ),
+    })),
+  };
+}
+
+function sidebarCacheHasItems(parentPageId: string | null, spaceId: string) {
+  return getSidebarQueriesByParent(parentPageId, spaceId).some(([, data]) =>
+    data?.pages.some((page) => page.items.length > 0),
+  );
+}
+
+function updateSidebarPageHasChildren(pageId: string, hasChildren: boolean) {
+  const allSideBarMatches = queryClient.getQueriesData<
+    InfiniteData<IPagination<IPage>>
+  >({
+    predicate: (query) =>
+      query.queryKey[0] === "root-sidebar-pages" ||
+      query.queryKey[0] === "sidebar-pages",
+  });
+
+  allSideBarMatches.forEach(([key]) => {
+    queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(key, (old) =>
+      updatePageInSidebarData(old, pageId, { hasChildren }),
+    );
+  });
+}
+
+export function addPageToSidebarCache(data: Partial<IPage>) {
+  if (!data.id || !data.spaceId) return;
+
+  const parentPageId = data.parentPageId ?? null;
   const newPage: Partial<IPage> = {
     creatorId: data.creatorId,
     hasChildren: data.hasChildren,
@@ -345,84 +447,20 @@ export function invalidateOnCreatePage(data: Partial<IPage>) {
     title: data.title,
   };
 
-  let queryKey: QueryKey = null;
-  if (data.parentPageId === null) {
-    queryKey = ["root-sidebar-pages", data.spaceId];
-  } else {
-    queryKey = [
-      "sidebar-pages",
-      { pageId: data.parentPageId, spaceId: data.spaceId },
-    ];
+  getSidebarQueriesByParent(parentPageId, data.spaceId).forEach(([key]) => {
+    queryClient.setQueryData<InfiniteData<IPagination<Partial<IPage>>>>(
+      key,
+      (old) => appendPageToSidebarData(old, newPage),
+    );
+  });
+
+  if (parentPageId !== null) {
+    updateSidebarPageHasChildren(parentPageId, true);
   }
+}
 
-  //update all sidebar pages
-  queryClient.setQueryData<InfiniteData<IPagination<Partial<IPage>>>>(
-    queryKey,
-    (old) => {
-      if (!old) return old;
-      return {
-        ...old,
-        pages: old.pages.map((page, index) => {
-          if (index === old.pages.length - 1) {
-            return {
-              ...page,
-              items: [...page.items, newPage],
-            };
-          }
-          return page;
-        }),
-      };
-    },
-  );
-
-  //update sidebar haschildren
-  if (data.parentPageId !== null) {
-    //update sub sidebar pages haschildern
-    const subSideBarMatches = queryClient.getQueriesData({
-      queryKey: ["sidebar-pages"],
-      exact: false,
-    });
-
-    subSideBarMatches.forEach(([key, d]) => {
-      queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(key, (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          pages: old.pages.map((page) => ({
-            ...page,
-            items: page.items.map((sidebarPage: IPage) =>
-              sidebarPage.id === data.parentPageId
-                ? { ...sidebarPage, hasChildren: true }
-                : sidebarPage,
-            ),
-          })),
-        };
-      });
-    });
-
-    //update root sidebar pages haschildern
-    const rootSideBarMatches = queryClient.getQueriesData({
-      queryKey: ["root-sidebar-pages", data.spaceId],
-      exact: false,
-    });
-
-    rootSideBarMatches.forEach(([key, d]) => {
-      queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(key, (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          pages: old.pages.map((page) => ({
-            ...page,
-            items: page.items.map((sidebarPage: IPage) =>
-              sidebarPage.id === data.parentPageId
-                ? { ...sidebarPage, hasChildren: true }
-                : sidebarPage,
-            ),
-          })),
-        };
-      });
-    });
-  }
+export function invalidateOnCreatePage(data: Partial<IPage>) {
+  addPageToSidebarCache(data);
 
   //update recent changes
   queryClient.invalidateQueries({
@@ -432,35 +470,17 @@ export function invalidateOnCreatePage(data: Partial<IPage>) {
 
 export function invalidateOnUpdatePage(
   spaceId: string,
-  parentPageId: string,
+  parentPageId: string | null,
   id: string,
   title: string,
   icon: string,
 ) {
-  let queryKey: QueryKey = null;
-  if (parentPageId === null) {
-    queryKey = ["root-sidebar-pages", spaceId];
-  } else {
-    queryKey = ["sidebar-pages", { pageId: parentPageId, spaceId: spaceId }];
-  }
   //update all sidebar pages
-  queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(
-    queryKey,
-    (old) => {
-      if (!old) return old;
-      return {
-        ...old,
-        pages: old.pages.map((page) => ({
-          ...page,
-          items: page.items.map((sidebarPage: IPage) =>
-            sidebarPage.id === id
-              ? { ...sidebarPage, title: title, icon: icon }
-              : sidebarPage,
-          ),
-        })),
-      };
-    },
-  );
+  getSidebarQueriesByParent(parentPageId, spaceId).forEach(([key]) => {
+    queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(key, (old) =>
+      updatePageInSidebarData(old, id, { title, icon }),
+    );
+  });
 
   //update recent changes
   queryClient.invalidateQueries({
@@ -476,118 +496,30 @@ export function updateCacheOnMovePage(
   pageData: Partial<IPage>,
 ) {
   // Remove page from old parent's cache
-  const oldQueryKey =
-    oldParentId === null
-      ? ["root-sidebar-pages", spaceId]
-      : ["sidebar-pages", { pageId: oldParentId, spaceId }];
-
-  queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(
-    oldQueryKey,
-    (old) => {
-      if (!old) return old;
-      return {
-        ...old,
-        pages: old.pages.map((page) => ({
-          ...page,
-          items: page.items.filter((item) => item.id !== pageId),
-        })),
-      };
-    },
-  );
+  getSidebarQueriesByParent(oldParentId, spaceId).forEach(([key]) => {
+    queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(key, (old) =>
+      removePageFromSidebarData(old, pageId),
+    );
+  });
 
   // Update old parent's hasChildren flag if it has no more children
   if (oldParentId !== null) {
-    const oldParentCache = queryClient.getQueryData<
-      InfiniteData<IPagination<IPage>>
-    >(["sidebar-pages", { pageId: oldParentId, spaceId }]);
-
-    const remainingChildren =
-      oldParentCache?.pages.flatMap((p) => p.items).length ?? 0;
-
-    if (remainingChildren === 0) {
-      // Update hasChildren in all caches where old parent appears
-      const allSideBarMatches = queryClient.getQueriesData({
-        predicate: (query) =>
-          query.queryKey[0] === "root-sidebar-pages" ||
-          query.queryKey[0] === "sidebar-pages",
-      });
-
-      allSideBarMatches.forEach(([key]) => {
-        queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(
-          key,
-          (old) => {
-            if (!old) return old;
-            return {
-              ...old,
-              pages: old.pages.map((page) => ({
-                ...page,
-                items: page.items.map((item) =>
-                  item.id === oldParentId
-                    ? { ...item, hasChildren: false }
-                    : item,
-                ),
-              })),
-            };
-          },
-        );
-      });
+    if (!sidebarCacheHasItems(oldParentId, spaceId)) {
+      updateSidebarPageHasChildren(oldParentId, false);
     }
   }
 
   // Add page to new parent's cache
-  const newQueryKey =
-    newParentId === null
-      ? ["root-sidebar-pages", spaceId]
-      : ["sidebar-pages", { pageId: newParentId, spaceId }];
-
-  queryClient.setQueryData<InfiniteData<IPagination<Partial<IPage>>>>(
-    newQueryKey,
-    (old) => {
-      if (!old) return old;
-
-      // Check if page already exists in new location
-      const exists = old.pages.some((page) =>
-        page.items.some((item) => item.id === pageId),
-      );
-      if (exists) return old;
-
-      return {
-        ...old,
-        pages: old.pages.map((page, index) => {
-          if (index === old.pages.length - 1) {
-            return {
-              ...page,
-              items: [...page.items, pageData],
-            };
-          }
-          return page;
-        }),
-      };
-    },
-  );
+  getSidebarQueriesByParent(newParentId, spaceId).forEach(([key]) => {
+    queryClient.setQueryData<InfiniteData<IPagination<Partial<IPage>>>>(
+      key,
+      (old) => appendPageToSidebarData(old, pageData),
+    );
+  });
 
   // Update new parent's hasChildren flag
   if (newParentId !== null) {
-    const allSideBarMatches = queryClient.getQueriesData({
-      predicate: (query) =>
-        query.queryKey[0] === "root-sidebar-pages" ||
-        query.queryKey[0] === "sidebar-pages",
-    });
-
-    allSideBarMatches.forEach(([key]) => {
-      queryClient.setQueryData<InfiniteData<IPagination<IPage>>>(key, (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          pages: old.pages.map((page) => ({
-            ...page,
-            items: page.items.map((item) =>
-              item.id === newParentId ? { ...item, hasChildren: true } : item,
-            ),
-          })),
-        };
-      });
-    });
+    updateSidebarPageHasChildren(newParentId, true);
   }
 }
 

--- a/apps/client/src/features/page/tree/components/space-tree-node-menu.tsx
+++ b/apps/client/src/features/page/tree/components/space-tree-node-menu.tsx
@@ -34,6 +34,7 @@ import { treeDataAtom } from "@/features/page/tree/atoms/tree-data-atom.ts";
 import { treeModel } from "@/features/page/tree/model/tree-model";
 import { useTreeMutation } from "@/features/page/tree/hooks/use-tree-mutation.ts";
 import type { SpaceTreeNode } from "@/features/page/tree/types.ts";
+import { addPageToSidebarCache } from "@/features/page/queries/page-query.ts";
 import classes from "@/features/page/tree/styles/tree.module.css";
 
 export interface NodeMenuProps {
@@ -97,6 +98,7 @@ export function NodeMenu({ node, canEdit }: NodeMenuProps) {
       setData((prev) =>
         treeModel.insert(prev, parentId, treeNodeData, newIndex),
       );
+      addPageToSidebarCache(duplicatedPage);
 
       setTimeout(() => {
         emit({

--- a/apps/client/src/pages/page/page.tsx
+++ b/apps/client/src/pages/page/page.tsx
@@ -106,6 +106,7 @@ function PageContent({ pageSlug }: { pageSlug: string | undefined }) {
           content={page.content}
           slugId={page.slugId}
           spaceSlug={page?.space?.slug}
+          spaceId={page.spaceId}
           editable={canEdit}
           creator={page.creator}
           contributors={page.contributors}


### PR DESCRIPTION
## Summary

Fixes: #2273 

The issue was caused by a React Query cache key mismatch. The Subpages block was reading child pages using a pageId-only sidebar query key, while page creation and related sidebar cache writers mostly updated the space-aware sidebar query key.

As a result, a newly created child page could exist in one sidebar cache entry while the Subpages block kept rendering stale data from another. Refreshing the browser rebuilt the cache and showed the correct result, which confirmed this was a frontend cache synchronization issue rather than a backend data issue.

## Changes

- Passed `spaceId` from the loaded page into the full editor flow.
- Stored both `pageId` and `spaceId` on the TipTap editor instance.
- Also stored both values on the temporary static editor render so the first pre-sync render uses the same page identity data.
- Updated `SubpagesView` to query sidebar child pages with `{ pageId, spaceId }` when `spaceId` is available.
- Preserved the existing shared-page Subpages behavior.
- Kept a pageId-only fallback for editor contexts where `spaceId` is unavailable.
- Added sidebar cache helpers so create, update, move, duplicate, and restore paths update matching sidebar child caches consistently.
- Added id-based deduplication when appending pages into sidebar cache data.
- Added regression tests for both sidebar query key shapes:
  - `["sidebar-pages", { pageId }]`
  - `["sidebar-pages", { pageId, spaceId }]`

## Why This Approach

The backend already returns the correct child pages. The stale UI happened because the Subpages block and mutation cache writers were not consistently using the same React Query cache entry.

Instead of changing backend APIs or forcing broader refetch behavior, this PR keeps the existing query strategy and updates the correct local sidebar caches when page mutations happen.

This keeps the fix narrow:

- no backend changes
- no global React Query default changes
- no CSS/layout changes
- shared-page rendering remains unchanged
- normal page tree behavior remains unchanged
- existing pageId-only sidebar cache entries are still handled defensively

## Testing

Ran:

```bash
pnpm.cmd --filter client test -- page-query.test.ts
pnpm.cmd --filter client build
```

Both passed.

## Notes

This PR intentionally does not modify the server-side page or sidebar APIs because the issue is caused by frontend React Query cache synchronization, not incorrect backend data.

It also avoids changing global React Query settings such as `refetchOnMount` or `staleTime`, since those settings affect the whole client and would be broader than needed for this bug.

The cache update helpers still handle pageId-only sidebar query keys defensively, even though the Subpages block now uses the space-aware key when available. This prevents stale sidebar cache entries from surviving if an older or fallback query shape is already present in the client cache.