### PR TITLE
fix: persist open sidebar branches

### DIFF
--- a/apps/client/src/features/page/tree/atoms/open-tree-nodes-atom.ts
+++ b/apps/client/src/features/page/tree/atoms/open-tree-nodes-atom.ts
@@ -1,5 +1,8 @@
-import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 
 export type OpenMap = Record<string, boolean>;
 
-export const openTreeNodesAtom = atom<OpenMap>({});
+export const openTreeNodesAtom = atomWithStorage<OpenMap>(
+  "docmost:open-tree-nodes:v1",
+  {},
+);

--- a/apps/client/src/features/page/tree/components/space-tree.tsx
+++ b/apps/client/src/features/page/tree/components/space-tree.tsx
@@ -164,7 +164,12 @@ export default function SpaceTree({ spaceId, readOnly }: SpaceTreeProps) {
 
   const handleToggle = useCallback(
     async (id: string, isOpen: boolean) => {
-      setOpenTreeNodes((prev) => ({ ...prev, [id]: isOpen }));
+      setOpenTreeNodes((prev) => {
+        if (isOpen) return { ...prev, [id]: true };
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
       if (isOpen) {
         const node = treeModel.find(data, id) as SpaceTreeNode | null;
         if (


### PR DESCRIPTION
## Summary

This PR preserves the expanded/collapsed state of page-tree branches in the space sidebar across page reloads. Previously, open branch state was stored only in an in-memory Jotai atom, so refreshing the browser reset the sidebar tree back to its default collapsed state.

Fixes #1895 

## Problem

When users expand nested pages in the sidebar and then reload the page, the expanded branches are lost. This is especially frustrating for spaces with deeply nested page trees because users have to manually reopen the same branches after every reload.

The sidebar tree already tracks open nodes through `openTreeNodesAtom`, and the tree rendering flow already knows how to lazy-load children for open nodes. The missing piece was persistence: the atom was using plain in-memory state.

## Root Cause

`openTreeNodesAtom` was defined with `atom`:

```ts
export const openTreeNodesAtom = atom<OpenMap>({});
```

That state only lasts for the current browser session/runtime. Once the page reloads, the atom is recreated with `{}`, so the tree has no memory of which branches were open.

## Solution

The atom now uses Jotai's `atomWithStorage`, which persists the open-node map in browser storage:

```ts
export const openTreeNodesAtom = atomWithStorage<OpenMap>(
  "docmost:open-tree-nodes:v1",
  {},
);
```

The toggle behavior was also tightened so the stored map only contains currently open branches:

- Opening a branch stores `{ [id]: true }`.
- Closing a branch removes that id from the map.

This keeps persisted state compact and makes the state shape easy to reason about: if a page id exists in the map, that branch is open; if it does not exist, that branch is closed.

## Files Changed

- `apps/client/src/features/page/tree/atoms/open-tree-nodes-atom.ts`
  - Replaced memory-only `atom` with `atomWithStorage`.
  - Added a namespaced storage key: `docmost:open-tree-nodes:v1`.

- `apps/client/src/features/page/tree/components/space-tree.tsx`
  - Updated branch toggle handling to persist only open branch ids.
  - Collapsed branch ids are deleted from the persisted map instead of being stored as `false`.

## Why This Is Client-Side Only

This is UI state, not server data. The backend already returns sidebar pages and children through the existing sidebar page APIs. The bug was caused by the client forgetting which tree nodes were expanded after a reload, so no backend endpoint, database migration, or API contract change is required.

## Testing

Build verification:

```bash
pnpm.cmd --filter ./apps/client run build
```