### PR TITLE
fix: carry per-user edit permission into all sidebar tree nodes

### DIFF
--- a/apps/client/src/features/page/tree/hooks/use-tree-mutation.ts
+++ b/apps/client/src/features/page/tree/hooks/use-tree-mutation.ts
@@ -150,6 +150,7 @@ export function useTreeMutation(spaceId: string): UseTreeMutation {
         spaceId: createdPage.spaceId,
         parentPageId: createdPage.parentPageId,
         hasChildren: false,
+        canEdit: true, // the creator can always edit their own page
         children: [],
       };
 
@@ -250,7 +251,16 @@ export function useTreeMutation(spaceId: string): UseTreeMutation {
         console.error("Failed to delete page:", error);
       }
     },
-    [removePageMutation, setData, store, pageSlug, navigate, spaceSlug, emit, spaceId],
+    [
+      removePageMutation,
+      setData,
+      store,
+      pageSlug,
+      navigate,
+      spaceSlug,
+      emit,
+      spaceId,
+    ],
   );
 
   return { handleMove, handleCreate, handleRename, handleDelete };

--- a/apps/client/src/features/websocket/use-tree-socket.ts
+++ b/apps/client/src/features/websocket/use-tree-socket.ts
@@ -7,6 +7,7 @@ import { SpaceTreeNode } from "@/features/page/tree/types.ts";
 import { useQueryClient } from "@tanstack/react-query";
 import { treeModel } from "@/features/page/tree/model/tree-model";
 import localEmitter from "@/lib/local-emitter.ts";
+import { getPageById } from "@/features/page/services/page-service.ts";
 
 export const useTreeSocket = () => {
   const [socket] = useAtom(socketAtom);
@@ -76,6 +77,29 @@ export const useTreeSocket = () => {
             }
             return next;
           });
