### PR TITLE
Set browser tab title for built-in routes

### DIFF
--- a/apps/client/src/pages/auth/forgot-password.tsx
+++ b/apps/client/src/pages/auth/forgot-password.tsx
@@ -1,12 +1,17 @@
 import { ForgotPasswordForm } from "@/features/auth/components/forgot-password-form";
 import { getAppName } from "@/lib/config";
 import { Helmet } from "react-helmet-async";
+import { useTranslation } from "react-i18next";
+
 
 export default function ForgotPassword() {
+    const { t } = useTranslation();
     return (
         <>
             <Helmet>
-                <title>Forgot Password - {getAppName()}</title>
+                <title>
+                    {`${t("Forgot Password")}`}
+                </title>
             </Helmet>
             <ForgotPasswordForm />
         </>

--- a/apps/client/src/pages/auth/invite-signup.tsx
+++ b/apps/client/src/pages/auth/invite-signup.tsx
@@ -9,7 +9,7 @@ export default function InviteSignup() {
   return (
     <>
       <Helmet>
-        <title>{t("Invitation Signup")} - {getAppName()}</title>
+        <title>{`${t("Invitation Signup")}`}</title>
       </Helmet>
       <InviteSignUpForm />
     </>

--- a/apps/client/src/pages/auth/login.tsx
+++ b/apps/client/src/pages/auth/login.tsx
@@ -10,7 +10,7 @@ export default function LoginPage() {
     <>
       <Helmet>
         <title>
-          {t("Login")} - {getAppName()}
+          {`${t("Login")}`}
         </title>
       </Helmet>
       <LoginForm />

--- a/apps/client/src/pages/auth/password-reset.tsx
+++ b/apps/client/src/pages/auth/password-reset.tsx
@@ -25,7 +25,7 @@ export default function PasswordReset() {
       <>
         <Helmet>
           <title>
-            {t("Password Reset")} - {getAppName()}
+            {`${t("Password Reset")}`}
           </title>
         </Helmet>
         <Container my={40}>
@@ -51,7 +51,7 @@ export default function PasswordReset() {
     <>
       <Helmet>
         <title>
-          {t("Password Reset")} - {getAppName()}
+            {`${t("Password Reset")}`}
         </title>
       </Helmet>
       <PasswordResetForm resetToken={resetToken} />

--- a/apps/client/src/pages/auth/setup-workspace.tsx
+++ b/apps/client/src/pages/auth/setup-workspace.tsx
@@ -37,7 +37,7 @@ export default function SetupWorkspace() {
       <>
         <Helmet>
           <title>
-            {t("Setup Workspace")} - {getAppName()}
+            {`${t("Setup Workspace")}`}
           </title>
         </Helmet>
         <SetupWorkspaceForm />

--- a/apps/client/src/pages/dashboard/home.tsx
+++ b/apps/client/src/pages/dashboard/home.tsx
@@ -13,7 +13,7 @@ export default function Home() {
     <>
       <Helmet>
         <title>
-          {t("Home")} - {getAppName()}
+          {`${getAppName()}`}
         </title>
       </Helmet>
       <Container size={"900"} pt="xl">

--- a/apps/client/src/pages/favorites/favorites-page.tsx
+++ b/apps/client/src/pages/favorites/favorites-page.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from "react-i18next";
 import { getInitialsColor } from "@/lib/get-initials-color";
 import PageListSkeleton from "@/components/ui/page-list-skeleton";
 import rowClasses from "@/components/ui/clickable-table-row.module.css";
+import { Helmet } from "react-helmet-async";
 
 export default function FavoritesPage() {
   const { t } = useTranslation();
@@ -29,9 +30,11 @@ export default function FavoritesPage() {
   if (isLoading) {
     return (
       <Container size={800} py="xl">
-        <Title order={3} mb="lg">
-          {t("Favorites")}
-        </Title>
+        <Helmet>
+          <title>
+            {`${t("Favorites")}`}
+          </title>
+        </Helmet>
         <PageListSkeleton />
       </Container>
     );
@@ -40,9 +43,11 @@ export default function FavoritesPage() {
   if (isError) {
     return (
       <Container size={800} py="xl">
-        <Title order={3} mb="lg">
-          {t("Favorites")}
-        </Title>
+        <Helmet>
+          <title>
+            {`${t("Favorites")}`}
+          </title>
+        </Helmet>
         <Text>{t("Failed to fetch favorite pages")}</Text>
       </Container>
     );
@@ -50,9 +55,11 @@ export default function FavoritesPage() {
 
   return (
     <Container size={800} py="xl">
-      <Title order={1} size="h3" mb="lg">
-        {t("Favorites")}
-      </Title>
+      <Helmet>
+        <title>
+          {`${t("Favorites")}`}
+        </title>
+      </Helmet>
       {favorites.length > 0 ? (
         <>
           <Table.ScrollContainer minWidth={500}>

--- a/apps/client/src/pages/label/label-page.tsx
+++ b/apps/client/src/pages/label/label-page.tsx
@@ -84,7 +84,7 @@ export default function LabelPage() {
     <>
       <Helmet>
         <title>
-          {labelName} - {getAppName()}
+          {`${labelName}`}
         </title>
       </Helmet>
 

--- a/apps/client/src/pages/settings/account/account-preferences.tsx
+++ b/apps/client/src/pages/settings/account/account-preferences.tsx
@@ -17,7 +17,7 @@ export default function AccountPreferences() {
     <>
       <Helmet>
         <title>
-          {t("Preferences")} - {getAppName()}
+          {`${t("Preferences")}`}
         </title>
       </Helmet>
       <SettingsTitle title={t("Preferences")} />

--- a/apps/client/src/pages/settings/account/account-settings.tsx
+++ b/apps/client/src/pages/settings/account/account-settings.tsx
@@ -17,7 +17,7 @@ export default function AccountSettings() {
     <>
       <Helmet>
         <title>
-          {t("My Profile")} - {getAppName()}
+          {`${t("My Profile")}`}
         </title>
       </Helmet>
       <SettingsTitle title={t("My Profile")} />

--- a/apps/client/src/pages/settings/group/group-info.tsx
+++ b/apps/client/src/pages/settings/group/group-info.tsx
@@ -12,7 +12,7 @@ export default function GroupInfo() {
     <>
       <Helmet>
         <title>
-          {t("Manage Group")} - {getAppName()}
+          {`${t("Manage Group")}`}
         </title>
       </Helmet>
       <SettingsTitle title={t("Manage Group")} />

--- a/apps/client/src/pages/settings/group/groups.tsx
+++ b/apps/client/src/pages/settings/group/groups.tsx
@@ -14,7 +14,7 @@ export default function Groups() {
   return (
     <>
         <Helmet>
-            <title>{t("Groups")} - {getAppName()}</title>
+            <title>{`${t("Groups")}`}</title>
         </Helmet>
       <SettingsTitle title={t("Groups")} />
 

--- a/apps/client/src/pages/settings/shares/shares.tsx
+++ b/apps/client/src/pages/settings/shares/shares.tsx
@@ -14,7 +14,7 @@ export default function Shares() {
     <>
       <Helmet>
         <title>
-          {t("Public sharing")} - {getAppName()}
+          {`${t("Public sharing")}`}
         </title>
       </Helmet>
       <SettingsTitle title={t("Public sharing")} />

--- a/apps/client/src/pages/settings/space/spaces.tsx
+++ b/apps/client/src/pages/settings/space/spaces.tsx
@@ -15,7 +15,7 @@ export default function Spaces() {
     <>
       <Helmet>
         <title>
-          {t("Spaces")} - {getAppName()}
+          {`${t("Spaces")}`}
         </title>
       </Helmet>
       <SettingsTitle title={t("Spaces")} />

--- a/apps/client/src/pages/settings/workspace/workspace-members.tsx
+++ b/apps/client/src/pages/settings/workspace/workspace-members.tsx
@@ -40,7 +40,7 @@ export default function WorkspaceMembers() {
     <>
       <Helmet>
         <title>
-          {t("Members")} - {getAppName()}
+          {`${t("Members")}`}
         </title>
       </Helmet>
       <SettingsTitle title={t("Members")} />

--- a/apps/client/src/pages/settings/workspace/workspace-settings.tsx
+++ b/apps/client/src/pages/settings/workspace/workspace-settings.tsx
@@ -15,7 +15,7 @@ export default function WorkspaceSettings() {
   return (
     <>
       <Helmet>
-        <title>Workspace Settings - {getAppName()}</title>
+        <title>{`${t("Settings")}`}</title>
       </Helmet>
       <SettingsTitle title={t("General")} />
       <WorkspaceIcon />

--- a/apps/client/src/pages/space/space-home.tsx
+++ b/apps/client/src/pages/space/space-home.tsx
@@ -12,7 +12,9 @@ export default function SpaceHome() {
     return (
         <>
             <Helmet>
-                <title>{space?.name || 'Overview'} - {getAppName()}</title>
+                <title>
+                    {`${space?.name || 'Overview'}`}
+                </title>
             </Helmet>
             <Container size={"900"} pt="xl">
                 {space && <SpaceHomeTabs/>}

--- a/apps/client/src/pages/spaces/spaces.tsx
+++ b/apps/client/src/pages/spaces/spaces.tsx
@@ -24,7 +24,7 @@ export default function Spaces() {
     <>
       <Helmet>
         <title>
-          {t("Spaces")} - {getAppName()}
+          {`${t("Spaces")}`}
         </title>
       </Helmet>
 


### PR DESCRIPTION

### What's this PR do?
Sets the browser tab titles to display appropriately.

### Problem
Built-in routes did not set browser tab titles. The URL would be displayed in the browser tab instead of the page title. 
 
### Relevant Issue
[Bug: Built-in routes do not set browser tab title #2372](https://github.com/docmost/docmost/issues/2372#issuecomment-5185840429)

### Root Cause
The React Helmet wants the <title> content to be one single string, but the old version gives it several separate pieces. 

<img width="667" height="606" alt="Screenshot 2026-08-07 123051" src="https://github.com/user-attachments/assets/9dc9fcad-dbca-4ec5-bfed-768baae70605" />

### Solution
The new implementation just sends one piece of string. -With a simple minimalistic approach of displaying the tab title without "- Docmost". 

<img width="770" height="673" alt="Screenshot 2026-08-07 123010" src="https://github.com/user-attachments/assets/9d57d0ab-9266-4ae4-abf7-0e1f82677c6b" />