### PR TITLE
#2439 - Fix PDF files not rendering when embedded

### DIFF
--- a/apps/server/src/common/helpers/security-headers.spec.ts
+++ b/apps/server/src/common/helpers/security-headers.spec.ts
@@ -1,6 +1,7 @@
 import {
   resolveFrameHeader,
   resolveFrameHeadersForPath,
+  resolveAttachmentCsp,
   SecurityHeader,
 } from './security-headers';
 
@@ -62,5 +63,44 @@ describe('resolveFrameHeadersForPath', () => {
 
   it('returns nothing for other paths when no header is configured', () => {
     expect(resolveFrameHeadersForPath('/home', null)).toEqual([]);
+  });
+});
+
+describe('resolveAttachmentCsp', () => {
+  it('returns a permissive CSP for PDF files (no default-src)', () => {
+    // Regression: PDFs must not have default-src 'self' because the browser
+    // built-in PDF viewer uses blob: URLs that violate that directive,
+    // causing an empty <iframe> frame (issue #2347).
+    const csp = resolveAttachmentCsp('.pdf');
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).not.toContain('default-src');
+  });
+
+  it('returns the strict CSP for image files', () => {
+    const csp = resolveAttachmentCsp('.jpg');
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("object-src 'self'");
+    expect(csp).toContain("default-src 'self'");
+  });
+
+  it('returns the strict CSP for video files', () => {
+    expect(resolveAttachmentCsp('.mp4')).toContain("default-src 'self'");
+  });
+
+  it('returns the strict CSP for audio files', () => {
+    expect(resolveAttachmentCsp('.mp3')).toContain("default-src 'self'");
+  });
+
+  it('returns the strict CSP for arbitrary non-PDF extensions', () => {
+    expect(resolveAttachmentCsp('.docx')).toContain("default-src 'self'");
+    expect(resolveAttachmentCsp('.png')).toContain("default-src 'self'");
+    expect(resolveAttachmentCsp('.zip')).toContain("default-src 'self'");
+  });
+
+  it('is case-sensitive — uppercase .PDF does not receive the permissive policy', () => {
+    // fileExt values from the DB are always lowercase (derived from path.extname).
+    // This test documents that assumption; if storage ever changes, this will catch it.
+    expect(resolveAttachmentCsp('.PDF')).toContain("default-src 'self'");
   });
 });

--- a/apps/server/src/common/helpers/security-headers.ts
+++ b/apps/server/src/common/helpers/security-headers.ts
@@ -33,3 +33,22 @@ export function resolveFrameHeadersForPath(
   }
   return configuredHeader ? [configuredHeader] : [];
 }
+
+/**
+ * Returns the Content-Security-Policy value to use for an attachment response.
+ *
+ * PDFs are rendered inside an <iframe> by the browser's built-in PDF viewer.
+ * That viewer loads resources via blob: URLs and browser-internal origins,
+ * which `default-src 'self'` would block — causing an empty frame (issue #2347).
+ * For PDF attachments we therefore omit `default-src` while keeping the
+ * `base-uri` and `object-src` restrictions.
+ *
+ * All other file types receive the stricter policy that limits sub-resource
+ * loading to same-origin.
+ */
+export function resolveAttachmentCsp(fileExt: string): string {
+  if (fileExt === '.pdf') {
+    return "base-uri 'none'; object-src 'none';";
+  }
+  return "base-uri 'none'; object-src 'self'; default-src 'self';";
+}

--- a/apps/server/src/core/attachment/attachment.controller.ts
+++ b/apps/server/src/core/attachment/attachment.controller.ts
@@ -31,7 +31,7 @@ import {
   getAttachmentFolderPath,
   validAttachmentTypes,
 } from './attachment.utils';
-import { getMimeType } from '../../common/helpers';
+import { getMimeType, resolveAttachmentCsp } from '../../common/helpers';
 import {
   AttachmentType,
   inlineFileExtensions,
@@ -522,10 +522,7 @@ export class AttachmentController {
     const rangeHeader = req.headers.range;
 
     res.header('Accept-Ranges', 'bytes');
-    res.header(
-      'Content-Security-Policy',
-      "base-uri 'none'; object-src 'self'; default-src 'self';",
-    );
+    res.header('Content-Security-Policy', resolveAttachmentCsp(attachment.fileExt));
 
     if (!inlineFileExtensions.includes(attachment.fileExt)) {
       res.header(


### PR DESCRIPTION
The default-src 'self' directive blocked the browser's built-in PDF viewer from loading internal resources (like blob: URLs), resulting in an empty iframe when rendering PDF attachments. This commit introduces a permissive CSP (omitting default-src) specifically for PDF responses, while maintaining the strict CSP for all other file types.