### PR TITLE
fix: locale-aware date/time formatting across editor and UI (#2053)

### DIFF
--- a/apps/client/src/ee/ai-chat/components/ai-chat-sidebar-item.tsx
+++ b/apps/client/src/ee/ai-chat/components/ai-chat-sidebar-item.tsx
@@ -62,8 +62,8 @@ export default function AiChatSidebarItem({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const formattedDate = useMemo(
-    () => formatChatDate(chat.updatedAt, i18n.language),
-    [chat.updatedAt, i18n.language],
+    () => formatChatDate(chat.updatedAt, i18n.resolvedLanguage),
+    [chat.updatedAt, i18n.resolvedLanguage],
   );
 
   const chatTitle = chat.title || t("Untitled chat");

--- a/apps/client/src/ee/api-key/components/create-api-key-modal.tsx
+++ b/apps/client/src/ee/api-key/components/create-api-key-modal.tsx
@@ -59,7 +59,7 @@ export function CreateApiKeyModal({
   const getExpirationLabel = (days: number) => {
     const date = new Date();
     date.setDate(date.getDate() + days);
-    const formatted = date.toLocaleDateString(i18n.language, {
+    const formatted = date.toLocaleDateString(i18n.resolvedLanguage, {
       month: "short",
       day: "2-digit",
       year: "numeric",

--- a/apps/client/src/ee/page-verification/components/expiration-fields.tsx
+++ b/apps/client/src/ee/page-verification/components/expiration-fields.tsx
@@ -31,7 +31,7 @@ export function addDays(days: number, from?: Date): Date {
 
 function formatShortDate(date: Date): string {
   const crossesYear = date.getFullYear() !== new Date().getFullYear();
-  return date.toLocaleDateString(i18n.language, {
+  return date.toLocaleDateString(i18n.resolvedLanguage, {
     month: "short",
     day: "numeric",
     ...(crossesYear && { year: "numeric" }),
@@ -39,7 +39,7 @@ function formatShortDate(date: Date): string {
 }
 
 function formatLongDate(date: Date): string {
-  return date.toLocaleDateString(i18n.language, {
+  return date.toLocaleDateString(i18n.resolvedLanguage, {
     month: "long",
     day: "numeric",
     year: "numeric",

--- a/apps/client/src/ee/page-verification/components/manage-verification-form.tsx
+++ b/apps/client/src/ee/page-verification/components/manage-verification-form.tsx
@@ -199,7 +199,7 @@ function ExpiringManageContent({ pageId, info, onClose }: ManageContentProps) {
               <Text size="xs" c="dimmed">
                 {t(status === "expired" ? "Expired {{date}}" : "Expires {{date}}", {
                   date: new Date(info.expiresAt).toLocaleDateString(
-                    i18n.language,
+                    i18n.resolvedLanguage,
                     {
                       month: "long",
                       day: "numeric",

--- a/apps/client/src/ee/page-verification/components/page-verification-modal.tsx
+++ b/apps/client/src/ee/page-verification/components/page-verification-modal.tsx
@@ -128,7 +128,7 @@ export function PageVerificationBadge({
     status === "verified" && verificationInfo?.expiresAt
       ? t("Verified until {{date}}", {
           date: new Date(verificationInfo.expiresAt).toLocaleDateString(
-            i18n.language,
+            i18n.resolvedLanguage,
             { month: "long", day: "numeric", year: "numeric" },
           ),
         })

--- a/apps/client/src/features/editor/components/fixed-toolbar/groups/more-inserts-group.tsx
+++ b/apps/client/src/features/editor/components/fixed-toolbar/groups/more-inserts-group.tsx
@@ -50,7 +50,7 @@ export const MoreInsertsGroup: FC<Props> = ({ editor, templateMode }) => {
     editor.chain().focus().setEmbed({ provider }).run();
 
   const insertDate = () => {
-    const currentDate = new Date().toLocaleDateString(i18n.language, {
+    const currentDate = new Date().toLocaleDateString(i18n.resolvedLanguage, {
       year: "numeric",
       month: "long",
       day: "numeric",

--- a/apps/client/src/features/editor/components/slash-menu/menu-items.ts
+++ b/apps/client/src/features/editor/components/slash-menu/menu-items.ts
@@ -483,7 +483,7 @@ const CommandGroups: SlashMenuGroupedItemsType = {
       searchTerms: ["date", "today"],
       icon: IconCalendar,
       command: ({ editor, range }: CommandProps) => {
-        const currentDate = new Date().toLocaleDateString(i18n.language, {
+        const currentDate = new Date().toLocaleDateString(i18n.resolvedLanguage, {
           year: "numeric",
           month: "long",
           day: "numeric",
@@ -503,7 +503,7 @@ const CommandGroups: SlashMenuGroupedItemsType = {
       searchTerms: ["time", "now", "clock"],
       icon: IconClock,
       command: ({ editor, range }: CommandProps) => {
-        const currentTime = new Date().toLocaleTimeString(i18n.language, {
+        const currentTime = new Date().toLocaleTimeString(i18n.resolvedLanguage, {
           hour: "numeric",
           minute: "numeric",
         });

--- a/apps/client/src/features/label/utils/format-label-date.ts
+++ b/apps/client/src/features/label/utils/format-label-date.ts
@@ -18,7 +18,7 @@ export function formatLabelListDate(date: Date): string {
     if (locale.code?.startsWith("en")) {
       return formatLocalized(date, "MMM dd", "MMM dd", locale);
     }
-    return new Intl.DateTimeFormat(i18n.language, {
+    return new Intl.DateTimeFormat(i18n.resolvedLanguage, {
       month: "short",
       day: "numeric",
     }).format(date);

--- a/apps/client/src/features/notification/notification.utils.ts
+++ b/apps/client/src/features/notification/notification.utils.ts
@@ -14,7 +14,7 @@ export function formatRelativeTime(dateStr: string): string {
   if (diffHours < 24) return `${diffHours}h`;
   if (diffDays < 7) return `${diffDays}d`;
 
-  return new Intl.DateTimeFormat(i18n.language, {
+  return new Intl.DateTimeFormat(i18n.resolvedLanguage, {
     month: "short",
     day: "numeric",
   }).format(date);


### PR DESCRIPTION
## Problem
The `/date` and `/time` slash commands (and other date displays) output US format regardless of user's selected locale.

## Root Cause
`toLocaleDateString()`/`toLocaleTimeString()` require full BCP 47 locale (e.g., `'en-US'`, `'fr-FR'`, `'de-DE'`) but `i18n.language` only returns language code (`'en'`, `'fr'`, `'de'`). Browser falls back to system locale or US format.

## Solution
Use `i18n.resolvedLanguage` which returns the full resolved locale with region.

## Files Fixed (9)
1. `slash-menu/menu-items.ts` - Date/Time slash commands
2. `fixed-toolbar/more-inserts-group.tsx` - Date toolbar button
3. `ai-chat-sidebar-item.tsx` - Chat timestamps
4. `create-api-key-modal.tsx` - API key expiration labels
5. `page-verification/expiration-fields.tsx` - Verification dates
6. `page-verification/page-verification-modal.tsx` - Tooltip date
7. `page-verification/manage-verification-form.tsx` - Expires date
8. `label/format-label-date.ts` - Label dates
9. `notification/notification.utils.ts` - Relative time fallback

## Testing
1. Change app language to French/German/etc.
2. Type `/date` or `/time` in editor
3. Verify output matches selected locale (e.g., `23 juillet 2025` for French, `23. Juli 2025` for German)

cc @Philipinho