### PR TITLE
fix: show heading title in anchor link mentions (#2346)

### DIFF
--- a/apps/client/src/features/editor/components/link/internal-link-paste.ts
+++ b/apps/client/src/features/editor/components/link/internal-link-paste.ts
@@ -17,6 +17,27 @@ export interface InternalLinkOptions {
   onResolveLink: (linkedPageId: string, creatorId: string) => Promise<any>;
 }
 
+function getHeadingText(content: string, anchorId: string): string | null {
+  try {
+    const doc = JSON.parse(content);
+    function find(node: any): string | null {
+      if (node.type === "heading" && node.attrs?.id === anchorId) {
+        return node.content?.[0]?.text || null;
+      }
+      if (node.content) {
+        for (const child of node.content) {
+          const result = find(child);
+          if (result) return result;
+        }
+      }
+      return null;
+    }
+    return find(doc);
+  } catch {
+    return null;
+  }
+}
+
 export const handleInternalLink =
   ({ validateFn, onResolveLink }: InternalLinkOptions): LinkFn =>
   async (url: string, view, pos, creatorId, anchorId) => {
@@ -29,9 +50,15 @@ export const handleInternalLink =
       (page: IPage) => {
         const { schema } = view.state;
 
+        let label = page.title || "Untitled";
+        if (anchorId && page.content) {
+          const headingText = getHeadingText(page.content, anchorId);
+          if (headingText) label = headingText;
+        }
+
         const node = schema.nodes.mention.create({
           id: v7(),
-          label: page.title || "Untitled",
+          label,
           entityType: "page",
           entityId: page.id,
           slugId: page.slugId,
@@ -45,7 +72,6 @@ export const handleInternalLink =
         view.dispatch(transaction);
       },
       () => {
-        // on failure, insert as normal link
         const { schema } = view.state;
 
         const transaction = view.state.tr.insertText(url, pos);
@@ -62,7 +88,6 @@ export const handleInternalLink =
 
 export const createMentionAction = handleInternalLink({
   onResolveLink: async (linkedPageId: string): Promise<any> => {
-    // eslint-disable-next-line no-useless-catch
     try {
       return await getPageById({ pageId: linkedPageId });
     } catch (err) {
@@ -70,7 +95,6 @@ export const createMentionAction = handleInternalLink({
     }
   },
   validateFn: (url: string, view: EditorView) => {
-    // validation is already done on the paste handler
     return true;
   },
 });

--- a/apps/client/src/features/editor/components/mention/mention-view.tsx
+++ b/apps/client/src/features/editor/components/mention/mention-view.tsx
@@ -46,7 +46,7 @@ export default function MentionView(props: NodeViewProps) {
     }
   };
 
-  const sharePageTitle = sharedPage?.page?.title || label;
+  const sharePageTitle = anchorId ? label : (sharedPage?.page?.title || label);
 
   const shareSlugUrl = buildSharedPageUrl({
     shareId,
@@ -135,7 +135,7 @@ export default function MentionView(props: NodeViewProps) {
           )}
 
           <span className={classes.pageMentionText}>
-            {page?.title || label}
+            {anchorId ? label : (page?.title || label)}
           </span>
         </Anchor>
       )}


### PR DESCRIPTION
## Problem
When pasting an anchor link to a heading (e.g., `/page#heading-1`), the mention displayed the **page title** instead of the **targeted heading's title**.

## Root Cause
In `internal-link-paste.ts`, the mention was created with `label: page.title` ignoring the `anchorId` entirely. The heading text existed in `page.content` (Tiptap JSON) but was never extracted.

## Solution
1. **internal-link-paste.ts**: Added `getHeadingText()` helper that parses Tiptap JSON content and finds the heading node matching `anchorId`. Uses heading text as mention `label` when `anchorId` is present, falls back to page title.

2. **mention-view.tsx**: Updated to display `label` (heading text) when `anchorId` exists, otherwise falls back to page title. Works for both regular and share routes.

## Testing
- Create a page with multiple headings
- Copy an anchor link to a specific heading (e.g., `#heading-2") 
- Paste in another page's editor
- Verify mention shows the heading title, not the page title

## Ponytail Notes
- No new dependencies, no API changes
- Reuses already-fetched `page.content`
- Tiny helper (~15 lines), graceful fallback on parse failure
- Minimal diff: 2 files, ~25 lines added