### PR TITLE
feat: add safe attachment removal and cleanup

### DIFF
--- a/apps/server/src/collaboration/collaboration.gateway.ts
+++ b/apps/server/src/collaboration/collaboration.gateway.ts
@@ -145,7 +145,12 @@ export class CollaborationGateway {
     documentName: string,
     payload: Parameters<CollabEventHandlers[TName]>[1],
   ) {
-    return this.redisSync?.handleEvent(eventName, documentName, payload);
+    if (this.redisSync) {
+      return this.redisSync.handleEvent(eventName, documentName, payload);
+    }
+
+    const handlers = this.collabEventsService.getHandlers(this.hocuspocus);
+    return handlers[eventName](documentName, payload as never);
   }
 
   openDirectConnection(documentName: string, context?: any) {

--- a/apps/server/src/collaboration/collaboration.handler.spec.ts
+++ b/apps/server/src/collaboration/collaboration.handler.spec.ts
@@ -1,0 +1,75 @@
+import * as Y from 'yjs';
+import { TiptapTransformer } from '@hocuspocus/transformer';
+import { removeAttachmentNodes } from './collaboration.handler';
+import { tiptapExtensions } from './collaboration.util';
+
+describe('removeAttachmentNodes', () => {
+  it('removes matching attachment nodes at any depth', () => {
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment('default');
+
+    const topLevelImage = new Y.XmlElement('image');
+    topLevelImage.setAttribute('attachmentId', 'attachment-1');
+
+    const wrapper = new Y.XmlElement('wrapper');
+    const nestedAttachment = new Y.XmlElement('attachment');
+    nestedAttachment.setAttribute('attachmentId', 'attachment-1');
+    const retainedImage = new Y.XmlElement('image');
+    retainedImage.setAttribute('attachmentId', 'attachment-2');
+    wrapper.insert(0, [nestedAttachment, retainedImage]);
+
+    fragment.insert(0, [topLevelImage, wrapper]);
+
+    expect(removeAttachmentNodes(fragment, 'attachment-1')).toBe(2);
+    expect(fragment.length).toBe(1);
+    expect(wrapper.length).toBe(1);
+    expect((wrapper.get(0) as Y.XmlElement).getAttribute('attachmentId')).toBe(
+      'attachment-2',
+    );
+  });
+
+  it('is idempotent when the attachment is already absent', () => {
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment('default');
+    const paragraph = new Y.XmlElement('paragraph');
+    fragment.insert(0, [paragraph]);
+
+    expect(removeAttachmentNodes(fragment, 'missing')).toBe(0);
+    expect(fragment.length).toBe(1);
+  });
+
+  it('removes nodes from the real Tiptap Yjs document shape', () => {
+    const doc = TiptapTransformer.toYdoc(
+      {
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'Keep me' }],
+          },
+          {
+            type: 'image',
+            attrs: {
+              src: '/api/files/attachment-1/diagram.png',
+              attachmentId: 'attachment-1',
+            },
+          },
+        ],
+      },
+      'default',
+      tiptapExtensions,
+    );
+
+    expect(
+      removeAttachmentNodes(doc.getXmlFragment('default'), 'attachment-1'),
+    ).toBe(1);
+
+    const result = TiptapTransformer.fromYdoc(doc, 'default');
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        type: 'paragraph',
+        content: [{ type: 'text', text: 'Keep me' }],
+      }),
+    ]);
+  });
+});

--- a/apps/server/src/collaboration/collaboration.handler.ts
+++ b/apps/server/src/collaboration/collaboration.handler.ts
@@ -13,6 +13,33 @@ export type CollabEventHandlers = ReturnType<
   CollaborationHandler['getHandlers']
 >;
 
+type YXmlContainer = Y.XmlFragment | Y.XmlElement;
+
+export function removeAttachmentNodes(
+  container: YXmlContainer,
+  attachmentId: string,
+): number {
+  let removed = 0;
+  const children = container.toArray();
+
+  for (let index = children.length - 1; index >= 0; index--) {
+    const child = children[index];
+    if (!(child instanceof Y.XmlElement)) {
+      continue;
+    }
+
+    if (child.getAttribute('attachmentId') === attachmentId) {
+      container.delete(index, 1);
+      removed++;
+      continue;
+    }
+
+    removed += removeAttachmentNodes(child, attachmentId);
+  }
+
+  return removed;
+}
+
 @Injectable()
 export class CollaborationHandler {
   private readonly logger = new Logger(CollaborationHandler.name);
@@ -111,6 +138,30 @@ export class CollaborationHandler {
             }
           },
         );