+          // The emitting client's snapshot carries no per-user permissions.
+          // Backfill this user's effective edit permission so restricted or
+          // read-only pages are never draggable/droppable in the sidebar.
+          void getPageById({ pageId: event.payload.data.id })
+            .then((page) => {
+              setTreeData((prev) => {
+                if (!treeModel.find(prev, page.id)) return prev;
+                return treeModel.update(prev, page.id, {
+                  canEdit: page.permissions?.canEdit ?? true,
+                } as Partial<SpaceTreeNode>);
+              });
+            })
+            .catch((err: any) => {
+              // This user cannot view the new page (e.g. it was created
+              // inside a restricted branch) — remove it from the tree.
+              // Other failures (network blips) leave the optimistic node.
+              const status = err?.response?.status;
+              if (status === 403 || status === 404) {
+                setTreeData((prev) =>
+                  treeModel.remove(prev, event.payload.data.id),
+                );
+              }
+            });
           break;
         case "moveTreeNode":
           setTreeData((prev) => {

--- a/apps/server/src/core/page/page.controller.ts
+++ b/apps/server/src/core/page/page.controller.ts
@@ -134,19 +134,12 @@ export class PageController {
 
     await this.pageAccessService.validateCanEdit(page, user);
 
-    return this.labelService.addLabelsToPage(
-      page.id,
-      dto.names,
-      workspace.id,
-    );
+    return this.labelService.addLabelsToPage(page.id, dto.names, workspace.id);
   }
 
   @HttpCode(HttpStatus.OK)
   @Post('labels/remove')
-  async removePageLabel(
-    @Body() dto: RemoveLabelDto,
-    @AuthUser() user: User,
-  ) {
+  async removePageLabel(@Body() dto: RemoveLabelDto, @AuthUser() user: User) {
     const page = await this.pageRepo.findById(dto.pageId);
     if (!page || page.deletedAt) {
       throw new NotFoundException('Page not found');
@@ -448,17 +441,19 @@ export class PageController {
     const targetUserId = dto.userId ?? user.id;
 
     if (dto.spaceId) {
-      const ability = await this.spaceAbility.createForUser(
-        user,
-        dto.spaceId,
-      );
+      const ability = await this.spaceAbility.createForUser(user, dto.spaceId);
 
       if (ability.cannot(SpaceCaslAction.Read, SpaceCaslSubject.Page)) {
         throw new ForbiddenException();
       }
     }
 
-    return this.pageService.getCreatedByPages(targetUserId, user.id, pagination, dto.spaceId);
+    return this.pageService.getCreatedByPages(
+      targetUserId,
+      user.id,
+      pagination,
+      dto.spaceId,
+    );
   }
 
   @HttpCode(HttpStatus.OK)
@@ -746,6 +741,15 @@ export class PageController {
 
     await this.pageAccessService.validateCanView(page, user);
 
-    return this.pageService.getPageBreadCrumbs(page.id);
+    const ability = await this.spaceAbility.createForUser(user, page.spaceId);
+    const spaceCanEdit = ability.can(
+      SpaceCaslAction.Edit,
+      SpaceCaslSubject.Page,
+    );
+
+    return this.pageService.getPageBreadCrumbs(page.id, {
+      userId: user.id,
+      spaceCanEdit,
+    });
   }
 }

--- a/apps/server/src/core/page/services/page.service.ts
+++ b/apps/server/src/core/page/services/page.service.ts
@@ -129,24 +129,27 @@ export class PageService {
       ydoc = createYdocFromJson(prosemirrorJson);
     }
 
-    const page = await this.pageRepo.insertPage({
-      slugId: generateSlugId(),
-      title: createPageDto.title,
-      position: await this.nextPagePosition(
-        createPageDto.spaceId,
-        parentPageId,
-      ),
-      icon: createPageDto.icon,
-      parentPageId: parentPageId,
-      spaceId: createPageDto.spaceId,
-      creatorId: userId,
-      workspaceId: workspaceId,
-      lastUpdatedById: userId,
-      isBase,
-      content,
-      textContent,
-      ydoc,
-    }, trx);
+    const page = await this.pageRepo.insertPage(
+      {
+        slugId: generateSlugId(),
+        title: createPageDto.title,
+        position: await this.nextPagePosition(
+          createPageDto.spaceId,
+          parentPageId,
+        ),
+        icon: createPageDto.icon,
+        parentPageId: parentPageId,
+        spaceId: createPageDto.spaceId,
+        creatorId: userId,
+        workspaceId: workspaceId,
+        lastUpdatedById: userId,
+        isBase,
+        content,
+        textContent,
+        ydoc,
+      },
+      trx,
+    );
 
     if (trx) {
       // Add the watcher inside the caller's transaction so the async worker
@@ -852,7 +855,10 @@ export class PageService {
     );
   }
 
-  async getPageBreadCrumbs(childPageId: string) {
+  async getPageBreadCrumbs(
+    childPageId: string,
+    opts?: { userId?: string; spaceCanEdit?: boolean },
+  ) {
     const ancestors = await this.db
       .withRecursive('page_ancestors', (db) =>
         db
@@ -903,7 +909,40 @@ export class PageService {
       )
       .execute();
 
-    return ancestors.reverse();
+    const rows = ancestors.reverse() as Array<
+      (typeof ancestors)[number] & { canEdit?: boolean }
+    >;
+
+    // Attach the requesting user's effective edit permission so clients can
+    // build sidebar nodes that carry a correct canEdit flag (e.g. to disable
+    // drag-and-drop of read-only pages). Mirrors getSidebarPages.
+    if (opts?.userId && rows.length > 0) {
+      const spaceId = rows[0].spaceId;
+      const spaceCanEdit = opts.spaceCanEdit ?? true;
+      const hasRestrictions =
+        await this.pagePermissionRepo.hasRestrictedPagesInSpace(spaceId);
+
+      if (!hasRestrictions) {
+        for (const row of rows) {
+          row.canEdit = spaceCanEdit;
+        }
+      } else {
+        const accessiblePages =
+          await this.pagePermissionRepo.filterAccessiblePageIdsWithPermissions(
+            rows.map((row) => row.id),
+            opts.userId,
+          );
+        const permissionMap = new Map(
+          accessiblePages.map((p) => [p.id, p.canEdit]),
+        );
+
+        for (const row of rows) {
+          row.canEdit = permissionMap.get(row.id) && spaceCanEdit;
+        }
+      }
+    }
+
+    return rows;
   }
 
   async getRecentSpacePages(


### PR DESCRIPTION
Closes #2357. The sidebar tree already disables drag-and-drop for users who cannot manage pages, but three paths could still insert nodes without permission data, letting restricted/read-only pages be dragged (failing server-side with an error toast):

- /pages/breadcrumbs now returns each ancestor's effective canEdit for the requesting user (mirroring getSidebarPages), so lazy-loaded ancestor nodes in the sidebar carry correct editability.
- Realtime addTreeNode events backfill the receiving user's canEdit via /pages/info and remove the node entirely if the user cannot view it.
- Optimistically created nodes are stamped with canEdit: true.