### PR TITLE
fix: allow resetting code block language to auto

### DIFF
--- a/apps/client/src/features/editor/components/code-block/code-block-view.tsx
+++ b/apps/client/src/features/editor/components/code-block/code-block-view.tsx
@@ -12,6 +12,8 @@ const MermaidView = React.lazy(
   () => import("@/features/editor/components/code-block/mermaid-view.tsx"),
 );
 
+const AUTO_LANGUAGE_VALUE = "__auto__";
+
 export default function CodeBlockView(props: NodeViewProps) {
   const { t } = useTranslation();
   const { node, updateAttributes, extension, editor, getPos } = props;
@@ -38,10 +40,12 @@ export default function CodeBlockView(props: NodeViewProps) {
     };
   }, [editor, getPos(), node.nodeSize]);
 
-  function changeLanguage(language: string) {
-    setLanguageValue(language);
+  function changeLanguage(language: string | null) {
+    const nextLanguage = language === AUTO_LANGUAGE_VALUE ? null : language;
+
+    setLanguageValue(nextLanguage);
     updateAttributes({
-      language: language,
+      language: nextLanguage,
     });
   }
 
@@ -55,8 +59,17 @@ export default function CodeBlockView(props: NodeViewProps) {
         <Select
           placeholder="auto"
           checkIconPosition="right"
-          data={extension.options.lowlight.listLanguages().sort()}
-          value={languageValue}
+          data={[
+            { value: AUTO_LANGUAGE_VALUE, label: "auto" },
+            ...extension.options.lowlight
+              .listLanguages()
+              .sort()
+              .map((language: string) => ({
+                value: language,
+                label: language,
+              })),
+          ]}
+          value={languageValue || AUTO_LANGUAGE_VALUE}
           onChange={changeLanguage}
           searchable
           style={{ maxWidth: "130px" }}


### PR DESCRIPTION
## Summary

Fixes #2263 code blocks so the language selector can be reset back to `auto` after a specific language has been selected.

## Problem

The selector displayed `auto` only as a placeholder. After choosing a language such as `shell`, clearing the visible input did not select an actual `auto` value. On blur, Mantine restored the previous selected value, so the code block stayed locked to the old language.

## Reproduction

1. Insert a code block.
2. Paste a JavaScript-like snippet.
3. Select `shell` from the code block language dropdown.
4. Open the language dropdown again and try to reset it to `auto`.
5. Click outside the dropdown.

Before this change, the selector returned to `shell` instead of staying on `auto`.

## Fix

- Adds `auto` as a real option in the code block language dropdown.
- Uses a UI-only sentinel value for the `auto` option.
- Maps that sentinel back to `language: null` before updating the code block node attributes.

This keeps the document model unchanged: `null` still represents auto-detection, and the existing lowlight plugin continues to call `highlightAuto` when no explicit language is set.

## Testing

- Ran `pnpm.cmd --filter client exec tsc --noEmit`
- Ran `git diff --check`
