### PR TITLE
fix: make search input field visible in Spotlight (#2240)

### DIFF
--- a/apps/client/src/features/search/components/search-spotlight.module.css
+++ b/apps/client/src/features/search/components/search-spotlight.module.css
@@ -1,0 +1,39 @@
+/*
+ * Makes the Spotlight search header visually distinct from the results list
+ * and ensures the search input is clearly identifiable as an input field.
+ *
+ * Root cause of issue #2240: Spotlight.Search renders with border:0 and
+ * a transparent background by default, blending into the modal body and
+ * making it look like a title bar rather than a text input.
+ */
+
+/* Gray header strip that frames the search field */
+.searchHeader {
+  border-bottom: 1px solid;
+
+  @mixin light {
+    background-color: var(--mantine-color-gray-0);
+    border-bottom-color: var(--mantine-color-gray-2);
+  }
+
+  @mixin dark {
+    background-color: var(--mantine-color-dark-6);
+    border-bottom-color: var(--mantine-color-dark-4);
+  }
+}
+
+/* The inner <input> element inside Spotlight.Search */
+.searchInput {
+  border: 1px solid;
+  border-radius: var(--mantine-radius-sm);
+
+  @mixin light {
+    background-color: var(--mantine-color-white);
+    border-color: var(--mantine-color-gray-3);
+  }
+
+  @mixin dark {
+    background-color: var(--mantine-color-dark-7);
+    border-color: var(--mantine-color-dark-3);
+  }
+}

--- a/apps/client/src/features/search/components/search-spotlight.tsx
+++ b/apps/client/src/features/search/components/search-spotlight.tsx
@@ -1,6 +1,7 @@
 import { Spotlight } from "@mantine/spotlight";
 import { IconSearch, IconSparkles } from "@tabler/icons-react";
 import { Group, Button, VisuallyHidden, Text } from "@mantine/core";
+import classes from "./search-spotlight.module.css";
 import React, { useState, useMemo, useEffect, useCallback } from "react";
 import { useDebouncedValue } from "@mantine/hooks";
 import { useTranslation } from "react-i18next";
@@ -161,12 +162,13 @@ export function SearchSpotlight({ spaceId }: SearchSpotlightProps) {
           backgroundOpacity: 0.55,
         }}
       >
-        <Group gap="xs" px="sm" pt="sm" pb="xs">
+        <Group gap="xs" px="sm" pt="sm" pb="xs" className={classes.searchHeader}>
           <Spotlight.Search
             placeholder={isAiMode ? t("Ask a question...") : t("Search...")}
             aria-label={isAiMode ? t("Ask a question...") : t("Search")}
             leftSection={<IconSearch size={20} stroke={1.5} />}
             style={{ flex: 1 }}
+            classNames={{ input: classes.searchInput }}
             onKeyDown={(e) => {
               if (e.key === "Enter" && isAiMode && query.trim() && !isAiLoading) {
                 e.preventDefault();

--- a/apps/client/src/features/search/components/share-search-spotlight.tsx
+++ b/apps/client/src/features/search/components/share-search-spotlight.tsx
@@ -2,6 +2,7 @@ import { Group, Center, Text } from "@mantine/core";
 import { Spotlight } from "@mantine/spotlight";
 import { IconSearch } from "@tabler/icons-react";
 import React, { useState } from "react";
+import classes from "./search-spotlight.module.css";
 import { Link } from "react-router-dom";
 import { useDebouncedValue } from "@mantine/hooks";
 import { useShareSearchQuery } from "@/features/search/queries/search-query";
@@ -72,11 +73,14 @@ export function ShareSearchSpotlight({ shareId }: ShareSearchSpotlightProps) {
           backgroundOpacity: 0.55,
         }}
       >
-        <Spotlight.Search
-          placeholder={t("Search...")}
-          aria-label={t("Search")}
-          leftSection={<IconSearch size={20} stroke={1.5} />}
-        />
+        <div className={classes.searchHeader} style={{ padding: "var(--mantine-spacing-sm)", paddingBottom: "var(--mantine-spacing-xs)" }}>
+          <Spotlight.Search
+            placeholder={t("Search...")}
+            aria-label={t("Search")}
+            leftSection={<IconSearch size={20} stroke={1.5} />}
+            classNames={{ input: classes.searchInput }}
+          />
+        </div>
         <Spotlight.ActionsList>
           {query.length === 0 && pages.length === 0 && (
             <Spotlight.Empty>{t("Start typing to search...")}</Spotlight.Empty>


### PR DESCRIPTION
Spotlight.Search renders with border:0 and a transparent background by default, causing it to blend into the modal body and appear as a plain title bar rather than a focusable input field. Add a CSS module that gives the search header a distinct gray background with a separator border, and gives the inner input a white/dark background with a visible border. Both SearchSpotlight and ShareSearchSpotlight receive the same treatment for consistency.