### PR TITLE
fix: map h1 to h2 in editor parseHTML to prevent h1 stripping from pasted markdown (#2277)

### DIFF
--- a/packages/editor-ext/src/lib/heading/heading.ts
+++ b/packages/editor-ext/src/lib/heading/heading.ts
@@ -65,6 +65,18 @@ export const Heading = TiptapHeading.extend<TiptapHeadingOptions>({
       }),
     ];
   },
+  parseHTML() {
+    return [
+      {
+        tag: 'h1',
+        attrs: { level: this.options.levels[0] },
+      },
+      ...this.options.levels.map((level: number) => ({
+        tag: `h${level}`,
+        attrs: { level },
+      })),
+    ];
+  },
   renderHTML({ node, HTMLAttributes }) {
     const hasLevel = this.options.levels.includes(node.attrs.level);
     const level = hasLevel ? node.attrs.level : this.options.levels[0];


### PR DESCRIPTION
## Fixes #2277 

### Description
Currently, when pasting or importing a Markdown document containing an `# H1` heading into Docmost, the heading is stripped and rendered as plain paragraph text. This happens because the editor's `Heading` extension restricts allowed levels to `[2, 3, 4, 5, 6]` (reserving H1 for the document title), causing Tiptap's `DOMParser` to drop unconfigured `<h1>` HTML tags.

### Fix
This PR adds a fallback `parseHTML` rule to the custom `Heading` extension. It intercepts any incoming `<h1>` tags during paste or Markdown import and gracefully downgrades them to `<h2>` (the highest configured heading level), preserving the document's structure and visual hierarchy instead of stripping the formatting.