### PR TITLE
feat: add HMAC-signed outgoing page webhooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,8 @@ DEBUG_DB=false
 
 # Log http requests
 LOG_HTTP=false
+
+# Optional HMAC-signed outgoing page event webhook.
+# OUTGOING_WEBHOOK_URL=https://example.com/docmost/events
+# OUTGOING_WEBHOOK_SECRET=replace-with-at-least-32-random-characters
+# OUTGOING_WEBHOOK_EVENTS=page.created,page.updated,page.moved,page.deleted,page.restored

--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,10 @@ DEBUG_DB=false
 LOG_HTTP=false
 
 # Optional HMAC-signed outgoing page event webhook.
+# Apply these variables to both app and collab processes in split deployments;
+# only the app process consumes the shared delivery queue.
 # OUTGOING_WEBHOOK_URL=https://example.com/docmost/events
 # OUTGOING_WEBHOOK_SECRET=replace-with-at-least-32-random-characters
 # OUTGOING_WEBHOOK_EVENTS=page.created,page.updated,page.moved,page.deleted,page.restored
+# Delivery is retried after an event reaches BullMQ. Consumers should also run
+# periodic reconciliation to recover events missed before queue insertion.

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -30,6 +30,7 @@ import { NoopAuditModule } from './integrations/audit/audit.module';
 import { ThrottleModule } from './integrations/throttle/throttle.module';
 import { EncryptionModule } from './integrations/encryption/encryption.module';
 import { OutgoingWebhookModule } from './integrations/outgoing-webhook/outgoing-webhook.module';
+import { OutgoingWebhookProcessorModule } from './integrations/outgoing-webhook/outgoing-webhook-processor.module';
 
 const enterpriseModules = [];
 try {
@@ -100,6 +101,7 @@ try {
     TelemetryModule,
     ThrottleModule,
     OutgoingWebhookModule,
+    OutgoingWebhookProcessorModule,
     ...enterpriseModules,
   ],
   controllers: [AppController],

--- a/apps/server/src/app.module.ts
+++ b/apps/server/src/app.module.ts
@@ -29,6 +29,7 @@ import { ClsModule } from 'nestjs-cls';
 import { NoopAuditModule } from './integrations/audit/audit.module';
 import { ThrottleModule } from './integrations/throttle/throttle.module';
 import { EncryptionModule } from './integrations/encryption/encryption.module';
+import { OutgoingWebhookModule } from './integrations/outgoing-webhook/outgoing-webhook.module';
 
 const enterpriseModules = [];
 try {
@@ -98,6 +99,7 @@ try {
     SecurityModule,
     TelemetryModule,
     ThrottleModule,
+    OutgoingWebhookModule,
     ...enterpriseModules,
   ],
   controllers: [AppController],

--- a/apps/server/src/collaboration/server/collab-app.module.ts
+++ b/apps/server/src/collaboration/server/collab-app.module.ts
@@ -16,6 +16,7 @@ import { CaslModule } from '../../core/casl/casl.module';
 import { CacheModule } from '@nestjs/cache-manager';
 import KeyvRedis, { defaultReconnectStrategy } from '@keyv/redis';
 import { parseRedisUrl } from '../../common/helpers';
+import { OutgoingWebhookModule } from '../../integrations/outgoing-webhook/outgoing-webhook.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { parseRedisUrl } from '../../common/helpers';
     QueueModule,
     HealthModule,
     EventEmitterModule.forRoot(),
+    OutgoingWebhookModule,
     RedisModule.forRootAsync({
       useClass: RedisConfigService,
     }),

--- a/apps/server/src/core/page/services/page.service.ts
+++ b/apps/server/src/core/page/services/page.service.ts
@@ -514,6 +514,11 @@ export class PageService {
       }
     });
 
+    this.eventEmitter.emit(EventName.PAGE_MOVED_TO_SPACE, {
+      pageIds: [rootPage.id, ...childPageIds],
+      workspaceId: rootPage.workspaceId,
+    });
+
     return { childPageIds };
   }
 

--- a/apps/server/src/integrations/environment/environment.service.ts
+++ b/apps/server/src/integrations/environment/environment.service.ts
@@ -226,6 +226,26 @@ export class EnvironmentService {
     return this.configService.get<string>('STRIPE_WEBHOOK_SECRET');
   }
 
