### PR TITLE
fix(server): return 400 instead of 500 from shares/page-info when pageId is missing

### DIFF
--- a/apps/server/src/core/share/share.controller.spec.ts
+++ b/apps/server/src/core/share/share.controller.spec.ts
@@ -1,0 +1,68 @@
+import { BadRequestException } from '@nestjs/common';
+import { ShareController } from './share.controller';
+import { ShareService } from './share.service';
+import { LicenseCheckService } from '../../integrations/environment/license-check.service';
+import { Workspace } from '@docmost/db/types/entity.types';
+import { ShareInfoDto } from './dto/share.dto';
+
+describe('ShareController - getSharedPageInfo', () => {
+  const buildController = () => {
+    const shareService = {
+      getSharedPage: jest.fn(),
+      isSharingAllowed: jest.fn(),
+    } as unknown as jest.Mocked<ShareService>;
+
+    const licenseCheckService = {
+      resolveFeatures: jest.fn().mockReturnValue({}),
+    } as unknown as jest.Mocked<LicenseCheckService>;
+
+    const controller = new ShareController(
+      shareService,
+      {} as any, // shareRepo
+      {} as any, // pageRepo
+      {} as any, // pagePermissionRepo
+      {} as any, // pageAccessService
+      licenseCheckService,
+      {} as any, // auditService
+    );
+
+    return { controller, shareService, licenseCheckService };
+  };
+
+  it('throws BadRequestException without touching the service when only shareId is provided', async () => {
+    const { controller, shareService } = buildController();
+    const dto = { shareId: 'some-share-key' } as ShareInfoDto;
+    const workspace = { id: 'workspace-1' } as Workspace;
+
+    await expect(
+      controller.getSharedPageInfo(dto, workspace),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(shareService.getSharedPage).not.toHaveBeenCalled();
+  });
+
+  it('resolves the shared page when pageId is provided', async () => {
+    const { controller, shareService, licenseCheckService } = buildController();
+    shareService.getSharedPage.mockResolvedValue({
+      page: { id: 'page-1' },
+      share: { spaceId: 'space-1' },
+    } as any);
+    shareService.isSharingAllowed.mockResolvedValue(true);
+
+    const dto = { pageId: 'page-1' } as ShareInfoDto;
+    const workspace = {
+      id: 'workspace-1',
+      licenseKey: null,
+      plan: 'free',
+    } as unknown as Workspace;
+
+    const result = await controller.getSharedPageInfo(dto, workspace);
+
+    expect(shareService.getSharedPage).toHaveBeenCalledWith(dto, workspace.id);
+    expect(licenseCheckService.resolveFeatures).toHaveBeenCalledWith(
+      workspace.licenseKey,
+      workspace.plan,
+    );
+    expect(result.page).toEqual({ id: 'page-1' });
+  });
+});

--- a/apps/server/src/core/share/share.controller.ts
+++ b/apps/server/src/core/share/share.controller.ts
@@ -65,8 +65,11 @@ export class ShareController {
     @Body() dto: ShareInfoDto,
     @AuthWorkspace() workspace: Workspace,
   ) {
-    if (!dto.pageId && !dto.shareId) {
-      throw new BadRequestException();
+    // getSharedPage only ever resolves by pageId, so require it explicitly
+    // instead of accepting shareId as a stand-in — passing shareId alone
+    // used to reach the DB driver as an undefined pageId and surface as a 500.
+    if (!dto.pageId) {
+      throw new BadRequestException('pageId is required');
     }
 
     const shareData = await this.shareService.getSharedPage(dto, workspace.id);


### PR DESCRIPTION
Fixes #2396

`POST /api/shares/page-info` returns a 500 when called with only `shareId` (no `pageId`), because `getSharedPage()` only ever resolves the share by `dto.pageId` and never reads `dto.shareId`. The undefined `pageId` reaches the postgres.js driver and throws `UNDEFINED_VALUE`, which Nest maps to a 500 instead of a 4xx.

This PR keeps the existing behavior (resolve by `pageId`) but validates for it explicitly, so a request missing `pageId` fails closed with a 400 instead of crashing with a 500.

Added `share.controller.spec.ts` covering:
- only `shareId` provided → `BadRequestException`, service never called
- `pageId` provided → resolves normally through `ShareService`/`LicenseCheckService`

Verified against the pre-fix code that the new test fails with the same `TypeError`/undefined-value crash reported in the issue, and passes after the fix.