+      },
+      removeAttachment: async (
+        documentName: string,
+        payload: {
+          attachmentId: string;
+          user: User;
+        },
+      ) => {
+        const { attachmentId, user } = payload;
+        let removed = 0;
+
+        await this.withYdocConnection(
+          hocuspocus,
+          documentName,
+          { user },
+          (doc) => {
+            removed = removeAttachmentNodes(
+              doc.getXmlFragment('default'),
+              attachmentId,
+            );
+          },
+        );
+
+        return removed;
       },
     };
   }

--- a/apps/server/src/common/events/audit-events.ts
+++ b/apps/server/src/common/events/audit-events.ts
@@ -98,7 +98,7 @@ export const AuditEvent = {
 
   // Attachment
   ATTACHMENT_UPLOADED: 'attachment.uploaded',
-  // ATTACHMENT_DELETED: 'attachment.deleted',
+  ATTACHMENT_REMOVED: 'attachment.removed',
 } as const;
 
 export type AuditEventType = (typeof AuditEvent)[keyof typeof AuditEvent];
@@ -111,7 +111,7 @@ export const EXCLUDED_AUDIT_EVENTS: Set<string> = new Set([
   AuditEvent.COMMENT_UPDATED,
   AuditEvent.COMMENT_RESOLVED,
   AuditEvent.COMMENT_REOPENED,
-  AuditEvent.ATTACHMENT_UPLOADED
+  AuditEvent.ATTACHMENT_UPLOADED,
 ]);
 
 export const AuditResource = {

--- a/apps/server/src/core/attachment/attachment.controller.spec.ts
+++ b/apps/server/src/core/attachment/attachment.controller.spec.ts
@@ -1,0 +1,121 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { AttachmentType } from './attachment.constants';
+import { AttachmentController } from './attachment.controller';
+
+describe('AttachmentController removeAttachment', () => {
+  const attachment = {
+    id: '019f9f01-95c0-75f5-8838-0c1781512e4b',
+    fileName: 'diagram.png',
+    type: AttachmentType.File,
+    pageId: 'page-1',
+    spaceId: 'space-1',
+    workspaceId: 'workspace-1',
+    deletedAt: null,
+  };
+  const page = { id: 'page-1', spaceId: 'space-1' };
+  const attachmentService = {
+    scheduleOrphanDeletion: jest.fn(),
+  };
+  const pageRepo = {
+    findById: jest.fn(),
+  };
+  const attachmentRepo = {
+    findById: jest.fn(),
+  };
+  const pageAccessService = {
+    validateCanEdit: jest.fn(),
+  };
+  const collaborationGateway = {
+    handleYjsEvent: jest.fn(),
+  };
+  const auditService = {
+    log: jest.fn(),
+  };
+  const controller = new AttachmentController(
+    attachmentService as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    pageRepo as never,
+    attachmentRepo as never,
+    {} as never,
+    {} as never,
+    pageAccessService as never,
+    collaborationGateway as never,
+    auditService as never,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    attachmentRepo.findById.mockResolvedValue(attachment);
+    pageRepo.findById.mockResolvedValue(page);
+    pageAccessService.validateCanEdit.mockResolvedValue(undefined);
+    collaborationGateway.handleYjsEvent.mockResolvedValue(1);
+    attachmentService.scheduleOrphanDeletion.mockResolvedValue({
+      ...attachment,
+      deletedAt: new Date(),
+    });
+  });
+
+  it('detaches through collaboration before scheduling deletion', async () => {
+    const result = await controller.removeAttachment(
+      { attachmentId: attachment.id },
+      { id: 'workspace-1', trashRetentionDays: 7 } as never,
+      { id: 'user-1' } as never,
+    );
+
+    expect(pageAccessService.validateCanEdit).toHaveBeenCalledWith(
+      page,
+      expect.objectContaining({ id: 'user-1' }),
+    );
+    expect(collaborationGateway.handleYjsEvent).toHaveBeenCalledWith(
+      'removeAttachment',
+      'page.page-1',
+      expect.objectContaining({ attachmentId: attachment.id }),
+    );
+    expect(
+      collaborationGateway.handleYjsEvent.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      attachmentService.scheduleOrphanDeletion.mock.invocationCallOrder[0],
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: attachment.id,
+        detached: true,
+        scheduledForDeletion: true,
+        retentionDays: 7,
+      }),
+    );
+    expect(auditService.log).toHaveBeenCalled();
+  });
+
+  it('does not disclose attachments from another workspace', async () => {
+    await expect(
+      controller.removeAttachment(
+        { attachmentId: attachment.id },
+        { id: 'another-workspace' } as never,
+        { id: 'user-1' } as never,
+      ),
+    ).rejects.toBeInstanceOf(NotFoundException);
+
+    expect(pageAccessService.validateCanEdit).not.toHaveBeenCalled();
+    expect(collaborationGateway.handleYjsEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not detach when the user cannot edit the owning page', async () => {
+    pageAccessService.validateCanEdit.mockRejectedValue(
+      new ForbiddenException(),
+    );
+
+    await expect(
+      controller.removeAttachment(
+        { attachmentId: attachment.id },
+        { id: 'workspace-1' } as never,
+        { id: 'user-1' } as never,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(collaborationGateway.handleYjsEvent).not.toHaveBeenCalled();
+    expect(attachmentService.scheduleOrphanDeletion).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/core/attachment/attachment.controller.ts
+++ b/apps/server/src/core/attachment/attachment.controller.ts
@@ -53,13 +53,18 @@ import { EnvironmentService } from '../../integrations/environment/environment.s
 import { TokenService } from '../auth/services/token.service';
 import { JwtAttachmentPayload, JwtType } from '../auth/dto/jwt-payload';
 import * as path from 'path';
-import { AttachmentInfoDto, RemoveIconDto } from './dto/attachment.dto';
+import {
+  AttachmentInfoDto,
+  RemoveAttachmentDto,
+  RemoveIconDto,
+} from './dto/attachment.dto';
 import { PageAccessService } from '../page/page-access/page-access.service';
 import { AuditEvent, AuditResource } from '../../common/events/audit-events';
 import {
   AUDIT_SERVICE,
   IAuditService,
 } from '../../integrations/audit/audit.service';
+import { CollaborationGateway } from '../../collaboration/collaboration.gateway';
 
 @Controller()
 export class AttachmentController {
@@ -75,6 +80,7 @@ export class AttachmentController {
     private readonly environmentService: EnvironmentService,
     private readonly tokenService: TokenService,
     private readonly pageAccessService: PageAccessService,
+    private readonly collaborationGateway: CollaborationGateway,
     @Inject(AUDIT_SERVICE) private readonly auditService: IAuditService,
   ) {}
 
@@ -412,6 +418,62 @@ export class AttachmentController {
     await this.pageAccessService.validateCanView(page, user);
 
     return attachment;
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @Post('files/remove')
+  async removeAttachment(
+    @Body() dto: RemoveAttachmentDto,
+    @AuthWorkspace() workspace: Workspace,
+    @AuthUser() user: User,
+  ) {
+    const attachment = await this.attachmentRepo.findById(dto.attachmentId);
+    if (
+      !attachment ||
+      !attachment.pageId ||
+      attachment.workspaceId !== workspace.id ||
+      attachment.type !== AttachmentType.File
+    ) {
+      throw new NotFoundException('File not found');
+    }
+
+    const page = await this.pageRepo.findById(attachment.pageId);
+    if (!page) {
+      throw new NotFoundException('File not found');
+    }
+
+    await this.pageAccessService.validateCanEdit(page, user);
+
+    const removedCount = await this.collaborationGateway.handleYjsEvent(
+      'removeAttachment',
+      `page.${page.id}`,
+      {
+        attachmentId: attachment.id,
+        user,
+      },
+    );
+    const scheduledAttachment =
+      await this.attachmentService.scheduleOrphanDeletion(attachment);
+
+    this.auditService.log({
+      event: AuditEvent.ATTACHMENT_REMOVED,
+      resourceType: AuditResource.ATTACHMENT,
+      resourceId: attachment.id,
+      spaceId: attachment.spaceId,
+      metadata: {
+        fileName: attachment.fileName,
+        pageId: page.id,
+        retentionDays: workspace.trashRetentionDays ?? 30,
+      },
+    });
+
+    return {
+      ...scheduledAttachment,
+      detached: Number(removedCount) > 0,
+      scheduledForDeletion: true,
+      retentionDays: workspace.trashRetentionDays ?? 30,
+    };
   }
 
   @UseGuards(JwtAuthGuard)

--- a/apps/server/src/core/attachment/attachment.module.ts
+++ b/apps/server/src/core/attachment/attachment.module.ts
@@ -6,9 +6,16 @@ import { UserModule } from '../user/user.module';
 import { WorkspaceModule } from '../workspace/workspace.module';
 import { AttachmentProcessor } from './processors/attachment.processor';
 import { TokenModule } from '../auth/token.module';
+import { CollaborationModule } from '../../collaboration/collaboration.module';
 
 @Module({
-  imports: [StorageModule, UserModule, WorkspaceModule, TokenModule],
+  imports: [
+    StorageModule,
+    UserModule,
+    WorkspaceModule,
+    TokenModule,
+    CollaborationModule,
+  ],
   controllers: [AttachmentController],
   providers: [AttachmentService, AttachmentProcessor],
 })

--- a/apps/server/src/core/attachment/dto/attachment.dto.ts
+++ b/apps/server/src/core/attachment/dto/attachment.dto.ts
@@ -7,6 +7,8 @@ export class AttachmentInfoDto {
   attachmentId: string;
 }
 
+export class RemoveAttachmentDto extends AttachmentInfoDto {}
+
 export class RemoveIconDto {
   @IsEnum(AttachmentType)
   @IsIn([

--- a/apps/server/src/core/attachment/services/attachment.service.spec.ts
+++ b/apps/server/src/core/attachment/services/attachment.service.spec.ts
@@ -1,0 +1,165 @@
+import { Attachment } from '@docmost/db/types/entity.types';
+import { Readable } from 'stream';
+import { AttachmentType } from '../attachment.constants';
+import { AttachmentService } from './attachment.service';
+
+const attachment = (overrides: Partial<Attachment> = {}): Attachment =>
+  ({
+    id: '019f9f01-95c0-75f5-8838-0c1781512e4b',
+    fileName: 'diagram.png',
+    filePath: 'workspace/files/attachment/diagram.png',
+    fileSize: 10,
+    fileExt: '.png',
+    mimeType: 'image/png',
+    type: AttachmentType.File,
+    creatorId: 'user-1',
+    pageId: 'page-1',
+    spaceId: 'space-1',
+    aiChatId: null,
+    workspaceId: 'workspace-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    ...overrides,
+  }) as Attachment;
+
+describe('AttachmentService orphan lifecycle', () => {
+  const storageService = {
+    delete: jest.fn(),
+    upload: jest.fn(),
+  };
+  const attachmentRepo = {
+    findById: jest.fn(),
+    updateAttachment: jest.fn(),
+    deleteAttachmentById: jest.fn(),
+    isReferencedByPageContent: jest.fn(),
+  };
+  const db = {};
+  const service = new AttachmentService(
+    storageService as never,
+    attachmentRepo as never,
+    {} as never,
+    {} as never,
+    {} as never,
+    db as never,
+    {} as never,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('replaces bytes at the existing storage path to preserve the URL', async () => {
+    const existing = attachment({
+      fileName: 'original.png',
+      filePath: 'workspace-1/files/attachment-id/original.png',
+      deletedAt: new Date(),
+    });
+    const updated = attachment({
+      fileName: existing.fileName,
+      filePath: existing.filePath,
+    });
+    attachmentRepo.findById.mockResolvedValue(existing);
+    attachmentRepo.updateAttachment.mockResolvedValue(updated);
+    storageService.upload.mockImplementation(
+      async (_path: string, content: Readable) => {
+        for await (const _chunk of content) {
+          // Consume the stream as a storage driver would.
+        }
+      },
+    );
+
+    const result = await service.uploadFile({
+      filePromise: Promise.resolve({
+        filename: 'renamed.png',
+        file: Readable.from(Buffer.from('replacement')),
+      } as never),
+      pageId: existing.pageId,
+      spaceId: existing.spaceId,
+      userId: existing.creatorId,
+      workspaceId: existing.workspaceId,
+      attachmentId: existing.id,
+    });
+
+    expect(storageService.upload).toHaveBeenCalledWith(
+      existing.filePath,
+      expect.any(Readable),
+    );
+    expect(attachmentRepo.updateAttachment).toHaveBeenLastCalledWith(
+      expect.objectContaining({ deletedAt: null, fileSize: 11 }),
+      existing.id,
+    );
+    expect(result.fileName).toBe('original.png');
+    expect(result.filePath).toBe(existing.filePath);
+  });
+
+  it('marks a detached attachment once without extending its retention', async () => {
+    const original = attachment();
+    const scheduled = attachment({ deletedAt: new Date() });
+    attachmentRepo.updateAttachment.mockResolvedValue(scheduled);
+
+    await expect(service.scheduleOrphanDeletion(original)).resolves.toBe(
+      scheduled,
+    );
+    expect(attachmentRepo.updateAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({ deletedAt: expect.any(Date) }),
+      original.id,
+    );
+
+    await expect(service.scheduleOrphanDeletion(scheduled)).resolves.toBe(
+      scheduled,
+    );
+    expect(attachmentRepo.updateAttachment).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels deletion when an attachment is referenced again', async () => {
+    const scheduled = attachment({ deletedAt: new Date() });
+    attachmentRepo.findById.mockResolvedValue(scheduled);
+    attachmentRepo.isReferencedByPageContent.mockResolvedValue(true);
+
+    await expect(service.purgeOrphanAttachment(scheduled.id)).resolves.toBe(
+      false,
+    );
+
+    expect(attachmentRepo.updateAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({ deletedAt: null }),
+      scheduled.id,
+    );
+    expect(storageService.delete).not.toHaveBeenCalled();
+    expect(attachmentRepo.deleteAttachmentById).not.toHaveBeenCalled();
+  });
+
+  it('deletes unreferenced attachment storage and metadata', async () => {
+    const scheduled = attachment({ deletedAt: new Date() });
+    attachmentRepo.findById.mockResolvedValue(scheduled);
+    attachmentRepo.isReferencedByPageContent.mockResolvedValue(false);
+
+    await expect(service.purgeOrphanAttachment(scheduled.id)).resolves.toBe(
+      true,
+    );
+
+    expect(storageService.delete).toHaveBeenCalledWith(scheduled.filePath);
+    expect(attachmentRepo.deleteAttachmentById).toHaveBeenCalledWith(
+      scheduled.id,
+    );
+  });
+
+  it('does not delete when the orphan marker changes during cleanup', async () => {
+    const scheduled = attachment({ deletedAt: new Date() });
+    const restored = attachment({
+      deletedAt: null,
+      updatedAt: new Date(scheduled.updatedAt.getTime() + 1),
+    });
+    attachmentRepo.findById
+      .mockResolvedValueOnce(scheduled)
+      .mockResolvedValueOnce(restored);
+    attachmentRepo.isReferencedByPageContent.mockResolvedValue(false);
+
+    await expect(service.purgeOrphanAttachment(scheduled.id)).resolves.toBe(
+      false,
+    );
+
+    expect(storageService.delete).not.toHaveBeenCalled();
+    expect(attachmentRepo.deleteAttachmentById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/core/attachment/services/attachment.service.ts
+++ b/apps/server/src/core/attachment/services/attachment.service.ts
@@ -4,6 +4,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
 import { Readable } from 'stream';
 import { StorageService } from '../../../integrations/storage/storage.service';
 import { MultipartFile } from '@fastify/multipart';
@@ -28,9 +29,13 @@ import { QueueJob, QueueName } from '../../../integrations/queue/constants';
 import { Queue } from 'bullmq';
 import { createByteCountingStream } from '../../../common/helpers/utils';
 
+const DEFAULT_ORPHAN_RETENTION_DAYS = 30;
+const ORPHAN_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
 @Injectable()
 export class AttachmentService {
   private readonly logger = new Logger(AttachmentService.name);
+  private orphanCleanupRunning = false;
   constructor(
     private readonly storageService: StorageService,
     private readonly attachmentRepo: AttachmentRepo,
@@ -56,11 +61,12 @@ export class AttachmentService {
 
     let isUpdate = false;
     let attachmentId = null;
+    let existingAttachment: Attachment = null;
 
     // passing attachmentId to allow for updating diagrams
     // instead of creating new files for each save
     if (opts?.attachmentId) {
-      const existingAttachment = await this.attachmentRepo.findById(
+      existingAttachment = await this.attachmentRepo.findById(
         opts.attachmentId,
       );
       if (!existingAttachment) {
@@ -76,13 +82,21 @@ export class AttachmentService {
       ) {
         throw new BadRequestException('File attachment does not match');
       }
+      if (existingAttachment.deletedAt) {
+        await this.attachmentRepo.updateAttachment(
+          { deletedAt: null, updatedAt: new Date() },
+          existingAttachment.id,
+        );
+      }
       attachmentId = opts.attachmentId;
       isUpdate = true;
     } else {
       attachmentId = uuid7();
     }
 
-    const filePath = `${getAttachmentFolderPath(AttachmentType.File, workspaceId)}/${attachmentId}/${preparedFile.fileName}`;
+    const filePath =
+      existingAttachment?.filePath ??
+      `${getAttachmentFolderPath(AttachmentType.File, workspaceId)}/${attachmentId}/${preparedFile.fileName}`;
 
     const { stream, getBytesRead } = createByteCountingStream(
       preparedFile.multiPartFile.file,
@@ -99,6 +113,7 @@ export class AttachmentService {
         attachment = await this.attachmentRepo.updateAttachment(
           {
             fileSize: preparedFile.fileSize,
+            deletedAt: null,
             updatedAt: new Date(),
           },
           attachmentId,
@@ -422,6 +437,105 @@ export class AttachmentService {
         err,
       );
       throw err;
+    }
+  }
+
+  async scheduleOrphanDeletion(attachment: Attachment): Promise<Attachment> {
+    if (attachment.deletedAt) {
+      return attachment;
+    }
+
+    return this.attachmentRepo.updateAttachment(
+      {
+        deletedAt: new Date(),
+        updatedAt: new Date(),
+      },
+      attachment.id,
+    );
+  }
+
+  async purgeOrphanAttachment(attachmentId: string): Promise<boolean> {
+    const attachment = await this.attachmentRepo.findById(attachmentId);
+    if (
+      !attachment ||
+      !attachment.deletedAt ||
+      attachment.type !== AttachmentType.File
+    ) {
+      return false;
+    }
+
+    const isReferenced = await this.attachmentRepo.isReferencedByPageContent(
+      attachment.id,
+      attachment.workspaceId,
+    );
+    if (isReferenced) {
+      await this.attachmentRepo.updateAttachment(
+        { deletedAt: null, updatedAt: new Date() },
+        attachment.id,
+      );
+      return false;
+    }
+
+    const confirmedAttachment = await this.attachmentRepo.findById(
+      attachment.id,
+    );
+    if (
+      !confirmedAttachment?.deletedAt ||
+      confirmedAttachment.deletedAt.getTime() !==
+        attachment.deletedAt.getTime() ||
+      confirmedAttachment.updatedAt.getTime() !== attachment.updatedAt.getTime()
+    ) {
+      return false;
+    }
+
+    await this.storageService.delete(confirmedAttachment.filePath);
+    await this.attachmentRepo.deleteAttachmentById(confirmedAttachment.id);
+    return true;
+  }
+
+  @Interval('orphan-attachment-cleanup', ORPHAN_CLEANUP_INTERVAL_MS)
+  async cleanupExpiredOrphans(): Promise<void> {
+    if (this.orphanCleanupRunning) {
+      return;
+    }
+    this.orphanCleanupRunning = true;
+
+    try {
+      const workspaces = await this.db
+        .selectFrom('workspaces')
+        .select(['id', 'trashRetentionDays'])
+        .where('deletedAt', 'is', null)
+        .execute();
+
+      for (const workspace of workspaces) {
+        const retentionDays =
+          workspace.trashRetentionDays ?? DEFAULT_ORPHAN_RETENTION_DAYS;
+        const olderThan = new Date();
+        olderThan.setDate(olderThan.getDate() - retentionDays);
+
+        const candidates = await this.attachmentRepo.findExpiredOrphans(
+          workspace.id,
+          olderThan,
+        );
+        for (const attachment of candidates) {
+          try {
+            await this.purgeOrphanAttachment(attachment.id);
+          } catch (error) {
+            this.logger.error(
+              `Failed to clean orphan attachment ${attachment.id}: ${
+                error instanceof Error ? error.message : 'Unknown error'
+              }`,
+            );
+          }
+        }
+      }
+    } catch (error) {
+      this.logger.error(
+        'Orphan attachment cleanup failed',
+        error instanceof Error ? error.stack : undefined,
+      );
+    } finally {
+      this.orphanCleanupRunning = false;
     }
   }
 

--- a/apps/server/src/database/repos/attachment/attachment.repo.ts
+++ b/apps/server/src/database/repos/attachment/attachment.repo.ts
@@ -8,6 +8,7 @@ import {
   UpdatableAttachment,
 } from '@docmost/db/types/entity.types';
 import { AttachmentType } from '../../../core/attachment/attachment.constants';
+import { sql } from 'kysely';
 
 @Injectable()
 export class AttachmentRepo {
@@ -143,6 +144,38 @@ export class AttachmentRepo {
       .where('id', '=', attachmentId)
       .returning(this.baseFields)
       .executeTakeFirst();
+  }
+
+  async findExpiredOrphans(
+    workspaceId: string,
+    olderThan: Date,
+    limit = 500,
+  ): Promise<Attachment[]> {
+    return this.db
+      .selectFrom('attachments')
+      .select(this.baseFields)
+      .where('workspaceId', '=', workspaceId)
+      .where('type', '=', AttachmentType.File)
+      .where('deletedAt', 'is not', null)
+      .where('deletedAt', '<', olderThan)
+      .orderBy('deletedAt', 'asc')
+      .limit(limit)
+      .execute();
+  }
+
+  async isReferencedByPageContent(
+    attachmentId: string,
+    workspaceId: string,
+  ): Promise<boolean> {
+    const match = await this.db
+      .selectFrom('pages')
+      .select('id')
+      .where('workspaceId', '=', workspaceId)
+      .where(sql<boolean>`CAST(content AS TEXT) LIKE ${`%${attachmentId}%`}`)
+      .limit(1)
+      .executeTakeFirst();
+
+    return Boolean(match);
   }
 
   async claimAttachmentsForChat(


### PR DESCRIPTION
## What changed

- add an authenticated `POST /files/remove` endpoint for page-owned file attachments
- validate edit access before removing every matching attachment node through the Yjs collaboration document
- retain detached files for the workspace trash-retention period
- run daily orphan cleanup that rechecks current page references before deleting storage and metadata
- cancel scheduled cleanup when an attachment is referenced or replaced again
- preserve the existing storage path during replacement so attachment IDs and URLs remain stable
- emit an `attachment.removed` audit event

## Why

Removing an attachment block previously left its storage object and database record behind indefinitely. Immediate physical deletion would make undo, concurrent editing, and temporary detachment unsafe.

This adds a collaboration-aware detach operation with a retention window and conservative reference check, balancing recoverability with eventual cleanup. It reuses the existing attachment `deletedAt` field, so no database migration is required.

## Validation

- `pnpm --filter server exec jest --runInBand src/core/attachment/attachment.controller.spec.ts src/core/attachment/services/attachment.service.spec.ts src/collaboration/collaboration.handler.spec.ts` — 11 tests passed
- targeted ESLint — passed
- targeted Prettier check — passed
- `pnpm server:build` — passed
- `git diff --check` — passed

The repository-wide Jest command was also run. Its 11 healthy suites and 155 tests passed, while 16 existing scaffold/config suites failed on missing Nest test dependencies or the unavailable transactional email module; none of those failing files are changed here.
