### PR TITLE
fix: copy invite link #2128

### DIFF
--- a/apps/client/src/features/workspace/components/members/components/invite-action-menu.tsx
+++ b/apps/client/src/features/workspace/components/members/components/invite-action-menu.tsx
@@ -26,13 +26,20 @@ export default function InviteActionMenu({ invitationId }: Props) {
   const handleCopyLink = async (invitationId: string) => {
     try {
       const link = await getInviteLink({ invitationId });
-      const url = new URL(link.inviteLink);
-      const inviteLink = `${window.location.origin}${url.pathname}${url.search}`;
+      let inviteLink = link?.inviteLink || "";
+      try {
+        const url = new URL(link.inviteLink);
+        inviteLink = `${window.location.origin}${url.pathname}${url.search}`;
+      } catch {
+        if (inviteLink.startsWith("/")) {
+          inviteLink = `${window.location.origin}${inviteLink}`;
+        }
+      }
       clipboard.copy(inviteLink);
       notifications.show({ message: t("Link copied") });
     } catch (err) {
       notifications.show({
-        message: err["response"]?.data?.message,
+        message: err["response"]?.data?.message || t("Failed to copy link"),
         color: "red",
       });
     }

--- a/apps/client/src/features/workspace/services/workspace-service.test.ts
+++ b/apps/client/src/features/workspace/services/workspace-service.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import api from "@/lib/api-client";
+import { getInviteLink, getInvitationById } from "./workspace-service";
+
+vi.mock("@/lib/api-client", () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+describe("workspace-service invitation API unboxing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("getInviteLink returns unboxed payload from api.post", async () => {
+    const mockPayload = { inviteLink: "http://localhost:3000/invites/inv-123?token=token-abc" };
+    (api.post as any).mockResolvedValue(mockPayload);
+
+    const result = await getInviteLink({ invitationId: "inv-123" });
+
+    expect(api.post).toHaveBeenCalledWith("/workspace/invites/link", { invitationId: "inv-123" });
+    expect(result).toEqual(mockPayload);
+    expect(result.inviteLink).toBe("http://localhost:3000/invites/inv-123?token=token-abc");
+  });
+
+  it("getInvitationById returns unboxed payload from api.post", async () => {
+    const mockPayload = {
+      id: "inv-123",
+      email: "user@example.com",
+      role: "member",
+      workspaceId: "ws-1",
+      invitedById: "user-1",
+      createdAt: new Date(),
+      enforceSso: false,
+    };
+    (api.post as any).mockResolvedValue(mockPayload);
+
+    const result = await getInvitationById({ invitationId: "inv-123" });
+
+    expect(api.post).toHaveBeenCalledWith("/workspace/invites/info", { invitationId: "inv-123" });
+    expect(result).toEqual(mockPayload);
+    expect(result.email).toBe("user@example.com");
+  });
+});

--- a/apps/client/src/features/workspace/services/workspace-service.ts
+++ b/apps/client/src/features/workspace/services/workspace-service.ts
@@ -89,7 +89,7 @@ export async function getInviteLink(data: {
   invitationId: string;
 }): Promise<IInvitationLink> {
   const req = await api.post("/workspace/invites/link", data);
-  return req.data;
+  return req;
 }
 
 export async function resendInvitation(data: {
@@ -108,7 +108,7 @@ export async function getInvitationById(data: {
   invitationId: string;
 }): Promise<IInvitation> {
   const req = await api.post("/workspace/invites/info", data);
-  return req.data;
+  return req;
 }
 
 export async function createWorkspace(


### PR DESCRIPTION
Summary:
Fixes #2128.

Changes:

* Fixed the Copy link functionality for member invitations.
* Added/updated regression coverage for the affected behavior.

Testing:

* Ran the relevant automated tests and checks.
