### PR TITLE
fix: resolve draw.io save failure on copied blocks (#2288)

### DIFF
--- a/apps/client/src/features/editor/components/common/editor-paste-handler.tsx
+++ b/apps/client/src/features/editor/components/common/editor-paste-handler.tsx
@@ -111,8 +111,9 @@ async function reuploadPastedAttachments(
     const match = ATTACHMENT_URL_RE.exec(src);
     if (!match) return;
 
+    const cleanSrc = src.split("?")[0];
     const fileName =
-      node.attrs.name || src.split("/").pop() || "file";
+      node.attrs.name || cleanSrc.split("/").pop() || "file";
 
     pastedNodes.push({
       pos,


### PR DESCRIPTION
**Fixes #2288**

### Bug Description
Copying a draw.io block and pasting it onto a different page caused a silent save failure. 
The paste handler (`editor-paste-handler.tsx`) was attempting to re-upload the draw.io attachment for the new page but incorrectly derived the file name from `src.split("/").pop()`. Because draw.io diagrams use cache-busting suffixes (e.g. `diagram.drawio.svg?t=17000`), the query string was saved as part of the file extension, causing subsequent saves to fail validation.

### Fix
This strips the query parameters using `src.split("?")[0]` before extracting the filename, ensuring the attachment receives a valid `.svg` extension.