+  getOutgoingWebhookUrl(): string | undefined {
+    return this.configService.get<string>('OUTGOING_WEBHOOK_URL');
+  }
+
+  getOutgoingWebhookSecret(): string | undefined {
+    return this.configService.get<string>('OUTGOING_WEBHOOK_SECRET');
+  }
+
+  getOutgoingWebhookEvents(): string[] {
+    const raw = this.configService.get<string>(
+      'OUTGOING_WEBHOOK_EVENTS',
+      'page.created,page.updated,page.moved,page.deleted,page.restored',
+    );
+
+    return raw
+      .split(',')
+      .map((event) => event.trim())
+      .filter(Boolean);
+  }
+
   getBillingTrialDays(): number {
     return parseInt(this.configService.get<string>('BILLING_TRIAL_DAYS', '14'));
   }

--- a/apps/server/src/integrations/environment/environment.validation.ts
+++ b/apps/server/src/integrations/environment/environment.validation.ts
@@ -54,6 +54,24 @@ export class EnvironmentVariables {
   STORAGE_DRIVER: string;
 
   @IsOptional()
+  @ValidateIf(
+    (obj) => obj.OUTGOING_WEBHOOK_URL != '' && obj.OUTGOING_WEBHOOK_URL != null,
+  )
+  @IsUrl({ protocols: ['http', 'https'], require_tld: false })
+  OUTGOING_WEBHOOK_URL: string;
+
+  @ValidateIf(
+    (obj) => obj.OUTGOING_WEBHOOK_URL != '' && obj.OUTGOING_WEBHOOK_URL != null,
+  )
+  @IsString()
+  @MinLength(32)
+  OUTGOING_WEBHOOK_SECRET: string;
+
+  @IsOptional()
+  @IsString()
+  OUTGOING_WEBHOOK_EVENTS: string;
+
+  @IsOptional()
   @ValidateIf((obj) => obj.COLLAB_URL != '' && obj.COLLAB_URL != null)
   @IsUrl({ protocols: ['http', 'https'], require_tld: false })
   COLLAB_URL: string;

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook-processor.module.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook-processor.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { OutgoingWebhookProcessor } from './outgoing-webhook.processor';
+import { OutgoingWebhookService } from './outgoing-webhook.service';
+
+@Module({
+  providers: [OutgoingWebhookProcessor, OutgoingWebhookService],
+})
+export class OutgoingWebhookProcessorModule {}

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.spec.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.spec.ts
@@ -5,10 +5,11 @@ import { OutgoingWebhookListener } from './outgoing-webhook.listener';
 describe('OutgoingWebhookListener', () => {
   const queue = { add: jest.fn().mockResolvedValue(undefined) };
 
-  beforeEach(() => queue.add.mockClear());
+  beforeEach(() => {
+    queue.add.mockReset().mockResolvedValue(undefined);
+  });
 
-  it('debounces page updates with a BullMQ-safe job ID', async () => {
-    jest.useFakeTimers().setSystemTime(new Date('2026-08-29T12:00:00Z'));
+  it('debounces page updates by extending and replacing the delayed job', async () => {
     const env = {
       getOutgoingWebhookUrl: () => 'https://example.com/events',
       getOutgoingWebhookEvents: () => ['page.updated'],
@@ -27,9 +28,16 @@ describe('OutgoingWebhookListener', () => {
         pageId: 'page-1',
         workspaceId: 'workspace-1',
       }),
-      { delay: 10_000, jobId: 'page-updated-page-1-178800480' },
+      {
+        delay: 10_000,
+        deduplication: {
+          id: 'page.updated-page-1',
+          ttl: 10_000,
+          extend: true,
+          replace: true,
+        },
+      },
     );
-    jest.useRealTimers();
   });
 
   it('ignores disabled events', async () => {
@@ -42,5 +50,18 @@ describe('OutgoingWebhookListener', () => {
     await listener.handleUpdated({ pageIds: ['page-1'] });
 
     expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('does not acknowledge queue insertion failures inside the listener', async () => {
+    queue.add.mockRejectedValueOnce(new Error('Redis unavailable'));
+    const env = {
+      getOutgoingWebhookUrl: () => 'https://example.com/events',
+      getOutgoingWebhookEvents: () => ['page.created'],
+    } as EnvironmentService;
+    const listener = new OutgoingWebhookListener(env, queue as never);
+
+    await expect(
+      listener.handleCreated({ pageIds: ['page-1'] }),
+    ).rejects.toThrow('Redis unavailable');
   });
 });

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.spec.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.spec.ts
@@ -3,13 +3,13 @@ import { QueueJob } from '../queue/constants';
 import { OutgoingWebhookListener } from './outgoing-webhook.listener';
 
 describe('OutgoingWebhookListener', () => {
-  const queue = { add: jest.fn().mockResolvedValue(undefined) };
+  const queue = { addBulk: jest.fn().mockResolvedValue(undefined) };
 
   beforeEach(() => {
-    queue.add.mockReset().mockResolvedValue(undefined);
+    queue.addBulk.mockReset().mockResolvedValue(undefined);
   });
 
-  it('debounces page updates by extending and replacing the delayed job', async () => {
+  it('keeps the latest page update when the previous job is active', async () => {
     const env = {
       getOutgoingWebhookUrl: () => 'https://example.com/events',
       getOutgoingWebhookEvents: () => ['page.updated'],
@@ -21,23 +21,24 @@ describe('OutgoingWebhookListener', () => {
       workspaceId: 'workspace-1',
     });
 
-    expect(queue.add).toHaveBeenCalledWith(
-      QueueJob.DELIVER_OUTGOING_WEBHOOK,
-      expect.objectContaining({
-        event: 'page.updated',
-        pageId: 'page-1',
-        workspaceId: 'workspace-1',
-      }),
+    expect(queue.addBulk).toHaveBeenCalledWith([
       {
-        delay: 10_000,
-        deduplication: {
-          id: 'page.updated-page-1',
-          ttl: 10_000,
-          extend: true,
-          replace: true,
+        name: QueueJob.DELIVER_OUTGOING_WEBHOOK,
+        data: expect.objectContaining({
+          event: 'page.updated',
+          pageId: 'page-1',
+          workspaceId: 'workspace-1',
+        }),
+        opts: {
+          delay: 10_000,
+          deduplication: {
+            id: 'page.updated-page-1',
+            replace: true,
+            keepLastIfActive: true,
+          },
         },
       },
-    );
+    ]);
   });
 
   it('ignores disabled events', async () => {
@@ -49,11 +50,11 @@ describe('OutgoingWebhookListener', () => {
 
     await listener.handleUpdated({ pageIds: ['page-1'] });
 
-    expect(queue.add).not.toHaveBeenCalled();
+    expect(queue.addBulk).not.toHaveBeenCalled();
   });
 
   it('does not acknowledge queue insertion failures inside the listener', async () => {
-    queue.add.mockRejectedValueOnce(new Error('Redis unavailable'));
+    queue.addBulk.mockRejectedValueOnce(new Error('Redis unavailable'));
     const env = {
       getOutgoingWebhookUrl: () => 'https://example.com/events',
       getOutgoingWebhookEvents: () => ['page.created'],
@@ -63,5 +64,21 @@ describe('OutgoingWebhookListener', () => {
     await expect(
       listener.handleCreated({ pageIds: ['page-1'] }),
     ).rejects.toThrow('Redis unavailable');
+  });
+
+  it('inserts large page events in bounded batches', async () => {
+    const env = {
+      getOutgoingWebhookUrl: () => 'https://example.com/events',
+      getOutgoingWebhookEvents: () => ['page.created'],
+    } as EnvironmentService;
+    const listener = new OutgoingWebhookListener(env, queue as never);
+    const pageIds = Array.from({ length: 201 }, (_, index) => `page-${index}`);
+
+    await listener.handleCreated({ pageIds });
+
+    expect(queue.addBulk).toHaveBeenCalledTimes(3);
+    expect(queue.addBulk.mock.calls.map(([jobs]) => jobs.length)).toEqual([
+      100, 100, 1,
+    ]);
   });
 });

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.spec.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.spec.ts
@@ -1,0 +1,46 @@
+import { EnvironmentService } from '../environment/environment.service';
+import { QueueJob } from '../queue/constants';
+import { OutgoingWebhookListener } from './outgoing-webhook.listener';
+
+describe('OutgoingWebhookListener', () => {
+  const queue = { add: jest.fn().mockResolvedValue(undefined) };
+
+  beforeEach(() => queue.add.mockClear());
+
+  it('debounces page updates with a BullMQ-safe job ID', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-29T12:00:00Z'));
+    const env = {
+      getOutgoingWebhookUrl: () => 'https://example.com/events',
+      getOutgoingWebhookEvents: () => ['page.updated'],
+    } as EnvironmentService;
+    const listener = new OutgoingWebhookListener(env, queue as never);
+
+    await listener.handleUpdated({
+      pageIds: ['page-1'],
+      workspaceId: 'workspace-1',
+    });
+
+    expect(queue.add).toHaveBeenCalledWith(
+      QueueJob.DELIVER_OUTGOING_WEBHOOK,
+      expect.objectContaining({
+        event: 'page.updated',
+        pageId: 'page-1',
+        workspaceId: 'workspace-1',
+      }),
+      { delay: 10_000, jobId: 'page-updated-page-1-178800480' },
+    );
+    jest.useRealTimers();
+  });
+
+  it('ignores disabled events', async () => {
+    const env = {
+      getOutgoingWebhookUrl: () => 'https://example.com/events',
+      getOutgoingWebhookEvents: () => ['page.created'],
+    } as EnvironmentService;
+    const listener = new OutgoingWebhookListener(env, queue as never);
+
+    await listener.handleUpdated({ pageIds: ['page-1'] });
+
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Queue } from 'bullmq';
+import { randomUUID } from 'node:crypto';
+import { EventName } from '../../common/events/event.contants';
+import { EnvironmentService } from '../environment/environment.service';
+import { QueueJob, QueueName } from '../queue/constants';
+import { IOutgoingWebhookJob } from '../queue/constants/queue.interface';
+import { OutgoingWebhookEvent } from './outgoing-webhook.types';
+
+interface PageEvent {
+  pageIds: string[];
+  workspaceId?: string;
+}
+
+@Injectable()
+export class OutgoingWebhookListener {
+  constructor(
+    private readonly environmentService: EnvironmentService,
+    @InjectQueue(QueueName.WEBHOOK_QUEUE) private readonly webhookQueue: Queue,
+  ) {}
+
+  @OnEvent(EventName.PAGE_CREATED)
+  handleCreated(event: PageEvent) {
+    return this.enqueue('page.created', event);
+  }
+
+  @OnEvent(EventName.PAGE_UPDATED)
+  handleUpdated(event: PageEvent) {
+    return this.enqueue('page.updated', event, 10_000);
+  }
+
+  @OnEvent(EventName.PAGE_MOVED_TO_SPACE)
+  handleMoved(event: PageEvent) {
+    return this.enqueue('page.moved', event);
+  }
+
+  @OnEvent(EventName.PAGE_SOFT_DELETED)
+  handleSoftDeleted(event: PageEvent) {
+    return this.enqueue('page.deleted', event);
+  }
+
+  @OnEvent(EventName.PAGE_DELETED)
+  handleDeleted(event: PageEvent) {
+    return this.enqueue('page.deleted', event);
+  }
+
+  @OnEvent(EventName.PAGE_RESTORED)
+  handleRestored(event: PageEvent) {
+    return this.enqueue('page.restored', event);
+  }
+
+  private async enqueue(
+    eventName: OutgoingWebhookEvent,
+    event: PageEvent,
+    delay = 0,
+  ): Promise<void> {
+    if (!this.environmentService.getOutgoingWebhookUrl()) return;
+    if (
+      !this.environmentService.getOutgoingWebhookEvents().includes(eventName)
+    ) {
+      return;
+    }
+
+    await Promise.all(
+      event.pageIds.map((pageId) => {
+        const occurredAt = new Date();
+        const data: IOutgoingWebhookJob = {
+          deliveryId: randomUUID(),
+          event: eventName,
+          occurredAt: occurredAt.toISOString(),
+          workspaceId: event.workspaceId,
+          pageId,
+        };
+
+        return this.webhookQueue.add(QueueJob.DELIVER_OUTGOING_WEBHOOK, data, {
+          delay,
+          // BullMQ custom job IDs must not contain colons.
+          jobId:
+            delay > 0
+              ? `${eventName.replaceAll('.', '-')}-${pageId}-${Math.floor(occurredAt.getTime() / delay)}`
+              : undefined,
+        });
+      }),
+    );
+  }
+}

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.ts
@@ -14,6 +14,11 @@ interface PageEvent {
   workspaceId?: string;
 }
 
+// Database events are best-effort until their BullMQ insertion completes.
+// Nest logs subscriber errors; webhook consumers must periodically reconcile
+// source state to recover an event lost before durable queue insertion.
+const pageEventOptions = { suppressErrors: true } as const;
+
 @Injectable()
 export class OutgoingWebhookListener {
   constructor(
@@ -21,32 +26,32 @@ export class OutgoingWebhookListener {
     @InjectQueue(QueueName.WEBHOOK_QUEUE) private readonly webhookQueue: Queue,
   ) {}
 
-  @OnEvent(EventName.PAGE_CREATED)
+  @OnEvent(EventName.PAGE_CREATED, pageEventOptions)
   handleCreated(event: PageEvent) {
     return this.enqueue('page.created', event);
   }
 
-  @OnEvent(EventName.PAGE_UPDATED)
+  @OnEvent(EventName.PAGE_UPDATED, pageEventOptions)
   handleUpdated(event: PageEvent) {
     return this.enqueue('page.updated', event, 10_000);
   }
 
-  @OnEvent(EventName.PAGE_MOVED_TO_SPACE)
+  @OnEvent(EventName.PAGE_MOVED_TO_SPACE, pageEventOptions)
   handleMoved(event: PageEvent) {
     return this.enqueue('page.moved', event);
   }
 
-  @OnEvent(EventName.PAGE_SOFT_DELETED)
+  @OnEvent(EventName.PAGE_SOFT_DELETED, pageEventOptions)
   handleSoftDeleted(event: PageEvent) {
     return this.enqueue('page.deleted', event);
   }
 
-  @OnEvent(EventName.PAGE_DELETED)
+  @OnEvent(EventName.PAGE_DELETED, pageEventOptions)
   handleDeleted(event: PageEvent) {
     return this.enqueue('page.deleted', event);
   }
 
-  @OnEvent(EventName.PAGE_RESTORED)
+  @OnEvent(EventName.PAGE_RESTORED, pageEventOptions)
   handleRestored(event: PageEvent) {
     return this.enqueue('page.restored', event);
   }
@@ -76,10 +81,14 @@ export class OutgoingWebhookListener {
 
         return this.webhookQueue.add(QueueJob.DELIVER_OUTGOING_WEBHOOK, data, {
           delay,
-          // BullMQ custom job IDs must not contain colons.
-          jobId:
+          deduplication:
             delay > 0
-              ? `${eventName.replaceAll('.', '-')}-${pageId}-${Math.floor(occurredAt.getTime() / delay)}`
+              ? {
+                  id: `${eventName}-${pageId}`,
+                  ttl: delay,
+                  extend: true,
+                  replace: true,
+                }
               : undefined,
         });
       }),

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.ts
@@ -18,6 +18,7 @@ interface PageEvent {
 // Nest logs subscriber errors; webhook consumers must periodically reconcile
 // source state to recover an event lost before durable queue insertion.
 const pageEventOptions = { suppressErrors: true } as const;
+const enqueueBatchSize = 100;
 
 @Injectable()
 export class OutgoingWebhookListener {
@@ -68,30 +69,36 @@ export class OutgoingWebhookListener {
       return;
     }
 
-    await Promise.all(
-      event.pageIds.map((pageId) => {
-        const occurredAt = new Date();
-        const data: IOutgoingWebhookJob = {
-          deliveryId: randomUUID(),
-          event: eventName,
-          occurredAt: occurredAt.toISOString(),
-          workspaceId: event.workspaceId,
-          pageId,
-        };
+    const jobs = event.pageIds.map((pageId) => {
+      const data: IOutgoingWebhookJob = {
+        deliveryId: randomUUID(),
+        event: eventName,
+        occurredAt: new Date().toISOString(),
+        workspaceId: event.workspaceId,
+        pageId,
+      };
 
-        return this.webhookQueue.add(QueueJob.DELIVER_OUTGOING_WEBHOOK, data, {
-          delay,
-          deduplication:
-            delay > 0
-              ? {
+      return {
+        name: QueueJob.DELIVER_OUTGOING_WEBHOOK,
+        data,
+        opts:
+          delay > 0
+            ? {
+                delay,
+                deduplication: {
                   id: `${eventName}-${pageId}`,
-                  ttl: delay,
-                  extend: true,
                   replace: true,
-                }
-              : undefined,
-        });
-      }),
-    );
+                  keepLastIfActive: true,
+                },
+              }
+            : undefined,
+      };
+    });
+
+    for (let offset = 0; offset < jobs.length; offset += enqueueBatchSize) {
+      await this.webhookQueue.addBulk(
+        jobs.slice(offset, offset + enqueueBatchSize),
+      );
+    }
   }
 }

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.module.spec.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.module.spec.ts
@@ -1,0 +1,26 @@
+import { MODULE_METADATA } from '@nestjs/common/constants';
+import { OutgoingWebhookModule } from './outgoing-webhook.module';
+import { OutgoingWebhookProcessorModule } from './outgoing-webhook-processor.module';
+import { OutgoingWebhookListener } from './outgoing-webhook.listener';
+import { OutgoingWebhookProcessor } from './outgoing-webhook.processor';
+
+describe('Outgoing webhook module topology', () => {
+  it('keeps queue consumption out of the producer module', () => {
+    const providers = Reflect.getMetadata(
+      MODULE_METADATA.PROVIDERS,
+      OutgoingWebhookModule,
+    );
+
+    expect(providers).toContain(OutgoingWebhookListener);
+    expect(providers).not.toContain(OutgoingWebhookProcessor);
+  });
+
+  it('registers the queue consumer only in the processor module', () => {
+    const providers = Reflect.getMetadata(
+      MODULE_METADATA.PROVIDERS,
+      OutgoingWebhookProcessorModule,
+    );
+
+    expect(providers).toContain(OutgoingWebhookProcessor);
+  });
+});

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.module.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.module.ts
@@ -1,13 +1,7 @@
 import { Module } from '@nestjs/common';
 import { OutgoingWebhookListener } from './outgoing-webhook.listener';
-import { OutgoingWebhookProcessor } from './outgoing-webhook.processor';
-import { OutgoingWebhookService } from './outgoing-webhook.service';
 
 @Module({
-  providers: [
-    OutgoingWebhookListener,
-    OutgoingWebhookProcessor,
-    OutgoingWebhookService,
-  ],
+  providers: [OutgoingWebhookListener],
 })
 export class OutgoingWebhookModule {}

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.module.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { OutgoingWebhookListener } from './outgoing-webhook.listener';
+import { OutgoingWebhookProcessor } from './outgoing-webhook.processor';
+import { OutgoingWebhookService } from './outgoing-webhook.service';
+
+@Module({
+  providers: [
+    OutgoingWebhookListener,
+    OutgoingWebhookProcessor,
+    OutgoingWebhookService,
+  ],
+})
+export class OutgoingWebhookModule {}

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.processor.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.processor.ts
@@ -1,0 +1,34 @@
+import { Logger, OnModuleDestroy } from '@nestjs/common';
+import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
+import { Job } from 'bullmq';
+import { QueueJob, QueueName } from '../queue/constants';
+import { IOutgoingWebhookJob } from '../queue/constants/queue.interface';
+import { OutgoingWebhookService } from './outgoing-webhook.service';
+
+@Processor(QueueName.WEBHOOK_QUEUE)
+export class OutgoingWebhookProcessor
+  extends WorkerHost
+  implements OnModuleDestroy
+{
+  private readonly logger = new Logger(OutgoingWebhookProcessor.name);
+
+  constructor(private readonly webhookService: OutgoingWebhookService) {
+    super();
+  }
+
+  async process(job: Job<IOutgoingWebhookJob>): Promise<void> {
+    if (job.name !== QueueJob.DELIVER_OUTGOING_WEBHOOK) return;
+    await this.webhookService.deliver(job.data);
+  }
+
+  @OnWorkerEvent('failed')
+  onFailed(job: Job) {
+    this.logger.warn(
+      `Outgoing webhook ${job.data.deliveryId} failed: ${job.failedReason}`,
+    );
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.worker) await this.worker.close();
+  }
+}

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.service.spec.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.service.spec.ts
@@ -64,4 +64,21 @@ describe('OutgoingWebhookService', () => {
       }),
     ).rejects.toThrow('HTTP 503');
   });
+
+  it('fails queued jobs when delivery configuration is unavailable', async () => {
+    const env = {
+      getOutgoingWebhookUrl: () => undefined,
+      getOutgoingWebhookSecret: () => undefined,
+    } as EnvironmentService;
+    const service = new OutgoingWebhookService(env);
+
+    await expect(
+      service.deliver({
+        deliveryId: 'delivery-1',
+        event: 'page.created',
+        occurredAt: '2026-08-29T12:00:00.000Z',
+        pageId: 'page-1',
+      }),
+    ).rejects.toThrow('delivery is not configured');
+  });
 });

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.service.spec.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.service.spec.ts
@@ -1,0 +1,67 @@
+import { createHmac } from 'node:crypto';
+import { EnvironmentService } from '../environment/environment.service';
+import {
+  OutgoingWebhookService,
+  signOutgoingWebhook,
+} from './outgoing-webhook.service';
+
+const secret = 'test-secret-with-at-least-thirty-two-characters';
+
+describe('OutgoingWebhookService', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('signs the exact request body with HMAC-SHA256', () => {
+    const body = '{"hello":"world"}';
+    expect(signOutgoingWebhook(secret, body)).toBe(
+      `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`,
+    );
+  });
+
+  it('delivers a signed page event', async () => {
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const env = {
+      getOutgoingWebhookUrl: () => 'https://example.com/events',
+      getOutgoingWebhookSecret: () => secret,
+    } as EnvironmentService;
+    const service = new OutgoingWebhookService(env);
+
+    await service.deliver({
+      deliveryId: 'delivery-1',
+      event: 'page.updated',
+      occurredAt: '2026-08-29T12:00:00.000Z',
+      workspaceId: 'workspace-1',
+      pageId: 'page-1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, request] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://example.com/events');
+    expect(request.headers['x-docmost-event']).toBe('page.updated');
+    expect(request.headers['x-docmost-delivery']).toBe('delivery-1');
+    expect(request.headers['x-docmost-signature-256']).toBe(
+      signOutgoingWebhook(secret, request.body as string),
+    );
+  });
+
+  it('throws on non-success responses so BullMQ retries delivery', async () => {
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 503 }));
+    const env = {
+      getOutgoingWebhookUrl: () => 'https://example.com/events',
+      getOutgoingWebhookSecret: () => secret,
+    } as EnvironmentService;
+    const service = new OutgoingWebhookService(env);
+
+    await expect(
+      service.deliver({
+        deliveryId: 'delivery-1',
+        event: 'page.created',
+        occurredAt: '2026-08-29T12:00:00.000Z',
+        pageId: 'page-1',
+      }),
+    ).rejects.toThrow('HTTP 503');
+  });
+});

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.service.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.service.ts
@@ -16,8 +16,12 @@ export class OutgoingWebhookService {
     const url = this.environmentService.getOutgoingWebhookUrl();
     const secret = this.environmentService.getOutgoingWebhookSecret();
 
-    // Configuration can be removed while already queued deliveries remain.
-    if (!url || !secret) return;
+    // Never acknowledge a queued delivery merely because this process has
+    // stale or incomplete configuration. Throwing keeps the job retryable and
+    // makes deployment drift observable in the failed-jobs set and logs.
+    if (!url || !secret) {
+      throw new Error('Outgoing webhook delivery is not configured');
+    }
 
     const payload: OutgoingWebhookPayload = {
       version: '1',

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.service.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.service.ts
@@ -1,0 +1,48 @@
+import { createHmac } from 'node:crypto';
+import { Injectable } from '@nestjs/common';
+import { EnvironmentService } from '../environment/environment.service';
+import { IOutgoingWebhookJob } from '../queue/constants/queue.interface';
+import { OutgoingWebhookPayload } from './outgoing-webhook.types';
+
+export function signOutgoingWebhook(secret: string, body: string): string {
+  return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+}
+
+@Injectable()
+export class OutgoingWebhookService {
+  constructor(private readonly environmentService: EnvironmentService) {}
+
+  async deliver(job: IOutgoingWebhookJob): Promise<void> {
+    const url = this.environmentService.getOutgoingWebhookUrl();
+    const secret = this.environmentService.getOutgoingWebhookSecret();
+
+    // Configuration can be removed while already queued deliveries remain.
+    if (!url || !secret) return;
+
+    const payload: OutgoingWebhookPayload = {
+      version: '1',
+      id: job.deliveryId,
+      event: job.event as OutgoingWebhookPayload['event'],
+      occurredAt: job.occurredAt,
+      workspaceId: job.workspaceId,
+      data: { pageId: job.pageId },
+    };
+    const body = JSON.stringify(payload);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'user-agent': 'Docmost-Webhook/1.0',
+        'x-docmost-delivery': job.deliveryId,
+        'x-docmost-event': job.event,
+        'x-docmost-signature-256': signOutgoingWebhook(secret, body),
+      },
+      body,
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Outgoing webhook returned HTTP ${response.status}`);
+    }
+  }
+}

--- a/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.types.ts
+++ b/apps/server/src/integrations/outgoing-webhook/outgoing-webhook.types.ts
@@ -1,0 +1,20 @@
+export const outgoingWebhookEvents = [
+  'page.created',
+  'page.updated',
+  'page.moved',
+  'page.deleted',
+  'page.restored',
+] as const;
+
+export type OutgoingWebhookEvent = (typeof outgoingWebhookEvents)[number];
+
+export interface OutgoingWebhookPayload {
+  version: '1';
+  id: string;
+  event: OutgoingWebhookEvent;
+  occurredAt: string;
+  workspaceId?: string;
+  data: {
+    pageId: string;
+  };
+}

--- a/apps/server/src/integrations/queue/constants/queue.constants.ts
+++ b/apps/server/src/integrations/queue/constants/queue.constants.ts
@@ -10,6 +10,7 @@ export enum QueueName {
   NOTIFICATION_QUEUE = '{notification-queue}',
   AUDIT_QUEUE = '{audit-queue}',
   BASE_QUEUE = '{base-queue}',
+  WEBHOOK_QUEUE = '{webhook-queue}',
 }
 
 export enum QueueJob {
@@ -82,6 +83,8 @@ export enum QueueJob {
 
   AUDIT_LOG = 'audit-log',
   AUDIT_CLEANUP = 'audit-cleanup',
+
+  DELIVER_OUTGOING_WEBHOOK = 'deliver-outgoing-webhook',
 
   PDF_EXPORT_TASK = 'pdf-export-task',
   PDF_EXPORT_CLEANUP = 'pdf-export-cleanup',

--- a/apps/server/src/integrations/queue/constants/queue.interface.ts
+++ b/apps/server/src/integrations/queue/constants/queue.interface.ts
@@ -68,6 +68,14 @@ export interface IPageUpdateNotificationJob {
   actorIds: string[];
 }
 
+export interface IOutgoingWebhookJob {
+  deliveryId: string;
+  event: string;
+  occurredAt: string;
+  workspaceId?: string;
+  pageId: string;
+}
+
 export interface IPermissionGrantedNotificationJob {
   userIds: string[];
   pageId: string;

--- a/apps/server/src/integrations/queue/queue.module.ts
+++ b/apps/server/src/integrations/queue/queue.module.ts
@@ -102,6 +102,15 @@ import { GeneralQueueProcessor } from './processors/general-queue.processor';
         removeOnFail: { count: 100 },
       },
     }),
+    BullModule.registerQueue({
+      name: QueueName.WEBHOOK_QUEUE,
+      defaultJobOptions: {
+        attempts: 5,
+        backoff: { type: 'exponential', delay: 1000 },
+        removeOnComplete: { count: 200 },
+        removeOnFail: { count: 500 },
+      },
+    }),
   ],
   exports: [BullModule],
   providers: [GeneralQueueProcessor],

--- a/apps/server/src/integrations/queue/queue.module.ts
+++ b/apps/server/src/integrations/queue/queue.module.ts
@@ -105,8 +105,10 @@ import { GeneralQueueProcessor } from './processors/general-queue.processor';
     BullModule.registerQueue({
       name: QueueName.WEBHOOK_QUEUE,
       defaultJobOptions: {
-        attempts: 5,
-        backoff: { type: 'exponential', delay: 1000 },
+        // Retry immediate failures for several hours instead of exhausting
+        // every attempt during a short receiver restart.
+        attempts: 12,
+        backoff: { type: 'exponential', delay: 10_000, jitter: 0.5 },
         removeOnComplete: { count: 200 },
         removeOnFail: { count: 500 },
       },


### PR DESCRIPTION
Closes #2455. Related to the future webhook channel mentioned in #1688.

## What this adds

- Optional instance-wide outgoing webhook for `page.created`, `page.updated`, `page.moved`, `page.deleted`, and `page.restored`.
- HMAC-SHA256 signature of the exact JSON body in `X-Docmost-Signature-256`.
- Stable delivery and event headers.
- BullMQ delivery with 12 jittered exponential-backoff attempts spanning roughly 3–6 hours.
- A trailing 10-second BullMQ debounce that replaces delayed jobs and preserves the latest update while a delivery is active.
- Bounded BullMQ bulk insertion in batches of 100 for large page trees.
- Event production in both the main and collaboration processes, with queue consumption restricted to the main process so workers cannot race with different delivery configuration.

The payload intentionally contains page identity and event metadata rather than page content. Consumers use the existing API to fetch current content and permissions. Configuration is disabled by default and uses `OUTGOING_WEBHOOK_URL`, `OUTGOING_WEBHOOK_SECRET`, and optional `OUTGOING_WEBHOOK_EVENTS`.

In split app/collab deployments the variables must be applied to both processes. Page events are best-effort until BullMQ insertion succeeds; durable retries begin after insertion, so consumers should periodically reconcile source state to recover a pre-queue loss.

## Verification

- `pnpm --filter server test -- --runInBand apps/server/src/integrations/outgoing-webhook/outgoing-webhook.service.spec.ts apps/server/src/integrations/outgoing-webhook/outgoing-webhook.listener.spec.ts apps/server/src/integrations/outgoing-webhook/outgoing-webhook.module.spec.ts` (10 tests)
- `pnpm --filter server build`
