### PR TITLE
fix(editor): don't let a title save echo drop typed characters

### DIFF
--- a/apps/client/src/features/editor/title-editor.tsx
+++ b/apps/client/src/features/editor/title-editor.tsx
@@ -1,5 +1,5 @@
 import "@/features/editor/styles/index.css";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { Document } from "@tiptap/extension-document";
 import { Heading } from "@tiptap/extension-heading";
@@ -54,6 +54,10 @@ export function TitleEditor({
   const emit = useQueryEmit();
   const navigate = useNavigate();
   const [activePageId, setActivePageId] = useState(pageId);
+  // The title we last pushed to the server. Lets the reconcile effect below
+  // tell our own save echo apart from a genuine remote rename.
+  const lastSentTitleRef = useRef<string | null>(title);
+  const syncedPageIdRef = useRef(pageId);
   const currentPageEditMode = useAtomValue(currentPageEditModeAtom);
 
   const titleEditor = useEditor({
@@ -132,9 +136,12 @@ export function TitleEditor({
       return;
     }
 
+    const outgoingTitle = titleEditor.getText();
+    lastSentTitleRef.current = outgoingTitle;
+
     updateTitlePageMutationAsync({
       pageId: pageId,
-      title: titleEditor.getText(),
+      title: outgoingTitle,
     }).then((page) => {
       const event: UpdateEvent = {
         operation: "updateOne",
@@ -161,13 +168,21 @@ export function TitleEditor({
   const debounceUpdate = useDebouncedCallback(saveTitle, 500);
 
   useEffect(() => {
-    if (
-      titleEditor &&
-      !titleEditor.isDestroyed &&
-      title !== titleEditor.getText()
-    ) {
-      titleEditor.commands.setContent(title);
-    }
+    const pageChanged = syncedPageIdRef.current !== pageId;
+    syncedPageIdRef.current = pageId;
+
+    if (!titleEditor || titleEditor.isDestroyed) return;
+    if (title === titleEditor.getText()) return;
+
+    // A save response lands asynchronously: the mutation's `.then` checks the
+    // editor text, but this effect only runs after React re-renders, so a
+    // keystroke can slip into that gap. Adopting the cached title then would
+    // drop the character just typed and reset the caret. Our own echo is
+    // always stale in that window, so only a remote rename (or an actual page
+    // switch) may replace what's in the editor.
+    if (!pageChanged && title === lastSentTitleRef.current) return;
+
+    titleEditor.commands.setContent(title);
   }, [pageId, title, titleEditor]);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

Typing a page title can silently drop characters and scramble the result.

**This happens very often on our company instance**, which has many users and a large number of pages — to the point that renaming a page is unreliable: characters vanish while typing, the title reverts to an older value mid-keystroke, and you end up having to fix the title up afterwards. It is much more likely the faster you type, and the higher the latency between the browser and the server.

## Cause

The reconcile effect in `TitleEditor` treats the React Query cache as the source of truth and replaces the editor content whenever the cached `title` differs from it:

```js
useEffect(() => {
  if (titleEditor && !titleEditor.isDestroyed && title !== titleEditor.getText()) {
    titleEditor.commands.setContent(title);
  }
}, [pageId, title, titleEditor]);
```

`saveTitle` already tries to avoid applying a stale response:

```js
if (page.title !== titleEditor.getText()) return;
updatePageData(page);
```

but that check runs **synchronously inside the mutation's `.then()`**, while the effect only runs **after React re-renders**. A keystroke landing in that gap is destroyed:

```
T+0ms   save response arrives with title "foo bar"
        guard: response === editor text  -> passes -> updatePageData()
T+15ms  user types "x"                   -> editor is now one char ahead
T+20ms  effect: title !== getText()      -> setContent(title) -> "x" is gone
```

`setContent` also resets the selection, so the caret jumps to the start and subsequent keystrokes are inserted in the wrong place. That is what turns a single lost character into a visibly mangled title.

Higher latency means more save cycles per title, and therefore more of these windows — which is why a busy instance with real network latency hits it constantly while a local dev setup essentially never does.

## Fix

Track the title we last pushed to the server, and skip the reconcile when the incoming value is our own echo — in that window the echo is always the stale side. Genuine remote renames and actual page switches still replace the editor content exactly as before.

## Reproduction

Deterministic, by holding the `/api/pages/update` response and releasing it a fixed offset before the next keystroke (type `d`, wait for the debounced save to fire, release the response, then type `X` after `offset` ms; expected result `…dX`):

| offset | before | after |
|---|---|---|
| 10 ms | ok | ok |
| 12 ms | **`ctrl1dX` → `ctrl1d`** | ok |
| 15 ms | ok | ok |
| 18 ms | **`ctrl3dX` → `ctrl3d`** | ok |
| 20 ms | **`ctrl4dX` → `ctrl4d`** | ok |

3 of 5 offsets lose the character before the change, 0 of 8 after (the previously failing offsets were re-run twice). The harness was validated by stashing the fix and confirming it still reproduces.

## Regressions checked

- **Remote rename still adopted** — renamed from a second tab through the UI; the first tab picks up the new title both when unfocused and when its title editor is focused but idle.
- **Page switching still syncs** — 5 in-app navigations including revisiting an earlier page; every title rendered correctly.
- **Out-of-order save responses** — still handled by the existing `page.title !== titleEditor.getText()` guard.
- Typing latency in the title measured unchanged (p50/p90 16 ms, one frame) on both a small page and a 1536-block / 200 KB page with an active collab session.
- `tsc --noEmit` clean.

Note: I deliberately used "is this our own echo?" rather than "is the editor focused?". A focus check would also block genuine remote renames while the cursor sits idle in the title, with no way to reconcile afterwards, since the effect would not re-run on blur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
