### PR TITLE
docs: fix typo seperates -> separates

### DIFF
--- a/packages/editor-ext/src/lib/prosemirror-docx/serializer.ts
+++ b/packages/editor-ext/src/lib/prosemirror-docx/serializer.ts
@@ -368,7 +368,7 @@ export class DocxSerializerState {
     this.maxImageWidth = MAX_IMAGE_WIDTH;
     const table = new Table({ ...tableOptions, rows });
     actualChildren.push(table);
-    // If there are multiple tables, this seperates them
+    // If there are multiple tables, this separates them
     actualChildren.push(new Paragraph(''));
     this.children = actualChildren;
   }


### PR DESCRIPTION
Corrects the misspelling `seperates` -> `separates` in `packages/editor-ext/src/lib/prosemirror-docx/serializer.ts`.

Documentation only, no behaviour change.