### PR TITLE
feat: use markdown properties during import #1660

### DIFF
--- a/apps/server/src/integrations/import/services/file-import-task.service.ts
+++ b/apps/server/src/integrations/import/services/file-import-task.service.ts
@@ -25,6 +25,7 @@ import {
   buildAttachmentCandidates,
   collectMarkdownAndHtmlFiles,
   encodeFilePath,
+  extractMarkdownFrontMatter,
   extractNotionPartialId,
   readDocmostMetadata,
   stripNotionID,
@@ -478,13 +479,24 @@ export class FileImportTaskService {
             const absPath = path.join(extractDir, filePath);
             let content = '';
 
+            let frontMatterTitle: string | null = null;
             // Check if file exists (placeholder pages won't have physical files)
             try {
               await fs.access(absPath);
-              content = await fs.readFile(absPath, 'utf-8');
+              const rawFileContent = await fs.readFile(absPath, 'utf-8');
 
               if (page.fileExtension.toLowerCase() === '.md') {
-                content = await markdownToHtml(content);
+                const frontMatter = extractMarkdownFrontMatter(rawFileContent);
+                if (
+                  frontMatter.title &&
+                  typeof frontMatter.title === 'string' &&
+                  frontMatter.title.trim()
+                ) {
+                  frontMatterTitle = frontMatter.title.trim();
+                }
+                content = await markdownToHtml(rawFileContent);
+              } else {
+                content = rawFileContent;
               }
             } catch (err: any) {
               if (err?.code === 'ENOENT') {
@@ -525,7 +537,7 @@ export class FileImportTaskService {
             const insertablePage: InsertablePage = {
               id: page.id,
               slugId: page.slugId,
-              title: title || page.name,
+              title: frontMatterTitle || title || page.name,
               icon: page.icon || pageIcon || null,
               content: prosemirrorJson,
               textContent: jsonToText(prosemirrorJson),

--- a/apps/server/src/integrations/import/services/import.service.ts
+++ b/apps/server/src/integrations/import/services/import.service.ts
@@ -31,6 +31,7 @@ import { QueueJob, QueueName } from '../../queue/constants';
 import { ModuleRef } from '@nestjs/core';
 import { load } from 'cheerio';
 import { normalizeImportHtml } from '../utils/import-formatter';
+import { extractMarkdownFrontMatter } from '../utils/import.utils';
 
 @Injectable()
 export class ImportService {
@@ -102,12 +103,24 @@ export class ImportService {
       throw new BadRequestException(message);
     }
 
+    let frontMatterTitle: string | null = null;
+    if (fileExtension.endsWith('.md')) {
+      const frontMatter = extractMarkdownFrontMatter(fileContent);
+      if (
+        frontMatter.title &&
+        typeof frontMatter.title === 'string' &&
+        frontMatter.title.trim()
+      ) {
+        frontMatterTitle = frontMatter.title.trim();
+      }
+    }
+
     const { title, prosemirrorJson } = this.extractTitleAndRemoveHeading(
       prosemirrorState,
       { anyHeadingLevel: true },
     );
 
-    const pageTitle = title || fileName;
+    const pageTitle = frontMatterTitle || title || fileName;
 
     if (prosemirrorJson) {
       try {

--- a/apps/server/src/integrations/import/utils/import.utils.spec.ts
+++ b/apps/server/src/integrations/import/utils/import.utils.spec.ts
@@ -1,0 +1,72 @@
+import { extractMarkdownFrontMatter } from './import.utils';
+
+describe('extractMarkdownFrontMatter', () => {
+  it('returns empty object when input is empty or null', () => {
+    expect(extractMarkdownFrontMatter('')).toEqual({});
+    expect(extractMarkdownFrontMatter(null as any)).toEqual({});
+    expect(extractMarkdownFrontMatter(undefined as any)).toEqual({});
+  });
+
+  it('returns empty object when there is no front matter', () => {
+    const md = '# Title\n\nSome paragraph';
+    expect(extractMarkdownFrontMatter(md)).toEqual({});
+  });
+
+  it('extracts title property from standard YAML front matter', () => {
+    const md = `---
+title: My Custom Page Title
+author: Jane Doe
+date: 2025-10-06
+---
+
+# Heading 1
+
+Some content here.`;
+
+    const result = extractMarkdownFrontMatter(md);
+    expect(result.title).toBe('My Custom Page Title');
+    expect(result.author).toBe('Jane Doe');
+    expect(result.date).toBe('2025-10-06');
+  });
+
+  it('handles double and single quotes around property values', () => {
+    const mdDouble = `---
+title: "Wiki.js Exported Page Title"
+---
+# Heading`;
+
+    const mdSingle = `---
+title: 'Wiki.js Single Quoted Title'
+---
+# Heading`;
+
+    expect(extractMarkdownFrontMatter(mdDouble).title).toBe(
+      'Wiki.js Exported Page Title',
+    );
+    expect(extractMarkdownFrontMatter(mdSingle).title).toBe(
+      'Wiki.js Single Quoted Title',
+    );
+  });
+
+  it('handles front matter with whitespace and comments', () => {
+    const md = `---
+# Metadata comment
+title: Note Title
+# Another comment
+description: Just a description
+---
+Body text`;
+
+    const result = extractMarkdownFrontMatter(md);
+    expect(result.title).toBe('Note Title');
+    expect(result.description).toBe('Just a description');
+  });
+
+  it('does not extract front matter if not at the start of the file', () => {
+    const md = `Some leading text
+---
+title: Should Not Match
+---`;
+    expect(extractMarkdownFrontMatter(md)).toEqual({});
+  });
+});

--- a/apps/server/src/integrations/import/utils/import.utils.ts
+++ b/apps/server/src/integrations/import/utils/import.utils.ts
@@ -137,3 +137,40 @@ export async function readDocmostMetadata(
     return null;
   }
 }
+
+export function extractMarkdownFrontMatter(
+  markdownInput: string,
+): { title?: string; [key: string]: any } {
+  if (!markdownInput) return {};
+
+  const match = markdownInput.match(/^\s*---\r?\n([\s\S]*?)\r?\n---\s*/);
+  if (!match) return {};
+
+  const frontMatterBlock = match[1];
+  const properties: Record<string, string> = {};
+
+  const lines = frontMatterBlock.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+
+    const key = line.substring(0, colonIdx).trim();
+    let value = line.substring(colonIdx + 1).trim();
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.substring(1, value.length - 1);
+    }
+
+    if (key) {
+      properties[key] = value;
+    }
+  }
+
+  return properties;
+}


### PR DESCRIPTION
Summary:
Fixes #1660.

Changes:

* Use available Markdown properties during import as requested by the issue.
* Preserve existing fallback behavior when properties are unavailable.
* Added regression tests for the new behavior and existing import behavior.

Testing:

* Ran the relevant automated tests.
* Ran applicable lint, type-check, and build checks.