### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 To get started with Docmost, please refer to our [documentation](https://docmost.com/docs) or try our [cloud version](https://docmost.com/pricing) .
 
+You can also spin up a fully managed instance in one click:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/docmost)
+
 ## Features
 
 - Real-time collaboration


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Docmost to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Getting started (links to https://zenith.hosting/host/docmost).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting