### PR TITLE
Fix/issue 2276

### DIFF
--- a/apps/client/src/features/editor/extensions/extensions.ts
+++ b/apps/client/src/features/editor/extensions/extensions.ts
@@ -214,6 +214,7 @@ export const mainExtensions = [
   TaskList,
   TaskItem.configure({
     nested: true,
+    onReadOnly: true,
   }),
   LinkExtension.configure({
     openOnClick: false,

--- a/apps/client/src/features/editor/styles/task-list.css
+++ b/apps/client/src/features/editor/styles/task-list.css
@@ -14,6 +14,7 @@ ul[data-type="taskList"] {
             flex: 0 0 auto;
             margin-right: 0.5rem;
             user-select: none;
+            pointer-events: none;
         }
 
         > div {
@@ -35,5 +36,6 @@ ul[data-type="taskList"] li > label input[type="checkbox"] {
     width: 1em;
     height: 1em;
     cursor: pointer;
+    pointer-events: auto;
 }
 

--- a/packages/editor-ext/src/lib/heading/heading.ts
+++ b/packages/editor-ext/src/lib/heading/heading.ts
@@ -65,6 +65,18 @@ export const Heading = TiptapHeading.extend<TiptapHeadingOptions>({
       }),
     ];
   },
+  parseHTML() {
+    return [
+      {
+        tag: 'h1',
+        attrs: { level: this.options.levels[0] },
+      },
+      ...this.options.levels.map((level: number) => ({
+        tag: `h${level}`,
+        attrs: { level },
+      })),
+    ];
+  },
   renderHTML({ node, HTMLAttributes }) {
     const hasLevel = this.options.levels.includes(node.attrs.level);
     const level = hasLevel ? node.attrs.level : this.options.levels[0];


### PR DESCRIPTION
### Description
Fixes #2276 

**Root Cause:** Tiptap renders task checkboxes inside a `<label>`. In some browser engines, applying `user-select: none` to this wrapper causes the browser or ProseMirror to swallow pointer events, preventing the click from reaching the input.

**Solution:** Updated `task-list.css` to add `pointer-events: none` to the wrapper label and `pointer-events: auto` to the checkbox. This allows clicks to bypass the wrapper and directly toggle the checkbox natively.