### PR TITLE
fix: use relative path for attachment entries in export zip

### DIFF
--- a/apps/server/src/integrations/export/export.service.spec.ts
+++ b/apps/server/src/integrations/export/export.service.spec.ts
@@ -1,0 +1,101 @@
+// slugify is an ESM-only package that jest does not transform; it is unrelated
+// to attachment zipping, so stub it to keep this suite importable.
+jest.mock('@sindresorhus/slugify', () => ({
+  __esModule: true,
+  default: (value: string) => value,
+}));
+
+import * as JSZip from 'jszip';
+import { ExportService } from './export.service';
+
+/**
+ * Regression tests for #1307 (invalid zip archives when exporting a space with
+ * attachments). Attachment entries must be written with a relative path; a
+ * leading slash produces an absolute zip entry that violates the ZIP spec
+ * (APPNOTE 4.4.17) and is rejected by tools such as Windows Explorer. The path
+ * must also match the relative "files/..." URLs written into the exported
+ * documents so the links resolve after extraction.
+ */
+describe('ExportService.zipAttachments', () => {
+  const attachmentId = '019b9105-ce1a-726b-a09d-eb2fc65f904a';
+  // non-ASCII name to also exercise the encoding path from the reporter
+  const fileName = '스크린샷_2026-01-06.png';
+
+  const buildDoc = () => ({
+    type: 'doc',
+    content: [
+      {
+        type: 'image',
+        attrs: {
+          attachmentId,
+          src: `/api/files/${attachmentId}/${fileName}`,
+        },
+      },
+    ],
+  });
+
+  const buildService = () => {
+    const storageService = {
+      read: jest.fn().mockResolvedValue(Buffer.from('image-bytes')),
+    };
+    // Only storageService is used by zipAttachments; the rest are irrelevant.
+    return new ExportService(
+      null as any,
+      null as any,
+      null as any,
+      storageService as any,
+      null as any,
+      null as any,
+    );
+  };
+
+  const entryNames = async (zip: JSZip): Promise<string[]> => {
+    const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+    const reloaded = await JSZip.loadAsync(buffer);
+    return Object.keys(reloaded.files).filter((name) => !name.endsWith('/'));
+  };
+
+  it('writes attachment entries with a relative path (no leading slash)', async () => {
+    const service = buildService();
+    const zip = new JSZip();
+    const allowed = new Map([
+      [
+        attachmentId,
+        {
+          id: attachmentId,
+          fileName,
+          filePath: `workspace/files/${attachmentId}/${fileName}`,
+        },
+      ],
+    ]);
+
+    await service.zipAttachments(buildDoc(), zip, allowed);
+
+    const names = await entryNames(zip);
+    expect(names).toContain(`files/${attachmentId}/${fileName}`);
+    // guard against a leading-slash regression on any entry
+    expect(names.every((name) => !name.startsWith('/'))).toBe(true);
+  });
+
+  it('places attachments relative to the page folder so links resolve', async () => {
+    const service = buildService();
+    const rootZip = new JSZip();
+    const pageFolder = rootZip.folder('Parent Page');
+    const allowed = new Map([
+      [
+        attachmentId,
+        {
+          id: attachmentId,
+          fileName,
+          filePath: `workspace/files/${attachmentId}/${fileName}`,
+        },
+      ],
+    ]);
+
+    await service.zipAttachments(buildDoc(), pageFolder as JSZip, allowed);
+
+    const names = await entryNames(rootZip);
+    expect(names).toContain(`Parent Page/files/${attachmentId}/${fileName}`);
+    expect(names.every((name) => !name.startsWith('/'))).toBe(true);
+  });
+});

--- a/apps/server/src/integrations/export/export.service.ts
+++ b/apps/server/src/integrations/export/export.service.ts
@@ -371,7 +371,12 @@ export class ExportService {
           const fileBuffer = await this.storageService.read(
             attachment.filePath,
           );
-          const filePath = `/files/${attachment.id}/${attachment.fileName}`;
+          // Use a relative path (no leading slash). A leading slash produces an
+          // absolute zip entry, which violates the ZIP spec (APPNOTE 4.4.17) and
+          // is rejected by tools like Windows Explorer. It also has to match the
+          // relative "files/..." URLs written by updateAttachmentUrlsToLocalPaths
+          // so the links resolve after extraction.
+          const filePath = `files/${attachment.id}/${attachment.fileName}`;
           zip.file(filePath, fileBuffer);
         } catch (err) {
           this.logger.debug(`Attachment export error ${attachment.id}`, err);


### PR DESCRIPTION
## Problem
Fixes #1307. When exporting a space (or a page tree) with attachments, the generated ZIP is invalid: Windows Explorer (and other spec-strict tools) cannot extract it. Attachment entries are written with a leading slash — an absolute path — which violates the ZIP spec (APPNOTE.TXT §4.4.17).

There is a second, silent consequence: exported pages reference attachments with the **relative** `files/...` URL (via `updateAttachmentUrlsToLocalPaths`), but the archive stores them at the **absolute** `/files/...` entry — so even when extracted, the links don't resolve for root-level pages.

## Fix
Write attachment entries with a relative `files/...` path. This makes the archive spec-compliant and aligns the entry path with the relative URLs already written into the documents, so links resolve after extraction. Nested pages are unaffected (JSZip already normalizes the slash inside subfolders); the bug is specific to root-level pages, which is the space-export case in the report.

## Testing
Added `export.service.spec.ts` covering `zipAttachments`: it asserts entries use a relative path (no leading slash) and are placed relative to the page folder. Verified fail-before/pass-after by reverting the one-line change (the root-page test fails with an absolute `/files/...` entry before). Confirmed the leading-slash behavior directly against `jszip@3.10.1`; `tsc --noEmit` clean.

## Notes / disclosure
- The spec stubs the ESM-only `@sindresorhus/slugify` (unrelated to zipping) so the export service can be imported under the current jest config without any config change.
- Supersedes the abandoned, never-merged #1327, taking a minimal one-line approach.
- This change was prepared with AI assistance (Claude); reviewed and verified before submission.
