### PR TITLE
Fix move page sidebar issue

### DIFF
--- a/apps/client/src/features/page/components/move-page-modal.tsx
+++ b/apps/client/src/features/page/components/move-page-modal.tsx
@@ -8,6 +8,9 @@ import { queryClient } from "@/main.tsx";
 import { SpaceSelect } from "@/features/space/components/sidebar/space-select.tsx";
 import { useNavigate } from "react-router-dom";
 import { buildPageUrl } from "@/features/page/page.utils.ts";
+import { useSetAtom } from "jotai";
+import { treeDataAtom } from "@/features/page/tree/atoms/tree-data-atom.ts";
+import { removePageFromTree } from "@/features/page/tree/utils";
 
 interface MovePageModalProps {
   pageId: string;
@@ -26,6 +29,7 @@ export default function MovePageModal({
 }: MovePageModalProps) {
   const { t } = useTranslation();
   const [targetSpace, setTargetSpace] = useState<ISpace>(null);
+  const setTreeData = useSetAtom(treeDataAtom);
   const navigate = useNavigate();
 
   const handlePageMove = async () => {
@@ -33,6 +37,7 @@ export default function MovePageModal({
 
     try {
       await movePageToSpace({ pageId, spaceId: targetSpace.id });
+      setTreeData((prev) => removePageFromTree(prev, pageId));
       queryClient.removeQueries({
         predicate: (item) =>
           ["pages", "sidebar-pages", "root-sidebar-pages"].includes(

--- a/apps/client/src/features/page/tree/utils/utils.test.ts
+++ b/apps/client/src/features/page/tree/utils/utils.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { treeModel } from '../model/tree-model';
+import type { SpaceTreeNode } from '../types';
+import { removePageFromTree } from './utils';
+
+function node(
+  id: string,
+  overrides: Partial<SpaceTreeNode> = {},
+): SpaceTreeNode {
+  return {
+    id,
+    slugId: id,
+    name: id,
+    position: id,
+    spaceId: 'space-a',
+    parentPageId: null,
+    hasChildren: false,
+    children: [],
+    ...overrides,
+  };
+}
+
+describe('removePageFromTree', () => {
+  it('removes a moved page subtree and clears the old parent child flag', () => {
+    const tree: SpaceTreeNode[] = [
+      node('parent', {
+        hasChildren: true,
+        children: [
+          node('child', {
+            parentPageId: 'parent',
+            hasChildren: true,
+            children: [node('grandchild', { parentPageId: 'child' })],
+          }),
+        ],
+      }),
+      node('unrelated-root', { spaceId: 'space-b' }),
+    ];
+
+    const next = removePageFromTree(tree, 'child');
+
+    expect(treeModel.find(next, 'child')).toBeNull();
+    expect(treeModel.find(next, 'grandchild')).toBeNull();
+    expect(treeModel.find(next, 'parent')).toMatchObject({
+      hasChildren: false,
+      children: [],
+    });
+    expect(treeModel.find(next, 'unrelated-root')).toBe(tree[1]);
+  });
+
+  it('keeps the old parent marked as having children when siblings remain', () => {
+    const tree: SpaceTreeNode[] = [
+      node('parent', {
+        hasChildren: true,
+        children: [
+          node('child', { parentPageId: 'parent' }),
+          node('sibling', { parentPageId: 'parent' }),
+        ],
+      }),
+    ];
+
+    const next = removePageFromTree(tree, 'child');
+
+    expect(treeModel.find(next, 'child')).toBeNull();
+    expect(treeModel.find(next, 'parent')).toMatchObject({
+      hasChildren: true,
+      children: [expect.objectContaining({ id: 'sibling' })],
+    });
+  });
+
+  it('removes duplicate stale copies across loaded spaces', () => {
+    const tree: SpaceTreeNode[] = [
+      node('source-parent', {
+        hasChildren: true,
+        children: [node('moved-page', { parentPageId: 'source-parent' })],
+      }),
+      node('other-space-parent', {
+        spaceId: 'space-b',
+        hasChildren: true,
+        children: [
+          node('moved-page', {
+            spaceId: 'space-b',
+            parentPageId: 'other-space-parent',
+          }),
+        ],
+      }),
+    ];
+
+    const next = removePageFromTree(tree, 'moved-page');
+
+    expect(treeModel.find(next, 'moved-page')).toBeNull();
+    expect(treeModel.find(next, 'source-parent')).toMatchObject({
+      hasChildren: false,
+      children: [],
+    });
+    expect(treeModel.find(next, 'other-space-parent')).toMatchObject({
+      hasChildren: false,
+      children: [],
+    });
+  });
+
+  it('returns the same tree reference when the page is not loaded', () => {
+    const tree: SpaceTreeNode[] = [node('parent')];
+
+    expect(removePageFromTree(tree, 'missing')).toBe(tree);
+  });
+});

--- a/apps/client/src/features/page/tree/utils/utils.ts
+++ b/apps/client/src/features/page/tree/utils/utils.ts
@@ -122,6 +122,45 @@ export const deleteTreeNode = (
     .filter((node) => node !== null);
 };
 
+export function removePageFromTree(
+  treeItems: SpaceTreeNode[],
+  pageId: string,
+): SpaceTreeNode[] {
+  const removeFromNodes = (
+    nodes: SpaceTreeNode[],
+  ): { nodes: SpaceTreeNode[]; changed: boolean } => {
+    let changed = false;
+    const nextNodes: SpaceTreeNode[] = [];
+
+    for (const node of nodes) {
+      if (node.id === pageId) {
+        changed = true;
+        continue;
+      }
+
+      if (node.children?.length) {
+        const result = removeFromNodes(node.children);
+        if (result.changed) {
+          changed = true;
+          nextNodes.push({
+            ...node,
+            children: result.nodes,
+            hasChildren: result.nodes.length > 0,
+          });
+          continue;
+        }
+      }
+
+      nextNodes.push(node);
+    }
+
+    return changed ? { nodes: nextNodes, changed } : { nodes, changed };
+  };
+
+  const result = removeFromNodes(treeItems);
+  return result.changed ? result.nodes : treeItems;
+}
+
 export function buildTreeWithChildren(items: SpaceTreeNode[]): SpaceTreeNode[] {
   const nodeMap = {};
   let result: SpaceTreeNode[] = [];


### PR DESCRIPTION
# PR Description: Fix Stale Sidebar And Breadcrumb After Moving Page To Space

## Summary

This PR fixes a frontend stale-state issue when moving a page from one space to another.

The backend move operation already succeeds, but the live UI could continue showing the moved page in its old location until the browser was refreshed. This happened because the move-to-space flow cleared React Query page/sidebar caches, but did not update the in-memory sidebar tree stored in `treeDataAtom`.

This PR updates the local page tree after a successful move-to-space operation so the sidebar and breadcrumb stop rendering the stale old parent path immediately.

No issue was filed for this bug. This PR is opened directly after identifying and reproducing the stale frontend state behavior.

## Bug / Problem

When a page is moved from one space to another, the server persists the move correctly. However, some frontend navigation state can remain stale.

The old parent page's Subpages block may correctly stop showing the moved page, but the sidebar and breadcrumb can still show the moved page under the old parent.

Example stale breadcrumb:

```txt
Parent page > Child page
```

After a full browser refresh, the sidebar and breadcrumb become correct. This confirms the backend data is correct and the problem is in client-side state synchronization.

## Steps To Reproduce

1. Create or open Space A.
2. Create a parent page in Space A.
3. Create a child page under that parent.
4. Open the child page.
5. Confirm the breadcrumb shows the old hierarchy:

```txt
Parent page > Child page
```

6. Move the child page to Space B using the move page modal.
7. The app navigates to the moved page in Space B.
8. Observe that the old parent page's Subpages block no longer shows the moved child.
9. Observe that the sidebar and/or breadcrumb can still show the moved page under the old parent.
10. Refresh the browser.
11. Observe that the sidebar and breadcrumb are now correct.

## Expected Behavior

After moving a page to another space:

- The moved page should disappear from the old space tree immediately.
- The old parent should no longer show the moved page as a child.
- The breadcrumb should not show the old parent path.
- A full browser reload should not be required.

## Actual Behavior Before This PR

The move persisted correctly, but `treeDataAtom` could still contain the moved page under the old parent.

Because the sidebar and breadcrumb read from this in-memory tree, they could continue rendering stale hierarchy data until reload.

## Root Cause

The move-to-space flow in `move-page-modal.tsx` only cleared React Query caches:

```ts
queryClient.removeQueries({
  predicate: (item) =>
    ["pages", "sidebar-pages", "root-sidebar-pages"].includes(
      item.queryKey[0] as string,
    ),
});
```

However, the sidebar tree and breadcrumb also depend on `treeDataAtom`.

Clearing React Query caches did not remove the stale moved page from `treeDataAtom`, so the UI could still find and render the old page path.

## Changes Made

### `apps/client/src/features/page/components/move-page-modal.tsx`

Updated the move-to-space success flow to remove the moved page from the local page tree after the backend confirms the move succeeded.

Added:

```ts
const setTreeData = useSetAtom(treeDataAtom);
```

And after the move succeeds:

```ts
setTreeData((prev) => removePageFromTree(prev, pageId));
```

Why this file changed:

- This is the entry point for moving a page to another space.
- The stale state must be cleared immediately after the server move succeeds.
- This keeps the fix close to the flow that creates the stale state.

### `apps/client/src/features/page/tree/utils/utils.ts`

Added `removePageFromTree`.

This helper:

- Walks the loaded page tree recursively.
- Removes the moved page by id.
- Removes any loaded children under that moved page.
- Updates the old parent's `hasChildren` flag when no loaded children remain.
- Preserves the original tree reference if the page is not found.

Why this file changed:

- Tree cleanup is reusable tree logic, not modal UI logic.
- Keeping it in the tree utilities makes it easier to test directly.
- It avoids putting recursive tree manipulation inside the modal component.

### `apps/client/src/features/page/tree/utils/utils.test.ts`

Added regression tests for the new tree cleanup helper.

The tests cover:

- Removing a moved page subtree.
- Clearing the old parent's `hasChildren` flag when the moved page was the last loaded child.
- Keeping `hasChildren: true` when sibling children remain.
- Removing duplicate stale copies across loaded spaces.
- Returning the original tree reference when the page is not loaded.

Why this file changed:

- The bug is specifically about stale frontend tree state.
- A focused utility test verifies the exact state transition without requiring a large component setup.
- It protects the sidebar/breadcrumb fix from future regressions.

## Why This Approach

This PR does not change the backend because the backend already persists the move correctly.

It also does not optimistically insert the moved page into the target space tree. The move-to-space API does not return the moved page's new root position or canonical target-space row, so guessing that data on the client could create incorrect ordering or duplicate entries.

Instead, this PR uses a safer flow:

1. Let the backend complete the move.
2. Remove stale old tree state from `treeDataAtom`.
3. Clear page/sidebar React Query caches as before.
4. Navigate to the target space.
5. Let the target space sidebar fetch canonical data from the server.

## Verification

Ran:

```bash
pnpm.cmd --filter client test -- src/features/page/tree/utils/utils.test.ts src/features/page/tree/model/tree-model.test.ts
pnpm.cmd --filter client build
```

Result:

```txt
Test Files  3 passed (3)
Tests       62 passed (62)
```

The client build also completed successfully.

Existing build warnings were emitted about pnpm config, deprecated `advancedChunks`, and large chunks. These warnings are unrelated to this change.

## Manual Testing Checklist

- Move a child page from Space A to Space B.
- Confirm the old parent no longer shows the moved page in the sidebar.
- Confirm the breadcrumb no longer shows `Parent page > Child page`.
- Refresh the browser and confirm the UI remains the same.
- Repeat with a moved page that has loaded child pages.
- Repeat when the old parent has another child that should remain.
- Confirm the old parent still shows as expandable when sibling children remain.
- Confirm the old parent stops showing as expandable when no loaded children remain.